### PR TITLE
Lower opacity for menu separators

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1543,7 +1543,7 @@ book-3d-viewer .zoom-modal .zoom-content .close-btn {
   align-items: center;
   gap: 0.75rem;
   cursor: pointer;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 }
 .mega-menu-list li:hover {
   opacity: 0.8;
@@ -1596,7 +1596,7 @@ book-3d-viewer .zoom-modal .zoom-content .close-btn {
   transform: translateX(0);
 }
 .mega-menu-list .has-submenu .go-back {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 }
 .mega-menu-list .has-submenu .go-back a {
   display: flex;

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -61,7 +61,7 @@
     align-items: center;
     gap: 0.75rem;
     cursor: pointer;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 
     &:hover {
       opacity: 0.8;
@@ -124,7 +124,7 @@
     }
 
     .go-back {
-      border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 
       a {
         display: flex;


### PR DESCRIPTION
## Summary
- adjust menu and submenu border opacity in `scss/style.scss`
- rebuild CSS so `assets/styles.css` matches

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688c5a258c008325ad8a91b94dca79ab