### PR TITLE
Add SUPABASE_DATABASE_URL fallback

### DIFF
--- a/scripts/generate-env.js
+++ b/scripts/generate-env.js
@@ -1,12 +1,14 @@
 const fs = require('fs');
 const path = require('path');
 
-const { SUPABASE_URL, SUPABASE_ANON_KEY } = process.env;
+const { SUPABASE_URL, SUPABASE_DATABASE_URL, SUPABASE_ANON_KEY } = process.env;
 
-if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
-  throw new Error('SUPABASE_URL and SUPABASE_ANON_KEY must be set');
+const url = SUPABASE_URL ?? SUPABASE_DATABASE_URL;
+
+if (!url || !SUPABASE_ANON_KEY) {
+  throw new Error('SUPABASE_URL or SUPABASE_DATABASE_URL and SUPABASE_ANON_KEY must be set');
 }
 
-const content = `export const SUPABASE_URL = '${SUPABASE_URL}';\nexport const SUPABASE_KEY = '${SUPABASE_ANON_KEY}';\n`;
+const content = `export const SUPABASE_URL = '${url}';\nexport const SUPABASE_KEY = '${SUPABASE_ANON_KEY}';\n`;
 const dest = path.join(__dirname, '..', 'js', 'env.js');
 fs.writeFileSync(dest, content);

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
 
-const url = process.env.SUPABASE_URL;
+const url = process.env.SUPABASE_URL ?? process.env.SUPABASE_DATABASE_URL;
 const anonKey = process.env.SUPABASE_ANON_KEY;
 
 if (!url || !anonKey) {
   // Skip tests when Supabase credentials are not provided
   describe.skip('supabase auth', () => {
-    it('skipped because SUPABASE_URL or SUPABASE_ANON_KEY is missing', () => {
+    it('skipped because SUPABASE_URL/SUPABASE_DATABASE_URL or SUPABASE_ANON_KEY is missing', () => {
       expect(true).toBe(true);
     });
   });

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
 
-const url = process.env.SUPABASE_URL;
+const url = process.env.SUPABASE_URL ?? process.env.SUPABASE_DATABASE_URL;
 const anonKey = process.env.SUPABASE_ANON_KEY;
 
 if (!url || !anonKey) {
   // Skip tests when Supabase credentials are not provided
   describe.skip('supabase storage', () => {
-    it('skipped because SUPABASE_URL or SUPABASE_ANON_KEY is missing', () => {
+    it('skipped because SUPABASE_URL/SUPABASE_DATABASE_URL or SUPABASE_ANON_KEY is missing', () => {
       expect(true).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary
- support Netlify's `SUPABASE_DATABASE_URL` in the env generation script
- allow tests to run when `SUPABASE_DATABASE_URL` is provided

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68948ccd1ad0832582027583573e0166