### PR TITLE
chore: add supabase env fallback

### DIFF
--- a/supabase/client.js
+++ b/supabase/client.js
@@ -24,10 +24,20 @@ if (typeof Deno !== 'undefined' && typeof Deno.env !== 'undefined') {
     process.env.SUPABASE_KEY ??
     '';
 } else {
-  const env = await import('../js/env.js');
-  url = env.SUPABASE_URL ?? env.SUPABASE_DATABASE_URL ?? '';
-  key = env.SUPABASE_KEY;
+  try {
+    const env = await import('../js/env.js');
+    url = env.SUPABASE_URL ?? env.SUPABASE_DATABASE_URL ?? '';
+    key = env.SUPABASE_KEY ?? '';
+  } catch (e) {
+    console.warn('Supabase env.js not found; client not initialized', e);
+  }
+}
+let supabase;
+if (url && key) {
+  supabase = createClient(url, key);
+} else {
+  supabase = undefined;
 }
 
-export const supabase = createClient(url, key);
+export { supabase };
 export default supabase;

--- a/supabase/client.ts
+++ b/supabase/client.ts
@@ -24,10 +24,20 @@ if (typeof Deno !== 'undefined' && typeof Deno.env !== 'undefined') {
     process.env.SUPABASE_KEY ??
     '';
 } else {
-  const env = await import('../js/env.js');
-  url = env.SUPABASE_URL ?? env.SUPABASE_DATABASE_URL ?? '';
-  key = env.SUPABASE_KEY;
+  try {
+    const env = await import('../js/env.js');
+    url = env.SUPABASE_URL ?? env.SUPABASE_DATABASE_URL ?? '';
+    key = env.SUPABASE_KEY ?? '';
+  } catch (e) {
+    console.warn('Supabase env.js not found; client not initialized', e);
+  }
+}
+let supabase;
+if (url && key) {
+  supabase = createClient(url, key);
+} else {
+  supabase = undefined;
 }
 
-export const supabase = createClient(url, key);
+export { supabase };
 export default supabase;


### PR DESCRIPTION
## Summary
- handle missing env.js in Supabase client so the app doesn't crash if the file isn't present at runtime
- export Supabase client only when both URL and key are available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68948952dadc8325b5a909f77f9aaa19