### PR TITLE
Add search bar toggle

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -3,6 +3,8 @@ document.addEventListener('DOMContentLoaded', function () {
   const megaMenu = document.querySelector('.js-mega-menu');
   const logoutBtn = document.querySelector('.logout-btn');
   const themeToggle = document.getElementById('themeToggle');
+  const searchToggle = document.querySelector('.js-search-toggle');
+  const searchBar = document.querySelector('.js-search-bar');
 
   if (menuToggle && megaMenu) {
     menuToggle.addEventListener('click', function () {
@@ -21,6 +23,25 @@ document.addEventListener('DOMContentLoaded', function () {
     themeToggle.addEventListener('change', function () {
       document.body.classList.toggle('theme-dark');
       document.body.classList.toggle('theme-light');
+    });
+  }
+
+  if (searchToggle && searchBar) {
+    searchToggle.addEventListener('click', function () {
+      if (searchBar.hasAttribute('hidden')) {
+        searchBar.removeAttribute('hidden');
+        const input = searchBar.querySelector('input[type="search"]');
+        if (input) input.focus();
+      } else {
+        searchBar.setAttribute('hidden', '');
+      }
+    });
+
+    document.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape' && !searchBar.hasAttribute('hidden')) {
+        searchBar.setAttribute('hidden', '');
+        searchToggle.focus();
+      }
     });
   }
 });


### PR DESCRIPTION
## Summary
- toggle `.js-search-bar` when clicking `.js-search-toggle`
- hide the dropdown with Escape key for accessibility

## Testing
- `npm run prepare`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b891e572083259d88369dc59ac012