### PR TITLE
refactor: centralize Supabase client

### DIFF
--- a/book.html
+++ b/book.html
@@ -175,12 +175,10 @@
   </footer>
   </div>
   <script type="module" src="/js/ui.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
-  <script type="module" src="/js/supabaseClient.js"></script>
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-  <script src="/js/profile-dropdown.js"></script>
+  <script type="module" src="/js/profile-dropdown.js"></script>
   <script src="/js/theme-toggle.js"></script>
   <script src="/js/book-details.js"></script>
-  <script src="/js/main.js"></script>
+  <script type="module" src="/js/main.js"></script>
 </body>
 </html>

--- a/components.html
+++ b/components.html
@@ -613,16 +613,14 @@
   </div>
   <script src="/js/mobile-nav.js"></script>
   <script type="module" src="/js/ui.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
-  <script type="module" src="/js/supabaseClient.js"></script>
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-  <script src="/js/profile-dropdown.js"></script>
+  <script type="module" src="/js/profile-dropdown.js"></script>
   <script src="/js/theme-toggle.js"></script>
   <script src="/js/book-tabs.js"></script>
   <script src="/js/book-details.js"></script>
   <script type="module" src="js/book-3d-inertia-light-slowspin.js"></script>
   <script src="/js/hero-demos.js"></script>
