### PR TITLE
feat: dynamically load supabase modules

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,3 @@
-import supabase from '../supabase/client.js';
-
 document.addEventListener('DOMContentLoaded', async function () {
   const menuToggle = document.querySelector('.js-menu-toggle');
   const megaMenu = document.querySelector('.js-mega-menu');
@@ -75,6 +73,7 @@ document.addEventListener('DOMContentLoaded', async function () {
   // ---------------------------
 
   try {
+    const { default: supabase } = await import('../supabase/client.js');
     const { data } = await supabase.auth.getSession();
     const session = data.session;
 

--- a/js/profile-dropdown.js
+++ b/js/profile-dropdown.js
@@ -1,5 +1,3 @@
-import supabase from '../supabase/client.js';
-
 document.addEventListener('DOMContentLoaded', () => {
   const toggle = document.querySelector('.js-profile-toggle');
   const dropdown = document.querySelector('.js-profile-dropdown');
@@ -37,6 +35,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // ---------------------------
   (async () => {
     try {
+      const { default: supabase } = await import('../supabase/client.js');
       const { data } = await supabase.auth.getSession();
       if (data.session) {
         const user = data.session.user;


### PR DESCRIPTION
## Summary
- load Supabase client via dynamic import with fallback for both main UI and profile dropdown
- ensure menu, search, and profile handlers initialize regardless of Supabase availability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895678658f0832592bc15c19a1e3db4