### PR TITLE
Fix Collabs menu icon

### DIFF
--- a/book.html
+++ b/book.html
@@ -32,7 +32,7 @@
       <li><a href="press.html"><i class="ti ti-camera"></i>Media</a></li>
       <li><a href="index.html"><i class="ti ti-shirt"></i>Swag</a></li>
       <li><a href="index.html"><i class="ti ti-news"></i>Blog</a></li>
-      <li><a href="index.html"><i class="ti ti-handshake"></i>Collabs</a></li>
+      <li><a href="index.html"><i class="ti ti-user-plus"></i>Collabs</a></li>
       <li><a href="contact.html"><i class="ti ti-mail"></i>Contact</a></li>
       <li class="social-row">
         <a href="#"><i class="ti ti-brand-facebook"></i></a>

--- a/components.html
+++ b/components.html
@@ -32,7 +32,7 @@
       <li><a href="press.html"><i class="ti ti-camera"></i>Media</a></li>
       <li><a href="index.html"><i class="ti ti-shirt"></i>Swag</a></li>
       <li><a href="index.html"><i class="ti ti-news"></i>Blog</a></li>
-      <li><a href="index.html"><i class="ti ti-handshake"></i>Collabs</a></li>
+      <li><a href="index.html"><i class="ti ti-user-plus"></i>Collabs</a></li>
       <li><a href="contact.html"><i class="ti ti-mail"></i>Contact</a></li>
       <li class="social-row">
         <a href="#"><i class="ti ti-brand-facebook"></i></a>

--- a/contact.html
+++ b/contact.html
@@ -32,7 +32,7 @@
       <li><a href="press.html"><i class="ti ti-camera"></i>Media</a></li>
       <li><a href="index.html"><i class="ti ti-shirt"></i>Swag</a></li>
       <li><a href="index.html"><i class="ti ti-news"></i>Blog</a></li>
-      <li><a href="index.html"><i class="ti ti-handshake"></i>Collabs</a></li>
+      <li><a href="index.html"><i class="ti ti-user-plus"></i>Collabs</a></li>
       <li><a href="contact.html" class="active"><i class="ti ti-mail"></i>Contact</a></li>
       <li class="social-row">
         <a href="#"><i class="ti ti-brand-facebook"></i></a>

--- a/dashboard.html
+++ b/dashboard.html
@@ -32,7 +32,7 @@
       <li><a href="press.html"><i class="ti ti-camera"></i>Media</a></li>
       <li><a href="index.html"><i class="ti ti-shirt"></i>Swag</a></li>
       <li><a href="index.html"><i class="ti ti-news"></i>Blog</a></li>
-      <li><a href="index.html"><i class="ti ti-handshake"></i>Collabs</a></li>
+      <li><a href="index.html"><i class="ti ti-user-plus"></i>Collabs</a></li>
       <li><a href="contact.html"><i class="ti ti-mail"></i>Contact</a></li>
       <li class="social-row">
         <a href="#"><i class="ti ti-brand-facebook"></i></a>

--- a/home.html
+++ b/home.html
@@ -32,7 +32,7 @@
       <li><a href="press.html"><i class="ti ti-camera"></i>Media</a></li>
       <li><a href="index.html"><i class="ti ti-shirt"></i>Swag</a></li>
       <li><a href="index.html"><i class="ti ti-news"></i>Blog</a></li>
-      <li><a href="index.html"><i class="ti ti-handshake"></i>Collabs</a></li>
+      <li><a href="index.html"><i class="ti ti-user-plus"></i>Collabs</a></li>
       <li><a href="contact.html"><i class="ti ti-mail"></i>Contact</a></li>
       <li class="social-row">
         <a href="#"><i class="ti ti-brand-facebook"></i></a>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
       <li><a href="press.html"><i class="ti ti-camera"></i>Media</a></li>
       <li><a href="index.html"><i class="ti ti-shirt"></i>Swag</a></li>
       <li><a href="index.html"><i class="ti ti-news"></i>Blog</a></li>
-      <li><a href="index.html"><i class="ti ti-handshake"></i>Collabs</a></li>
+      <li><a href="index.html"><i class="ti ti-user-plus"></i>Collabs</a></li>
       <li><a href="contact.html"><i class="ti ti-mail"></i>Contact</a></li>
       <li class="social-row">
         <a href="#"><i class="ti ti-brand-facebook"></i></a>

--- a/login.html
+++ b/login.html
@@ -32,7 +32,7 @@
       <li><a href="press.html"><i class="ti ti-camera"></i>Media</a></li>
       <li><a href="index.html"><i class="ti ti-shirt"></i>Swag</a></li>
       <li><a href="index.html"><i class="ti ti-news"></i>Blog</a></li>
-      <li><a href="index.html"><i class="ti ti-handshake"></i>Collabs</a></li>
+      <li><a href="index.html"><i class="ti ti-user-plus"></i>Collabs</a></li>
       <li><a href="contact.html"><i class="ti ti-mail"></i>Contact</a></li>
       <li class="social-row">
         <a href="#"><i class="ti ti-brand-facebook"></i></a>

--- a/press.html
+++ b/press.html
@@ -32,7 +32,7 @@
       <li><a href="press.html" class="active"><i class="ti ti-camera"></i>Media</a></li>
       <li><a href="index.html"><i class="ti ti-shirt"></i>Swag</a></li>
       <li><a href="index.html"><i class="ti ti-news"></i>Blog</a></li>
-      <li><a href="index.html"><i class="ti ti-handshake"></i>Collabs</a></li>
+      <li><a href="index.html"><i class="ti ti-user-plus"></i>Collabs</a></li>
       <li><a href="contact.html"><i class="ti ti-mail"></i>Contact</a></li>
       <li class="social-row">
         <a href="#"><i class="ti ti-brand-facebook"></i></a>


### PR DESCRIPTION
## Summary
- use a supported Tabler icon for the Collabs link in the mega menu so an icon displays consistently across pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892e1037f18832583bee721c126645a