### PR TITLE
feat: support Netlify supabase db URL

### DIFF
--- a/supabase/client.js
+++ b/supabase/client.js
@@ -4,14 +4,20 @@ let url = '';
 let key = '';
 
 if (typeof Deno !== 'undefined' && typeof Deno.env !== 'undefined') {
-  url = Deno.env.get('SUPABASE_URL') ?? '';
+  url =
+    Deno.env.get('SUPABASE_URL') ??
+    Deno.env.get('SUPABASE_DATABASE_URL') ??
+    '';
   key =
     Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ??
     Deno.env.get('SUPABASE_ANON_KEY') ??
     Deno.env.get('SUPABASE_KEY') ??
     '';
 } else if (typeof process !== 'undefined' && typeof process.env !== 'undefined') {
-  url = process.env.SUPABASE_URL ?? '';
+  url =
+    process.env.SUPABASE_URL ??
+    process.env.SUPABASE_DATABASE_URL ??
+    '';
   key =
     process.env.SUPABASE_SERVICE_ROLE_KEY ??
     process.env.SUPABASE_ANON_KEY ??
@@ -19,7 +25,7 @@ if (typeof Deno !== 'undefined' && typeof Deno.env !== 'undefined') {
     '';
 } else {
   const env = await import('../js/env.js');
-  url = env.SUPABASE_URL;
+  url = env.SUPABASE_URL ?? env.SUPABASE_DATABASE_URL ?? '';
   key = env.SUPABASE_KEY;
 }
 

--- a/supabase/client.ts
+++ b/supabase/client.ts
@@ -4,14 +4,20 @@ let url = '';
 let key = '';
 
 if (typeof Deno !== 'undefined' && typeof Deno.env !== 'undefined') {
-  url = Deno.env.get('SUPABASE_URL') ?? '';
+  url =
+    Deno.env.get('SUPABASE_URL') ??
+    Deno.env.get('SUPABASE_DATABASE_URL') ??
+    '';
   key =
     Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ??
     Deno.env.get('SUPABASE_ANON_KEY') ??
     Deno.env.get('SUPABASE_KEY') ??
     '';
 } else if (typeof process !== 'undefined' && typeof process.env !== 'undefined') {
-  url = process.env.SUPABASE_URL ?? '';
+  url =
+    process.env.SUPABASE_URL ??
+    process.env.SUPABASE_DATABASE_URL ??
+    '';
   key =
     process.env.SUPABASE_SERVICE_ROLE_KEY ??
     process.env.SUPABASE_ANON_KEY ??
@@ -19,7 +25,7 @@ if (typeof Deno !== 'undefined' && typeof Deno.env !== 'undefined') {
     '';
 } else {
   const env = await import('../js/env.js');
-  url = env.SUPABASE_URL;
+  url = env.SUPABASE_URL ?? env.SUPABASE_DATABASE_URL ?? '';
   key = env.SUPABASE_KEY;
 }
 


### PR DESCRIPTION
## Summary
- add `SUPABASE_DATABASE_URL` fallback for Deno, Node, and build-time envs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894818b672c83258a881fddf775a9e1