### PR TITLE
Use build script in Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
   publish = "./"
-  command = "sass scss/styles.scss assets/styles.css"
+  command = "npm run build"


### PR DESCRIPTION
## Summary
- Ensure Netlify runs `npm run build` so `generate-env` executes before Sass compilation

## Testing
- `npm test`
- `npm run build` *(fails: SUPABASE_URL and SUPABASE_ANON_KEY must be set)*

------
https://chatgpt.com/codex/tasks/task_e_6894818cacc48325b574a0edf50b55ef