### PR TITLE
fix: isolate 3d book from demo container

### DIFF
--- a/components.html
+++ b/components.html
@@ -342,10 +342,12 @@
       <button class="copy-btn" data-target="book-tabs-code">Copy</button>
     </div>
 
-    <section id="book" class="book-preview demo-section">
+    <section id="book" class="demo-section">
       <div class="container demo-container">
-        <div class="book-3d">
-          <img src="https://placehold.co/200x300?text=Cover" alt="Sample Book Cover">
+        <div class="book-preview">
+          <div class="book-3d">
+            <img src="https://placehold.co/200x300?text=Cover" alt="Sample Book Cover">
+          </div>
         </div>
       </div>
     </section>
@@ -353,8 +355,8 @@
       <h3>Book Cover</h3>
       <p>Function: static 3D book render.</p>
       <p>Tech Specs: styles in <code>scss/components/_book.scss</code>.</p>
-      <p>Implementation:</p>
-      <pre id="book-code"><code class="language-html">&lt;section id=&quot;book&quot;&gt;...&lt;/section&gt;</code></pre>
+            <p>Implementation:</p>
+      <pre id="book-code"><code class="language-html">&lt;div class=&quot;book-preview&quot;&gt;&lt;div class=&quot;book-3d&quot;&gt;&lt;img src=&quot;cover.jpg&quot; alt=&quot;Book cover&quot;&gt;&lt;/div&gt;&lt;/div&gt;</code></pre>
       <button class="copy-btn" data-target="book-code">Copy</button>
     </div>
 


### PR DESCRIPTION
## Summary
- keep demo container static for the Book Cover component so only the 3D book rotates
- clarify Book Cover markup in documentation snippet

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893c561fe188325ac4c4612ec578662