### PR TITLE
Fix documentation inconsistencies

### DIFF
--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -18,7 +18,8 @@ PHASE 1: FOUNDATIONAL DESIGN STRATEGY
 ==================================================
 
 1. ✅ Brand Alignment
-   - Use official Game On! fonts: League Spartan, Futura, Knockout Welterweight, Helvetica Now
+   - Use default CodyHouse fonts for all UI.
+   - Brand fonts (League Spartan, Futura, Knockout Welterweight, Helvetica Now) reserved for graphics or print assets
    - Apply HEX-coded color palette consistently: Charcoal, Deep Greens, Mint Green, White, etc.
    - Maintain bold, real, emotionally intelligent tone in layout and microcopy
    - Avoid all hyphens, dashes, or truncated content
@@ -117,9 +118,9 @@ PHASE 3: SCSS, SPACING & STRUCTURE STRATEGY
 - Mobile-first media queries
 - Layout breakpoints at: 480px, 768px, 1024px, 1440px
 
-✅ TYPOGRAPHY
-- Headings: Use brand fonts in defined sizes (e.g., H1 = 3.2rem)
-- Body: Helvetica Now or fallback sans-serif
+-✅ TYPOGRAPHY
+- Headings: Use default CodyHouse font stack (e.g., H1 = 3.2rem)
+- Body: sans-serif (Helvetica Now or system font)
 - Line height, letter spacing defined for legibility
 
 ==================================================

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,6 @@ This project is driven by AI collaboration through OpenAI’s Codex:
 - Modular prompts generate SCSS components
 - Systematic integration with Codex logic tracked in `docs/CODEX_PROMPTS.md`
 - Brand-aware personality definitions in `docs/AGENTS.md`
-- Each build phase references `AUTHOR_SITE_MASTER_STRATEGY_EXPANDED.txt`
 
 ⚠️ All prompts, component logic, and layout flow must follow the official strategy and never deviate from:
 - Brand fonts
@@ -63,7 +62,7 @@ For Graphic Design, Ads, Images:
 - `#D5D5D5` Light Gray
 - `#B8BAB7` Medium Gray
 - `#3B3C3B` Charcoal
-- `#141414` Black
+ - `#070A06` Black
 - `#456F3A` Deep Green
 - `#6DA667` Medium Green
 - `#87BD72` Bright Green

--- a/docs/archive/UPDATED_README_DarenPrince.md
+++ b/docs/archive/UPDATED_README_DarenPrince.md
@@ -1,5 +1,6 @@
 
 # 🖥️ Daren Prince Author Platform & Website
+⚠️ **Legacy:** This file is kept for historical reference. For the latest information see `docs/README.md`.
 
 Welcome to the official development repository for **Daren M. Prince**, bestselling author of *Game On! Master the Conversation & Win Her Heart*. This site is the digital command center for Daren’s entire brand ecosystem – designed to convert browsers into readers, amplify the author's voice, and build a movement around real connection, emotional intelligence, and modern masculinity.
 
@@ -34,7 +35,6 @@ This project is driven by AI collaboration through OpenAI’s Codex:
 - Modular prompts generate SCSS components
 - Systematic integration with Codex logic tracked in `docs/CODEX_PROMPTS.md`
 - Brand-aware personality definitions in `docs/AGENTS.md`
-- Each build phase references `AUTHOR_SITE_MASTER_STRATEGY_EXPANDED.txt`
 
 ⚠️ All prompts, component logic, and layout flow must follow the official strategy and never deviate from:
 - Brand fonts

--- a/docs/navigation_overview.md
+++ b/docs/navigation_overview.md
@@ -49,7 +49,7 @@ The header at the top of each page contains icons that toggle search, the profil
 
 Navigation styles live primarily in the SCSS folder:
 
-- `scss/style.scss` – defines the mega menu layout and transitions.
+- `scss/styles.scss` – defines the mega menu layout and transitions.
 - `scss/layout/_header.scss` – styles the sticky header bar.
 - `scss/layout/_nav.scss` – shared styles for icon buttons, search bar and the profile dropdown.
 - `scss/components/_profile-dropdown.scss` – extra styling for the dropdown itself.


### PR DESCRIPTION
## Summary
- clean up README
- align color palette with brand guide
- clarify font usage in MASTER_PLAN
- fix navigation docs path
- mark archived README as legacy

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688c5693eed8832591216e892e64c4f6