### PR TITLE
chore: output env to js directory

### DIFF
--- a/scripts/generate-env.js
+++ b/scripts/generate-env.js
@@ -16,7 +16,7 @@ const content = `window._env_ = {
 };
 `;
 
-const dest = path.join(__dirname, '..', 'assets', 'js', 'env.js');
+const dest = path.join(__dirname, '..', 'js', 'env.js');
 fs.mkdirSync(path.dirname(dest), { recursive: true });
 fs.writeFileSync(dest, content);
 console.log('Environment file generated at', dest);


### PR DESCRIPTION
## Summary
- write generated env.js to `js/` to match supabase client

## Testing
- `npm run build`
- `node supabase/client.js` (via local module)

------
https://chatgpt.com/codex/tasks/task_e_689567360c348325a73a30351ba20682