### PR TITLE
Warn instead of failing when Supabase env vars missing

### DIFF
--- a/scripts/generate-env.js
+++ b/scripts/generate-env.js
@@ -2,14 +2,14 @@ const fs = require('fs');
 const path = require('path');
 
 const {
-  SUPABASE_DATABASE_URL,
-  SUPABASE_ANON_KEY,
+  SUPABASE_DATABASE_URL = '',
+  SUPABASE_ANON_KEY = '',
   SUPABASE_SERVICE_ROLE_KEY = '',
   SUPABASE_JWT_SECRET = '',
 } = process.env;
 
 if (!SUPABASE_DATABASE_URL || !SUPABASE_ANON_KEY) {
-  throw new Error('SUPABASE_DATABASE_URL and SUPABASE_ANON_KEY must be set');
+  console.warn('SUPABASE_DATABASE_URL and SUPABASE_ANON_KEY must be set');
 }
 
 const content = `export const SUPABASE_DATABASE_URL = '${SUPABASE_DATABASE_URL}';\nexport const SUPABASE_ANON_KEY = '${SUPABASE_ANON_KEY}';\nexport const SUPABASE_SERVICE_ROLE_KEY = '${SUPABASE_SERVICE_ROLE_KEY}';\nexport const SUPABASE_JWT_SECRET = '${SUPABASE_JWT_SECRET}';\n`;


### PR DESCRIPTION
## Summary
- log a warning rather than throw an error if SUPABASE env vars are missing during deploy
- default missing Supabase env vars to empty strings when generating env.js

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894b43e30ec8325bf77ad30f5d0c8f2