### PR TITLE
Update docs for optional light theme

### DIFF
--- a/docs/FILE_STRUCTURE.md
+++ b/docs/FILE_STRUCTURE.md
@@ -123,7 +123,7 @@ This document details the exact folder and file structure used in the Codex-powe
 ## 🛠 Misc
 
 - **Colors:** Only use HEX values defined in `brand-style-guide.md`
-- **Dark Mode:** Always active by default — light mode not required.
+- **Dark Mode:** Baseline is dark, but a light theme can be enabled via `#themeToggle`.
 - **Fonts:** CodyHouse system defaults, no custom brand fonts (yet)
 - **Filenames:** Follow all conventions from `assets-brand-README.md`
 

--- a/docs/brand-style-guide.md
+++ b/docs/brand-style-guide.md
@@ -52,6 +52,6 @@ This should be reflected in UI copy, system prompts, and all AI agent replies.
 
 ---
 
-## ✅ Dark Mode Always On
+## ✅ Dark Mode Baseline
 
-All components and media are designed to be shown in dark mode. Any light-mode variants (such as `logo-web-for-light-bg.png`) are fallback-only.
+All components and media are designed for dark mode, with optional light variants triggered by `#themeToggle`.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -41,6 +41,6 @@ This serves the project locally and reflects your SCSS changes immediately.
 
 ## 5. Keep It Bold
 
-Daren’s brand voice is confident and direct. When you write or code, keep copy short and powerful. Dark mode is the default—no need to design a light theme yet.
+Daren’s brand voice is confident and direct. Keep copy short and powerful. Dark mode is the baseline, but a light theme is available via `#themeToggle`.
 
 That’s it! You’re ready to create components and push updates. If you get stuck, read `docs/FILE_STRUCTURE.md` for more details.


### PR DESCRIPTION
## Summary
- clarify light theme availability in file structure guide
- mention optional light theme in onboarding
- note light theme in brand style guide as a `#themeToggle` variant

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b785f222483258e2b7e6cd84b35ab