### PR TITLE
Add local setup scripts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -170,9 +170,10 @@ All public content, meta descriptions, button text, and landing copy must reflec
 
 Build Tools:
 ```bash
-npm install     # install dependencies
-npm run build   # one-time SCSS compilation
-npm run watch   # live watching and compiling
+./scripts/local_setup.sh   # install deps and compile once
+./scripts/start_dev.sh     # watch files & launch dev server
+npm run build              # one-time SCSS compilation
+npm run watch              # live watching and compiling
 ```
 
 Local Preview (via Netlify CLI):

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -4,10 +4,10 @@ Welcome to the Daren Prince Author Platform! This quick primer gets you building
 
 ## 1. Install Dependencies
 
-The project uses Node and the `sass` package to compile styles. Install everything with:
+Run the helper script to install Node packages and compile the initial stylesheet:
 
 ```bash
-npm install
+./scripts/local_setup.sh
 ```
 
 ## 2. Compile SCSS
@@ -31,10 +31,10 @@ Every component imports into `scss/styles.scss`, so keep file names consistent.
 
 ## 4. Preview the Site
 
-After compiling styles, open `index.html` in your browser or run Netlify’s dev server:
+After compiling styles, start the live dev server:
 
 ```bash
-npx netlify-cli dev
+./scripts/start_dev.sh
 ```
 
 This serves the project locally and reflects your SCSS changes immediately.

--- a/scripts/local_setup.sh
+++ b/scripts/local_setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# local_setup.sh - Install dependencies and compile initial assets
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required but not installed. Please install Node.js." >&2
+  exit 1
+fi
+
+# install npm packages
+npm install
+
+# ensure sass is available
+if ! command -v sass >/dev/null 2>&1; then
+  npx sass --version >/dev/null 2>&1 || npm install --no-save sass
+fi
+
+# compile initial stylesheet
+npx sass scss/styles.scss assets/styles.css
+
+echo "Project dependencies installed and styles compiled."

--- a/scripts/start_dev.sh
+++ b/scripts/start_dev.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# start_dev.sh - Watch SCSS and launch Netlify dev server
+
+npm run watch &
+NETLIFY_PID=$!
+
+npx netlify-cli dev
+
+# kill the watch process on exit
+kill $NETLIFY_PID


### PR DESCRIPTION
## Summary
- add `scripts/local_setup.sh` to install dependencies and compile styles
- add `scripts/start_dev.sh` to launch Netlify dev server with a watcher
- document usage of the new scripts in `docs/README.md`
- update onboarding guide to use the helper scripts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688c6957082c83258f055cb9df3bef03