### PR TITLE
Generate env.js instead of .env.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 *.env.*
 .env.js
 *.env.js
+env.js

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Deployment: Push to `main` auto-deploys via Netlify CI/CD.
 ### Supabase Setup
 
 1. Copy `.env.example` to `.env` and fill in `SUPABASE_DATABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, and `SUPABASE_JWT_SECRET`.
-2. Run `npm run build` (or `npm run watch`) to generate `js/env.js` with your credentials.
+2. Run `npm run build` (or `npm run watch`) to generate `assets/js/env.js` with your credentials.
 3. Apply database changes with the Supabase CLI:
    ```bash
    supabase db push

--- a/scripts/generate-env.js
+++ b/scripts/generate-env.js
@@ -16,7 +16,7 @@ const content = `window._env_ = {
 };
 `;
 
-const dest = path.join(__dirname, '..', 'assets', 'js', '.env.js');
+const dest = path.join(__dirname, '..', 'assets', 'js', 'env.js');
 fs.mkdirSync(path.dirname(dest), { recursive: true });
 fs.writeFileSync(dest, content);
 console.log('Environment file generated at', dest);


### PR DESCRIPTION
## Summary
- Write environment variables to `env.js` instead of hidden `.env.js`
- Ignore generated `env.js` and document new path

## Testing
- `node scripts/generate-env.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68954e3bb7e483258b65adc29f1e5ec5