### PR TITLE
Add Supabase config and extend user profile forms

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -115,13 +115,33 @@
             <label for="new-email">Email</label>
             <input type="email" id="new-email">
           </div>
-          <div class="form-group">
-            <label for="new-password">Password</label>
-            <input type="password" id="new-password">
-          </div>
-          <button class="btn btn--primary" type="submit">Update</button>
-          <p class="profile-msg"></p>
-        </form>
+        <div class="form-group">
+          <label for="new-password">Password</label>
+          <input type="password" id="new-password">
+        </div>
+        <div class="form-group">
+          <label for="first-name">First Name</label>
+          <input type="text" id="first-name">
+        </div>
+        <div class="form-group">
+          <label for="last-name">Last Name</label>
+          <input type="text" id="last-name">
+        </div>
+        <div class="form-group">
+          <label for="phone">Phone</label>
+          <input type="tel" id="phone">
+        </div>
+        <div class="form-group">
+          <label for="birthdate">Birthdate</label>
+          <input type="date" id="birthdate">
+        </div>
+        <div class="form-group">
+          <label for="shipping-address">Shipping Address</label>
+          <textarea id="shipping-address"></textarea>
+        </div>
+        <button class="btn btn--primary" type="submit">Update</button>
+        <p class="profile-msg"></p>
+      </form>
       </div>
 
       <div id="billing" class="card">

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,5 +1,5 @@
-const SUPABASE_URL = 'YOUR_SUPABASE_URL';
-const SUPABASE_KEY = 'YOUR_SUPABASE_ANON_KEY';
+const SUPABASE_URL = 'https://ogftwcrihcihqahfasmg.supabase.co';
+const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9nZnR3Y3JpaGNpaHFhaGZhc21nIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM5MjAxNTcsImV4cCI6MjA2OTQ5NjE1N30.XI6epagbdQZgoxOnB63UYXUjUOZEpS8ezKPWuhToP9A';
 const supabase = supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
 
 async function checkSession() {
@@ -9,10 +9,16 @@ async function checkSession() {
   }
 }
 
+const signupFields = document.querySelectorAll('.signup-only');
+const titleEl = document.querySelector('.login-container h1');
+
 function toggleMode() {
   mode = mode === 'signin' ? 'signup' : 'signin';
   submitBtn.textContent = mode === 'signin' ? 'Sign In' : 'Sign Up';
-  toggleLink.textContent = mode === 'signin' ? 'Need an account? Sign Up' : 'Already have an account? Sign In';
+  toggleLink.textContent =
+    mode === 'signin' ? 'Need an account? Sign Up' : 'Already have an account? Sign In';
+  signupFields.forEach((el) => (el.hidden = mode !== 'signup'));
+  if (titleEl) titleEl.textContent = mode === 'signin' ? 'Member Login' : 'Create Account';
   errorEl.textContent = '';
 }
 
@@ -22,7 +28,10 @@ const submitBtn = document.querySelector('.js-submit');
 const toggleLink = document.querySelector('.js-toggle-auth');
 const errorEl = document.querySelector('.auth-error');
 