-  <script src="/js/main.js"></script>
+  <script type="module" src="/js/main.js"></script>
   <script>
     document.querySelectorAll('.copy-btn').forEach(btn => {
       btn.addEventListener('click', () => {

--- a/contact.html
+++ b/contact.html
@@ -126,11 +126,9 @@
 </footer>
   </div>
   <script type="module" src="/js/ui.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
-  <script type="module" src="/js/supabaseClient.js"></script>
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-  <script src="/js/profile-dropdown.js"></script>
+  <script type="module" src="/js/profile-dropdown.js"></script>
   <script src="/js/theme-toggle.js"></script>
-  <script src="/js/main.js"></script>
+  <script type="module" src="/js/main.js"></script>
 </body>
 </html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -189,13 +189,11 @@
     </div>
   </footer>
   </div>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
-  <script type="module" src="/js/supabaseClient.js"></script>
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-  <script src="/js/dashboard.js"></script>
+  <script type="module" src="/js/dashboard.js"></script>
   <script type="module" src="/js/ui.js"></script>
-  <script src="/js/profile-dropdown.js"></script>
+  <script type="module" src="/js/profile-dropdown.js"></script>
   <script src="/js/theme-toggle.js"></script>
-  <script src="/js/main.js"></script>
+  <script type="module" src="/js/main.js"></script>
 </body>
 </html>

--- a/home.html
+++ b/home.html
@@ -175,12 +175,10 @@
   </footer>
   </div>
   <script type="module" src="/js/ui.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
-  <script type="module" src="/js/supabaseClient.js"></script>
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-  <script src="/js/profile-dropdown.js"></script>
+  <script type="module" src="/js/profile-dropdown.js"></script>
   <script src="/js/hero-video.js"></script>
   <script src="/js/theme-toggle.js"></script>
-  <script src="/js/main.js"></script>
+  <script type="module" src="/js/main.js"></script>
   </body>
   </html>

--- a/index.html
+++ b/index.html
@@ -228,14 +228,12 @@
   </footer>
   </div>
   <script type="module" src="/js/ui.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
-  <script type="module" src="/js/supabaseClient.js"></script>
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-  <script src="/js/profile-dropdown.js"></script>
+  <script type="module" src="/js/profile-dropdown.js"></script>
   <script src="/js/trailer-modal.js"></script>
   <script src="/js/theme-toggle.js"></script>
   <script src="/js/book-3d-inertia-light-slowspin.js"></script>
   <script src="/js/book-details.js"></script>
-  <script src="/js/main.js"></script>
+  <script type="module" src="/js/main.js"></script>
   </body>
   </html>

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,5 +1,5 @@
 import { initPasswordStrength, passwordsValid, resetPasswordStrength } from './password-strength.js';
-import { supabaseClient } from './supabaseClient.js';
+import supabaseClient from '../supabase/client.js';
 
 async function checkSession() {
   const { data } = await supabaseClient.auth.getSession();

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,4 +1,4 @@
-import { supabaseClient } from './supabaseClient.js';
+import supabaseClient from '../supabase/client.js';
 
 async function requireSession() {
   const { data } = await supabaseClient.auth.getSession();

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,5 @@
+import supabase from '../supabase/client.js';
+
 document.addEventListener('DOMContentLoaded', async function () {
   const menuToggle = document.querySelector('.js-menu-toggle');
   const megaMenu = document.querySelector('.js-mega-menu');
@@ -8,13 +10,8 @@ document.addEventListener('DOMContentLoaded', async function () {
   const searchToggle = document.querySelector('.js-search-toggle');
   const searchBar = document.querySelector('.js-search-bar');
 
-  const supabaseClient = window.supabaseClient;
-
-  let session = null;
-  if (supabaseClient) {
-    const { data } = await supabaseClient.auth.getSession();
-    session = data.session;
-  }
+  const { data } = await supabase.auth.getSession();
+  const session = data.session;
 
   if (menuToggle && megaMenu) {
     menuToggle.addEventListener('click', function () {
@@ -48,7 +45,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     if (session) {
       authToggle.innerHTML = '<i class="ti ti-door-exit"></i> Logout';
       authToggle.addEventListener('click', async function () {
-        if (supabaseClient) await supabaseClient.auth.signOut();
+        await supabase.auth.signOut();
         window.location.href = '/';
       });
     } else {

--- a/js/profile-dropdown.js
+++ b/js/profile-dropdown.js
@@ -1,3 +1,5 @@
+import supabase from '../supabase/client.js';
+
 document.addEventListener('DOMContentLoaded', async () => {
   const toggle = document.querySelector('.js-profile-toggle');
   const dropdown = document.querySelector('.js-profile-dropdown');
@@ -5,18 +7,15 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   const avatarImg = dropdown.querySelector('.profile-avatar');
   const nameEl = dropdown.querySelector('.profile-name');
-  const client = window.supabaseClient;
-  if (client) {
-    const { data } = await client.auth.getSession();
-    if (data.session) {
-      const user = data.session.user;
-      nameEl.textContent = user.user_metadata?.full_name || user.email;
-      const { data: avatarData } = await client.storage
-        .from('avatars')
-        .getPublicUrl(`${user.id}.jpg`);
-      if (avatarData?.publicUrl) {
-        avatarImg.src = avatarData.publicUrl;
-      }
+  const { data } = await supabase.auth.getSession();
+  if (data.session) {
+    const user = data.session.user;
+    nameEl.textContent = user.user_metadata?.full_name || user.email;
+    const { data: avatarData } = await supabase.storage
+      .from('avatars')
+      .getPublicUrl(`${user.id}.jpg`);
+    if (avatarData?.publicUrl) {
+      avatarImg.src = avatarData.publicUrl;
     }
   }
 
@@ -33,7 +32,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const logoutEl = dropdown.querySelector('.js-auth-toggle');
   if (logoutEl) {
     logoutEl.addEventListener('click', async () => {
-      if (client) await client.auth.signOut();
+      await supabase.auth.signOut();
       window.location.href = '/';
     });
   }

--- a/js/supabaseClient.js
+++ b/js/supabaseClient.js
@@ -1,4 +1,0 @@
-import { SUPABASE_URL, SUPABASE_KEY } from './env.js';
-
-export const supabaseClient = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
-window.supabaseClient = supabaseClient;

--- a/login.html
+++ b/login.html
@@ -164,13 +164,11 @@
   </footer>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
-  <script type="module" src="/js/supabaseClient.js"></script>
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ui.js"></script>
-  <script src="/js/profile-dropdown.js"></script>
+  <script type="module" src="/js/profile-dropdown.js"></script>
   <script src="/js/theme-toggle.js"></script>
-  <script src="/js/main.js"></script>
+  <script type="module" src="/js/main.js"></script>
 </body>
 </html>

--- a/press.html
+++ b/press.html
@@ -130,11 +130,9 @@
   </footer>
   </div>
   <script type="module" src="/js/ui.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
-  <script type="module" src="/js/supabaseClient.js"></script>
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-  <script src="/js/profile-dropdown.js"></script>
+  <script type="module" src="/js/profile-dropdown.js"></script>
   <script src="/js/theme-toggle.js"></script>
-  <script src="/js/main.js"></script>
+  <script type="module" src="/js/main.js"></script>
 </body>
 </html>

--- a/supabase/client.js
+++ b/supabase/client.js
@@ -1,0 +1,27 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+let url = '';
+let key = '';
+
+if (typeof Deno !== 'undefined' && typeof Deno.env !== 'undefined') {
+  url = Deno.env.get('SUPABASE_URL') ?? '';
+  key =
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ??
+    Deno.env.get('SUPABASE_ANON_KEY') ??
+    Deno.env.get('SUPABASE_KEY') ??
+    '';
+} else if (typeof process !== 'undefined' && typeof process.env !== 'undefined') {
+  url = process.env.SUPABASE_URL ?? '';
+  key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ??
+    process.env.SUPABASE_ANON_KEY ??
+    process.env.SUPABASE_KEY ??
+    '';
+} else {
+  const env = await import('../js/env.js');
+  url = env.SUPABASE_URL;
+  key = env.SUPABASE_KEY;
+}
+
+export const supabase = createClient(url, key);
+export default supabase;

--- a/supabase/client.ts
+++ b/supabase/client.ts
@@ -1,0 +1,27 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+let url = '';
+let key = '';
+
+if (typeof Deno !== 'undefined' && typeof Deno.env !== 'undefined') {
+  url = Deno.env.get('SUPABASE_URL') ?? '';
+  key =
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ??
+    Deno.env.get('SUPABASE_ANON_KEY') ??
+    Deno.env.get('SUPABASE_KEY') ??
+    '';
+} else if (typeof process !== 'undefined' && typeof process.env !== 'undefined') {
+  url = process.env.SUPABASE_URL ?? '';
+  key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ??
+    process.env.SUPABASE_ANON_KEY ??
+    process.env.SUPABASE_KEY ??
+    '';
+} else {
+  const env = await import('../js/env.js');
+  url = env.SUPABASE_URL;
+  key = env.SUPABASE_KEY;
+}
+
+export const supabase = createClient(url, key);
+export default supabase;

--- a/supabase/functions/secure-storage/index.ts
+++ b/supabase/functions/secure-storage/index.ts
@@ -1,12 +1,7 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import supabase from '../../client.ts';
 import { serve } from 'https://deno.land/std@0.182.0/http/server.ts';
 
 serve(async (req) => {
-  const supabase = createClient(
-    Deno.env.get('SUPABASE_URL')!,
-    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-  );
-
   const authHeader = req.headers.get('Authorization') ?? '';
   const token = authHeader.replace('Bearer ', '');
   const { data: { user } } = await supabase.auth.getUser(token);


### PR DESCRIPTION
## Summary
- add shared Supabase client that reads environment variables and exports a configured instance
- update front-end scripts and secure-storage function to import the shared client
- convert profile dropdown and main scripts to ES modules and remove window-based client

## Testing
- `SUPABASE_URL='https://example.supabase.co' SUPABASE_ANON_KEY='anonkey' npm test`

------
https://chatgpt.com/codex/tasks/task_e_689429ab428c832597c4cc47f3b8ca7a