### PR TITLE
Add hero and other demo sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repo serves as the central build system for maintaining, improving, and exp
 - **Dark Mode by Default** — All components, layouts, and views are built assuming dark mode is the active theme.
 - **SCSS-First** — All styling is modular and built using SCSS variables, functions, mixins, and partials.
 - **Codex Integrated** — Prompt-driven development using OpenAI’s Codex (https://chat.openai.com/codex).
-- **Custom Component Library** — A dedicated `components.html` showcases reusable building blocks styled for Daren’s brand.
+- **Custom Component Library** — `components.html` demos every UI component used across the site. Add new components here to keep them organized.
 
 ---
 
@@ -43,7 +43,7 @@ This repo serves as the central build system for maintaining, improving, and exp
 📁 assets/brand/       # Logos, icons, press kit files (see docs/assets-brand-README.md)
 📁 docs/               # Internal documentation (style guide, prompts, agent logic)
 📄 index.html          # Landing page
-📄 components.html     # UI Kit component reference
+📄 components.html     # Demo page for every component
 📝 README.md           # You are here!
 ```
 

--- a/components.html
+++ b/components.html
@@ -22,19 +22,92 @@
         </ul>
       </nav>
     </div>
-    <nav class="component-nav margin-top-md">
-      <ul class="flex gap-sm justify-center">
-        <li><a href="#buttons">Buttons</a></li>
-        <li><a href="#forms">Forms</a></li>
-        <li><a href="#cards">Cards</a></li>
-        <li><a href="#modals">Modals</a></li>
-        <li><a href="#alerts">Alerts</a></li>
-        <li><a href="#toggles">Toggles</a></li>
-      </ul>
-    </nav>
+      <nav class="component-nav margin-top-md">
+        <ul class="flex gap-sm justify-center">
+          <li><a href="#hero">Hero</a></li>
+          <li><a href="#testimonials">Testimonials</a></li>
+          <li><a href="#downloads">Downloads</a></li>
+          <li><a href="#viewer">Viewer</a></li>
+          <li><a href="#buttons">Buttons</a></li>
+          <li><a href="#forms">Forms</a></li>
+          <li><a href="#cards">Cards</a></li>
+          <li><a href="#modals">Modals</a></li>
+          <li><a href="#alerts">Alerts</a></li>
+          <li><a href="#toggles">Toggles</a></li>
+        </ul>
+      </nav>
   </header>
 
   <main>
+    <section id="hero" class="hero text-center">
+      <div class="container max-width-adaptive-lg">
+        <h2>Hero</h2>
+        <p class="margin-bottom-sm">Quick hero example with centered copy and actions.</p>
+        <div class="flex justify-center gap-sm">
+          <a href="#" class="btn btn--primary">Primary Action</a>
+          <a href="#" class="btn btn--accent">Secondary Action</a>
+        </div>
+      </div>
+    </section>
+
+    <section id="testimonials" class="testimonials">
+      <div class="container">
+        <h2>Testimonials</h2>
+        <div class="testimonial-grid">
+          <div class="card">
+            <img src="https://placehold.co/100x100?text=Avatar" alt="Reviewer 1">
+            <blockquote>"A must-read!"</blockquote>
+            <cite>- Alex</cite>
+          </div>
+          <div class="card">
+            <img src="https://placehold.co/100x100?text=Avatar" alt="Reviewer 2">
+            <blockquote>"Truly inspiring."</blockquote>
+            <cite>- Casey</cite>
+          </div>
+          <div class="card">
+            <img src="https://placehold.co/100x100?text=Avatar" alt="Reviewer 3">
+            <blockquote>"Eye-opening and real."</blockquote>
+            <cite>- Jordan</cite>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="downloads" class="downloads">
+      <div class="container">
+        <h2>Downloads</h2>
+        <div class="download-grid">
+          <div class="download-card">
+            <img src="https://placehold.co/800x1100?text=Preview" alt="PDF Preview">
+            <p class="file-info">Press Kit – 4MB PDF</p>
+            <a href="#" class="btn btn--primary">Download</a>
+          </div>
+          <div class="download-card">
+            <img src="https://placehold.co/800x1100?text=Preview" alt="PDF Preview">
+            <p class="file-info">Sample Chapter – 2MB PDF</p>
+            <a href="#" class="btn btn--primary">Download</a>
+          </div>
+          <div class="download-card">
+            <img src="https://placehold.co/800x1100?text=Preview" alt="PDF Preview">
+            <p class="file-info">Media Sheet – 1MB PDF</p>
+            <a href="#" class="btn btn--primary">Download</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="viewer" class="viewer">
+      <div class="container">
+        <h2>Viewer</h2>
+        <div class="toolbar">
+          <a href="#" class="btn btn--ghost">Download</a>
+          <a href="#" class="btn btn--ghost">Zoom</a>
+          <a href="#" class="btn btn--ghost">Print</a>
+        </div>
+        <iframe src="https://placehold.co/800x1100?text=Preview" title="Document preview"></iframe>
+      </div>
+    </section>
+
     <section id="buttons">
       <h2>Buttons</h2>
       <button class="btn">Primary</button>

--- a/docs/CODEX_PROMPTS.md
+++ b/docs/CODEX_PROMPTS.md
@@ -17,7 +17,7 @@ Use the following color palette (HEX format only), and reference filenames EXACT
 ## 📄 Page Builds
 
 ```plaintext
-Generate a full HTML + SCSS page called components.html. Include previews of buttons, forms, navbars, alerts, cards, and toggles. Use dark mode and mobile-first responsive layout. Do not use external libraries.
+Generate a full HTML + SCSS page called components.html. Include previews of hero banners, testimonial grids, download cards, document viewer, buttons, forms, navbars, alerts, cards, and toggles. Use dark mode and mobile-first responsive layout. Do not use external libraries.
 ```
 
 ```plaintext

--- a/docs/FILE_STRUCTURE.md
+++ b/docs/FILE_STRUCTURE.md
@@ -10,7 +10,7 @@ This document details the exact folder and file structure used in the Codex-powe
 ```
 / (Project Root)
 ├── index.html                 # Homepage (dark mode layout)
-├── components.html            # UI kit reference for reusable components
+├── components.html            # Demo page listing every UI component
 ├── assets/                    # Images, logos and compiled CSS
 ├── scss/                      # Source SCSS files
 ├── js/                        # JavaScript helpers
@@ -49,6 +49,14 @@ This document details the exact folder and file structure used in the Codex-powe
 /components/
 ├── _buttons.scss             # Default button styles
 ├── _forms.scss               # Input fields and form layout
+├── _cards.scss               # Card layouts
+├── _modals.scss              # Modal windows
+├── _alerts.scss              # Alert messages
+├── _toggles.scss             # Toggle switches
+├── _hero.scss                # Hero banner section
+├── _testimonials.scss        # Testimonial grid
+├── _downloads.scss           # Download cards
+├── _viewer.scss              # Embedded document viewer
 ```
 
 ---

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -25,7 +25,7 @@ The `--watch` flag keeps Sass running so any edits automatically rebuild.
 - **SCSS Components:** `scss/components/` contains partials like `_buttons.scss` and `_forms.scss`.
 - **Base Styles:** Global resets and variables live under `scss/base/`.
 - **Tokens:** Brand colors are defined in `scss/tokens/_colors.scss`.
-- **Pages:** `index.html` is the landing page. `components.html` showcases reusable bits.
+- **Pages:** `index.html` is the landing page. `components.html` demos all available components—add new ones here for easy reference.
 
 Every component imports into `scss/styles.scss`, so keep file names consistent.
 


### PR DESCRIPTION
## Summary
- add hero, testimonials, downloads and viewer demos to components.html
- extend component navigation to include all sections
- clarify component library usage in README and docs
- expand file structure docs with all component partials
- refresh Codex prompts with new components

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f397a28d883259d1d1059e1a7b729