-document.addEventListener('DOMContentLoaded', checkSession);
+document.addEventListener('DOMContentLoaded', () => {
+  checkSession();
+  signupFields.forEach((el) => (el.hidden = true));
+});
 if (toggleLink) toggleLink.addEventListener('click', (e) => { e.preventDefault(); toggleMode(); });
 
 if (form) {
@@ -30,11 +39,26 @@ if (form) {
     e.preventDefault();
     const email = document.getElementById('email').value;
     const password = document.getElementById('password').value;
+    const firstName = document.getElementById('first-name')?.value;
+    const lastName = document.getElementById('last-name')?.value;
+    const phone = document.getElementById('phone')?.value;
+    const shipping = document.getElementById('shipping-address')?.value;
     let result;
     if (mode === 'signin') {
       result = await supabase.auth.signInWithPassword({ email, password });
     } else {
-      result = await supabase.auth.signUp({ email, password });
+      result = await supabase.auth.signUp({
+        email,
+        password,
+        options: {
+          data: {
+            first_name: firstName,
+            last_name: lastName,
+            phone,
+            shipping_address: shipping,
+          },
+        },
+      });
     }
     if (result.error) {
       errorEl.textContent = result.error.message;

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,5 +1,5 @@
-const SUPABASE_URL = 'YOUR_SUPABASE_URL';
-const SUPABASE_KEY = 'YOUR_SUPABASE_ANON_KEY';
+const SUPABASE_URL = 'https://ogftwcrihcihqahfasmg.supabase.co';
+const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9nZnR3Y3JpaGNpaHFhaGZhc21nIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM5MjAxNTcsImV4cCI6MjA2OTQ5NjE1N30.XI6epagbdQZgoxOnB63UYXUjUOZEpS8ezKPWuhToP9A';
 const supabase = supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
 
 async function requireSession() {
@@ -49,6 +49,12 @@ async function init() {
   if (!session) return;
   const user = session.user;
   updateGreeting(user.email);
+  const metadata = user.user_metadata || {};
+  document.getElementById('first-name').value = metadata.first_name || '';
+  document.getElementById('last-name').value = metadata.last_name || '';
+  document.getElementById('phone').value = metadata.phone || '';
+  document.getElementById('birthdate').value = metadata.birthdate || '';
+  document.getElementById('shipping-address').value = metadata.shipping_address || '';
   await listFiles('user-data', user.id, 'file-list');
   await loadSharedFiles(user.id);
 
@@ -75,15 +81,25 @@ async function init() {
     e.preventDefault();
     const email = document.getElementById('new-email').value;
     const password = document.getElementById('new-password').value;
+    const firstName = document.getElementById('first-name').value;
+    const lastName = document.getElementById('last-name').value;
+    const phone = document.getElementById('phone').value;
+    const birthdate = document.getElementById('birthdate').value;
+    const shipping = document.getElementById('shipping-address').value;
     let msg = '';
-    if (email) {
-      const { error } = await supabase.auth.updateUser({ email });
-      if (error) msg += error.message + ' ';
-    }
-    if (password) {
-      const { error } = await supabase.auth.updateUser({ password });
-      if (error) msg += error.message;
-    }
+    const updates = {
+      data: {
+        first_name: firstName,
+        last_name: lastName,
+        phone,
+        birthdate,
+        shipping_address: shipping,
+      },
+    };
+    if (email) updates.email = email;
+    if (password) updates.password = password;
+    const { error } = await supabase.auth.updateUser(updates);
+    if (error) msg = error.message;
     document.querySelector('.profile-msg').textContent = msg || 'Updated';
   });
 

--- a/js/main.js
+++ b/js/main.js
@@ -9,8 +9,8 @@ document.addEventListener('DOMContentLoaded', async function () {
 
   let supabaseClient;
   if (window.supabase) {
-    const SUPABASE_URL = 'YOUR_SUPABASE_URL';
-    const SUPABASE_KEY = 'YOUR_SUPABASE_ANON_KEY';
+    const SUPABASE_URL = 'https://ogftwcrihcihqahfasmg.supabase.co';
+    const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9nZnR3Y3JpaGNpaHFhaGZhc21nIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM5MjAxNTcsImV4cCI6MjA2OTQ5NjE1N30.XI6epagbdQZgoxOnB63UYXUjUOZEpS8ezKPWuhToP9A';
     supabaseClient = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
   }
 

--- a/js/profile-dropdown.js
+++ b/js/profile-dropdown.js
@@ -7,8 +7,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   const nameEl = dropdown.querySelector('.profile-name');
   let client;
   if (window.supabase) {
-    const SUPABASE_URL = 'YOUR_SUPABASE_URL';
-    const SUPABASE_KEY = 'YOUR_SUPABASE_ANON_KEY';
+    const SUPABASE_URL = 'https://ogftwcrihcihqahfasmg.supabase.co';
+    const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9nZnR3Y3JpaGNpaHFhaGZhc21nIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM5MjAxNTcsImV4cCI6MjA2OTQ5NjE1N30.XI6epagbdQZgoxOnB63UYXUjUOZEpS8ezKPWuhToP9A';
     client = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
     const { data } = await client.auth.getSession();
     if (data.session) {

--- a/login.html
+++ b/login.html
@@ -86,6 +86,22 @@
           <label for="password">Password</label>
           <input type="password" id="password" required>
         </div>
+        <div class="form-group signup-only" hidden>
+          <label for="first-name">First Name</label>
+          <input type="text" id="first-name">
+        </div>
+        <div class="form-group signup-only" hidden>
+          <label for="last-name">Last Name</label>
+          <input type="text" id="last-name">
+        </div>
+        <div class="form-group signup-only" hidden>
+          <label for="phone">Phone</label>
+          <input type="tel" id="phone">
+        </div>
+        <div class="form-group signup-only" hidden>
+          <label for="shipping-address">Shipping Address</label>
+          <textarea id="shipping-address"></textarea>
+        </div>
         <p class="auth-error color-accent"></p>
         <button type="submit" class="btn btn--primary full-width js-submit">Sign In</button>
         <p class="text-center margin-top-sm auth-switch">


### PR DESCRIPTION
## Summary
- configure Supabase client with project credentials
- extend signup form to collect personal info
- show/hide signup fields when toggling modes
- include additional user metadata in auth calls
- add profile fields and update logic on dashboard

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bac7f179483259109e001b05b1d11