### PR TITLE
Align Supabase env handling

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,8 +1,8 @@
 import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
 
-const { SUPABASE_URL = '', SUPABASE_ANON_KEY = '' } = window._env_ || {};
+const { SUPABASE_DATABASE_URL = '', SUPABASE_ANON_KEY = '' } = window._env_ || {};
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+const supabase = createClient(SUPABASE_DATABASE_URL, SUPABASE_ANON_KEY);
 
 // Example: log current session
 supabase.auth.getSession().then(({ data }) => {

--- a/scripts/generate-env.js
+++ b/scripts/generate-env.js
@@ -3,7 +3,8 @@ const path = require('path');
 
 const {
   SUPABASE_DATABASE_URL = '',
-  SUPABASE_ANON_KEY = ''
+  SUPABASE_ANON_KEY = '',
+  SUPABASE_SERVICE_ROLE_KEY = ''
 } = process.env;
 
 if (!SUPABASE_DATABASE_URL || !SUPABASE_ANON_KEY) {
@@ -11,12 +12,19 @@ if (!SUPABASE_DATABASE_URL || !SUPABASE_ANON_KEY) {
 }
 
 const content = `window._env_ = {
-  SUPABASE_URL: "${SUPABASE_DATABASE_URL}",
-  SUPABASE_ANON_KEY: "${SUPABASE_ANON_KEY}"
+  SUPABASE_DATABASE_URL: "${SUPABASE_DATABASE_URL}",
+  SUPABASE_ANON_KEY: "${SUPABASE_ANON_KEY}",
+  SUPABASE_SERVICE_ROLE_KEY: "${SUPABASE_SERVICE_ROLE_KEY}"
 };
 `;
 
-const dest = path.join(__dirname, '..', 'js', 'env.js');
-fs.mkdirSync(path.dirname(dest), { recursive: true });
-fs.writeFileSync(dest, content);
-console.log('Environment file generated at', dest);
+const destinations = [
+  path.join(__dirname, '..', 'js', 'env.js'),
+  path.join(__dirname, '..', 'assets', 'js', 'env.js'),
+];
+
+for (const dest of destinations) {
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.writeFileSync(dest, content);
+  console.log('Environment file generated at', dest);
+}

--- a/supabase/client.js
+++ b/supabase/client.js
@@ -16,13 +16,9 @@ if (typeof Deno !== 'undefined' && typeof Deno.env !== 'undefined') {
     process.env.SUPABASE_ANON_KEY ??
     '';
 } else {
-  try {
-    const env = await import('../js/env.js');
-    url = env.SUPABASE_DATABASE_URL ?? '';
-    key = env.SUPABASE_SERVICE_ROLE_KEY ?? env.SUPABASE_ANON_KEY ?? '';
-  } catch (e) {
-    console.warn('Supabase env.js not found; client not initialized', e);
-  }
+  const env = typeof window !== 'undefined' ? window._env_ || {} : {};
+  url = env.SUPABASE_DATABASE_URL ?? '';
+  key = env.SUPABASE_SERVICE_ROLE_KEY ?? env.SUPABASE_ANON_KEY ?? '';
 }
 let supabase;
 if (url && key) {

--- a/supabase/client.ts
+++ b/supabase/client.ts
@@ -16,13 +16,9 @@ if (typeof Deno !== 'undefined' && typeof Deno.env !== 'undefined') {
     process.env.SUPABASE_ANON_KEY ??
     '';
 } else {
-  try {
-    const env = await import('../js/env.js');
-    url = env.SUPABASE_DATABASE_URL ?? '';
-    key = env.SUPABASE_SERVICE_ROLE_KEY ?? env.SUPABASE_ANON_KEY ?? '';
-  } catch (e) {
-    console.warn('Supabase env.js not found; client not initialized', e);
-  }
+  const env = typeof window !== 'undefined' ? (window as any)._env_ || {} : {};
+  url = env.SUPABASE_DATABASE_URL ?? '';
+  key = env.SUPABASE_SERVICE_ROLE_KEY ?? env.SUPABASE_ANON_KEY ?? '';
 }
 let supabase;
 if (url && key) {


### PR DESCRIPTION
## Summary
- expose SUPABASE_DATABASE_URL, SUPABASE_ANON_KEY, and SUPABASE_SERVICE_ROLE_KEY via the generate-env script
- read Supabase config from `window._env_` in JS/TS clients and app
- standardize on `SUPABASE_DATABASE_URL` for all client lookups

## Testing
- `node scripts/generate-env.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68967b9d45f88325b07088ebc48f0982