### PR TITLE
docs: document supabase integration and file structure

### DIFF
--- a/docs/FILE_STRUCTURE.md
+++ b/docs/FILE_STRUCTURE.md
@@ -14,9 +14,11 @@ This document details the exact folder and file structure used in the Codex-powe
 ├── assets/                    # Images, logos and compiled CSS
 ├── scss/                      # Source SCSS files
 ├── js/                        # JavaScript helpers
+├── supabase/                  # Supabase client, migrations and edge functions
 ├── member/                    # Member area (in progress)
 ├── docs/                      # Project documentation
 ├── test/                      # Demo layouts and checks
+├── tests/                     # Vitest suites for Supabase logic
 ├── archive/                   # Archived files and legacy docs
 ├── package.json               # Build scripts and dependencies
 ├── package-lock.json          # Version-locked dependencies

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ This project is built to:
 - **Build Tools**: Node, npm, Netlify CLI
 - **Auto Deployment**: Netlify CI/CD connected to GitHub main branch
 - **Prompt Engine**: Codex by OpenAI powers real-time generation of components, prompts, and site logic
+- **Supabase**: Auth, storage, and edge functions handled through Supabase
 
 ---
 
@@ -154,6 +155,14 @@ const bar = document.querySelector('.progress');
 GameOnUI.showProgress(bar);
 GameOnUI.setProgress(bar, 50);
 ```
+
+---
+
+## 🔐 Supabase Integration
+
+Supabase powers sign-ups, secure file storage, and serverless logic. The client lives in `/supabase` and is reused across `js/main.js`, `js/auth.js`, `js/dashboard.js`, and `js/profile-dropdown.js`. Edge uploads are locked down by `functions/secure-storage`.
+
+More details live in [docs/supabase.md](supabase.md).
 
 ---
 

--- a/docs/supabase.md
+++ b/docs/supabase.md
@@ -27,7 +27,7 @@ The client is reused across `js/main.js`, `js/auth.js`, `js/dashboard.js`, and `
 
 * **Sign Up / Sign In** – `js/auth.js` handles both modes. New users are stored with metadata like name, phone, and shipping address.
 * **Session Guard** – `js/dashboard.js` and `js/main.js` redirect visitors without a valid session.
-* **Password Reset** – `js/auth.js` sends reset links and `reset-password.html` updates credentials via `supabaseClient.auth.updateUser`.
+* **Password Reset** – `js/auth.js` sends reset links and `reset-password.html` updates credentials via `supabase.auth.updateUser`.
 
 ## 📦 Storage Operations
 

--- a/docs/supabase.md
+++ b/docs/supabase.md
@@ -41,6 +41,9 @@ The client is reused across `js/main.js`, `js/auth.js`, `js/dashboard.js`, and `
 
 ```ts
 const { data: { user } } = await supabase.auth.getUser(token);
+if (!user) {
+  throw new Error('User not found');
+}
 await supabase.storage.from(bucket).upload(`${user.id}/${file.name}`, file.stream());
 ```
 

--- a/docs/supabase.md
+++ b/docs/supabase.md
@@ -1,0 +1,57 @@
+# 🔐 Supabase Integration
+
+This stack uses [Supabase](https://supabase.com) for auth, secure file storage, and edge logic. Everything is wired for dark-mode defaults and plugs directly into the CodyHouse SCSS system.
+
+## 🚀 Environment
+
+Set these variables locally or in Netlify:
+
+```bash
+SUPABASE_URL=<project_url>
+SUPABASE_ANON_KEY=<anon_key>
+SUPABASE_SERVICE_ROLE_KEY=<service_role_key>
+```
+
+## 🧠 Client Setup
+
+`supabase/client.js` and `supabase/client.ts` read the env variables and expose a `supabase` client:
+
+```javascript
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+export const supabase = createClient(url, key);
+```
+
+The client is reused across `js/main.js`, `js/auth.js`, `js/dashboard.js`, and `js/profile-dropdown.js` for session checks, sign-ins, and secure storage.
+
+## 🔑 Authentication Flow
+
+* **Sign Up / Sign In** – `js/auth.js` handles both modes. New users are stored with metadata like name, phone, and shipping address.
+* **Session Guard** – `js/dashboard.js` and `js/main.js` redirect visitors without a valid session.
+* **Password Reset** – `js/auth.js` sends reset links and `reset-password.html` updates credentials via `supabaseClient.auth.updateUser`.
+
+## 📦 Storage Operations
+
+* **User Files** – `js/dashboard.js` uploads to the `user-data` bucket and lists files for the signed-in user.
+* **Avatars** – `js/profile-dropdown.js` and `js/dashboard.js` read/write images in the `avatars` bucket.
+* **Public URLs** – Every upload immediately retrieves a `getPublicUrl` for display.
+
+## ⚙️ Edge Functions
+
+`supabase/functions/secure-storage/index.ts` enforces JWT-based uploads. It verifies the bearer token, then streams the file into the requested bucket.
+
+```ts
+const { data: { user } } = await supabase.auth.getUser(token);
+await supabase.storage.from(bucket).upload(`${user.id}/${file.name}`, file.stream());
+```
+
+## ✅ Tests
+
+`tests/auth.spec.ts` and `tests/storage.spec.ts` validate sign-up, sign-in, password reset, and bucket permissions. They auto-skip when credentials are missing, keeping the CI pipeline fast.
+
+---
+
+### ⚙️ Next Steps
+
+- Harden error messaging for edge cases.
+- Add role-based access rules for collaborative folders.
+- Expand test coverage to profile updates and edge functions.


### PR DESCRIPTION
## Summary
- Add comprehensive Supabase integration guide covering environment setup, client usage, auth flows, storage, edge functions, and tests
- Reference Supabase in project README with dedicated integration section
- Expand file structure docs to list Supabase and test directories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68943c8f95d883259e005d65dbfb713b