### PR TITLE
feat: implement secure storage upload

### DIFF
--- a/supabase/functions/secure-storage/index.ts
+++ b/supabase/functions/secure-storage/index.ts
@@ -14,8 +14,31 @@ serve(async (req) => {
     return new Response('Unauthorized', { status: 401 });
   }
 
-  // Placeholder for storage write logic
-  return new Response(JSON.stringify({ message: 'Authorized' }), {
+  const formData = await req.formData();
+  const file = formData.get('file');
+  const bucket = formData.get('bucket');
+
+  if (!file || !(file instanceof File) || !bucket || typeof bucket !== 'string') {
+    return new Response(JSON.stringify({ error: 'Missing file or bucket' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const { data, error } = await supabase.storage.from(bucket).upload(
+    `${user.id}/${file.name}`,
+    file.stream(),
+    { contentType: file.type },
+  );
+
+  if (error || !data) {
+    return new Response(JSON.stringify({ error: error?.message ?? 'Upload failed' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(JSON.stringify({ path: data.path }), {
     headers: { 'Content-Type': 'application/json' },
   });
 });


### PR DESCRIPTION
## Summary
- add storage upload to secure-storage function
- validate input and respond with path or error

## Testing
- `SUPABASE_URL=http://localhost SUPABASE_ANON_KEY=dummy npm test`


------
https://chatgpt.com/codex/tasks/task_e_68941eb63b2c83258a3c10ac90387e77