### PR TITLE
Update nav separators opacity

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1386,7 +1386,7 @@ book-3d-viewer .zoom-modal .zoom-content .close-btn {
 }
 
 .separator {
-  border-top: 1px solid var(--color-muted);
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
   margin: 2rem 0;
 }
 
@@ -1606,7 +1606,7 @@ book-3d-viewer .zoom-modal .zoom-content .close-btn {
 .mega-menu-list hr {
   margin: 1rem 0;
   border: none;
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
 }
 .mega-menu-list .social-row {
   display: flex;

--- a/scss/components/_separator.scss
+++ b/scss/components/_separator.scss
@@ -2,6 +2,6 @@
 @use "../base/variables" as *;
 
 .separator {
-  border-top: 1px solid $medium-gray;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
   margin: $spacing-lg 0;
 }

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -137,7 +137,7 @@
   hr {
     margin: 1rem 0;
     border: none;
-    border-top: 1px solid var(--color-border);
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
   }
 
   .social-row {


### PR DESCRIPTION
## Summary
- make global separator borders 5% opacity
- match mega-menu hr style to 5% opacity

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688c4b6737748325af218c5bbaa2afac