### PR TITLE
Generate env.js during build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
   publish = "./"
-  command = "sass scss/styles.scss assets/styles.css"
+  command = "npm run build"

--- a/supabase/client.js
+++ b/supabase/client.js
@@ -18,10 +18,21 @@ if (typeof Deno !== 'undefined' && typeof Deno.env !== 'undefined') {
     process.env.SUPABASE_KEY ??
     '';
 } else {
-  const env = await import('../js/env.js');
-  url = env.SUPABASE_URL;
-  key = env.SUPABASE_KEY;
+  try {
+    const env = await import('../js/env.js');
+    url = env.SUPABASE_URL;
+    key = env.SUPABASE_KEY;
+  } catch (error) {
+    console.error('Failed to load env.js for Supabase config:', error);
+  }
 }
 
-export const supabase = createClient(url, key);
+let supabase = null;
+if (url && key) {
+  supabase = createClient(url, key);
+} else {
+  console.warn('Supabase URL or key not provided; Supabase client not initialized.');
+}
+
+export { supabase };
 export default supabase;


### PR DESCRIPTION
## Summary
- run Supabase env generator during Netlify builds so js/env.js is available for client code
- add fallback handling in Supabase client for missing js/env.js

## Testing
- `SUPABASE_URL=https://example.supabase.co SUPABASE_ANON_KEY=anon node scripts/generate-env.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894833942208325a2146fc2f25465b4