### PR TITLE
feat: add maintenance landing content

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,73 @@
   </header>
 
   <main>
-  Acknowledged. No more assumptions. No guessing. Let’s correct that.
+    <!-- ⚙️ Site Maintenance Landing Page for DarenPrince.com -->
+
+    <!-- 1. Hero Section -->
+    <section class="hero text-center padding-y-xl">
+      <div class="container max-width-adaptive-lg">
+        <img src="/assets/brand/maintenance-banner.jpg" alt="Game On Website Facelift" class="hero-image margin-bottom-lg" />
+        <h1 class="hero-heading font-primary text-xxxl margin-bottom-sm">Daren’s Site is Leveling Up</h1>
+        <p class="hero-subtext text-lg">
+          Game on, even when the site is down. We’re upgrading your experience—faster, sleeker, bolder. Hang tight.
+        </p>
+      </div>
+    </section>
+
+    <!-- 2. Get the Book Section -->
+    <section class="book-section padding-y-xl">
+      <div class="container max-width-adaptive-lg">
+        <h2 class="section-heading text-center margin-bottom-lg">Get the Book That Started It All</h2>
+
+        <div class="book-content flex gap-md items-center">
+          <div class="book-mockup">
+            <img src="/assets/books/game-on-mockup.png" alt="Game On Book Cover" class="mockup-image" />
+          </div>
+
+          <div class="accordion">
+            <div class="accordion-item">
+              <button class="accordion-trigger" aria-expanded="true">Game On! Master the Conversation &amp; Win Her Heart</button>
+              <div class="accordion-panel">
+                <p>
+                  No gimmicks. No games. Just real results. <strong>Game On!</strong> is not another gimmicky guide — it’s a real-world roadmap to magnetic connection.
+                  <br /><br />
+                  Bold, emotionally intelligent, and psychology-backed, this 5-star bestseller gives you step-by-step guidance to approach women confidently, flirt with charm, and build meaningful, lasting relationships. Whether you're navigating dating apps or real-world sparks, <strong>Game On!</strong> helps you level up your confidence and communication.
+                  <br /><br />
+                  <strong>Bonus Content:</strong> Daily Connection Rituals, a 30-Day Confidence Challenge, and Conflict Resolution Tools.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- 3. Contact Form Section -->
+    <section class="contact-section padding-y-xl">
+      <div class="container max-width-adaptive-lg text-center">
+        <h2 class="section-heading margin-bottom-lg">Want to Reach Out?</h2>
+        <!-- Import contact form from components -->
+        <div class="contact-form-wrapper margin-bottom-lg">
+          <include src="/components/contact-form.html"></include>
+        </div>
+        <p class="form-note text-lg">For media, interviews, or reader messages, contact: <a href="mailto:press@darenprince.com">press@darenprince.com</a></p>
+      </div>
+    </section>
+
+    <!-- 4. Bookstore Links Section -->
+    <section class="bookstore-logos padding-y-xl">
+      <div class="container max-width-adaptive-lg">
+        <h3 class="section-heading text-center margin-bottom-lg">Available At</h3>
+        <div class="store-logos flex gap-md justify-center">
+          <a href="https://a.co/d/irajx1w" target="_blank"><img src="/assets/logos/amazon.png" alt="Amazon Logo" /></a>
+          <a href="https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900" target="_blank"><img src="/assets/logos/apple-books.png" alt="Apple Books Logo" /></a>
+          <a href="https://play.google.com/store/books/details?id=BYFbEQAAQBAJ" target="_blank"><img src="/assets/logos/google-play.png" alt="Google Play Logo" /></a>
+          <a href="https://www.booksamillion.com/p/Game-Master-Conversation-Win-Her/Daren-Prince/9798303844407" target="_blank"><img src="/assets/logos/books-a-million.png" alt="Books-A-Million Logo" /></a>
+          <a href="https://www.thriftbooks.com/w/game-on-master-the-conversation--win-her-heart-the-comprehensive-mens-playbook-for-flirting-seduction-dating--amazing-relationships_daren-prince/54448380/?resultid=c09fe73b" target="_blank"><img src="/assets/logos/thriftbooks.png" alt="ThriftBooks Logo" /></a>
+          <a href="https://www.waterstones.com/book/game-on-master-the-conversation-and-win-her-heart/daren-prince/9798303844407" target="_blank"><img src="/assets/logos/waterstones.png" alt="Waterstones Logo" /></a>
+        </div>
+      </div>
+    </section>
   </main>
 
   <footer class="site-footer">


### PR DESCRIPTION
## Summary
- replace index.html main content with site maintenance landing page
- apply global spacing utilities and component-based styling for a sleeker layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68918013faa4832584b59d46ca53c484