### PR TITLE
Guard auth and storage calls when Supabase is missing

### DIFF
--- a/js/supabase-helper.js
+++ b/js/supabase-helper.js
@@ -1,0 +1,25 @@
+import supabaseClient from '../supabase/client.js';
+
+/**
+ * Retrieves the Supabase client if it is configured.
+ * Runs the optional onMissing callback to provide user feedback or
+ * disable features when the client is not available.
+ *
+ * @param {Function} [onMissing] Callback executed when Supabase isn't configured.
+ * @returns {import('@supabase/supabase-js').SupabaseClient|null}
+ */
+export function getSupabase(onMissing) {
+  if (!supabaseClient) {
+    if (typeof onMissing === 'function') {
+      try {
+        onMissing();
+      } catch (_) {
+        // ignore errors from callbacks
+      }
+    } else {
+      alert('Supabase is not configured.');
+    }
+    return null;
+  }
+  return supabaseClient;
+}


### PR DESCRIPTION
## Summary
- Add helper to safely retrieve Supabase client and surface missing configuration
- Update auth and dashboard scripts to check client before calling auth or storage APIs and provide user feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68967b9666ec8325a419c2ee2b288f01