### PR TITLE
Remove spinner and adjust progress bar in PicDetective

### DIFF
--- a/Picdetective/analysis.html
+++ b/Picdetective/analysis.html
@@ -10,7 +10,6 @@
 <body>
 <div id="loadingScreen" class="loading-screen">
   <video class="loading-bg" src="../detbgvid.webm" autoplay muted loop playsinline></video>
-  <img src="deticon.png" alt="loading">
   <div class="progress"><div class="bar"></div></div>
 </div>
 <div id="loginOverlay" class="overlay" style="display:none;">

--- a/Picdetective/index.html
+++ b/Picdetective/index.html
@@ -10,7 +10,6 @@
 <body>
 <div id="loadingScreen" class="loading-screen">
   <video class="loading-bg" src="../detbgvid.webm" autoplay muted loop playsinline></video>
-  <img src="deticon.png" alt="loading">
   <div class="progress"><div class="bar"></div></div>
 </div>
 <div id="loginOverlay" class="overlay" style="display:none;">

--- a/Picdetective/script.js
+++ b/Picdetective/script.js
@@ -4,7 +4,7 @@ let loggedIn = false;
 window.addEventListener('DOMContentLoaded', () => {
   const bar = document.querySelector('#loadingScreen .bar');
   let w = 0;
-  const loadDuration = 3000;
+  const loadDuration = 3500;
   const iv = setInterval(() => {
     if (w < 100) {
       bar.style.width = (++w) + '%';

--- a/Picdetective/style.css
+++ b/Picdetective/style.css
@@ -157,14 +157,17 @@ body {
   pointer-events: none;
   z-index: -1;
 }
-.loading-screen img { max-width: 150px; margin-bottom:20px; animation: spin 3s linear infinite; filter: drop-shadow(0 0 15px var(--accent)); }
-.loading-screen .progress{width:80%;height:6px;background:#333;border-radius:4px;margin-top:20px;overflow:hidden;}
-.loading-screen .bar{height:100%;width:0;background:var(--primary);}
-
-@keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+.loading-screen .progress{
+  width:80%;
+  height:6px;
+  background:#333;
+  border-radius:4px;
+  overflow:hidden;
+  position:absolute;
+  top:75%;
+  transform:translateY(-50%);
 }
+.loading-screen .bar{height:100%;width:0;background:#ccc;}
 
 @keyframes fadeIn {
   from { opacity: 0; transform: scale(0.9); }


### PR DESCRIPTION
## Summary
- remove spinning logo from loading screen
- reposition progress bar and set light gray color
- slow loading animation to 3.5 seconds

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6882e9406a9083259090b3725679b55d