### PR TITLE
feat: add intro spin to book viewer

### DIFF
--- a/js/book-3d-viewer.js
+++ b/js/book-3d-viewer.js
@@ -5,7 +5,7 @@ const rotateRight = document.getElementById('rotate-right');
 let rotation = 360;
 let isDragging = false;
 let startX = 0;
-let autoInterval = startAutoRotate();
+let autoInterval;
 
 function applyRotation(angle) {
   book.style.transform = `rotateY(${angle}deg)`;
@@ -22,6 +22,32 @@ function startAutoRotate() {
 function resetAutoRotate() {
   clearInterval(autoInterval);
   autoInterval = startAutoRotate();
+}
+
+function initialSpin() {
+  book.style.transition = 'transform 1s linear';
+  rotation += 360;
+  applyRotation(rotation);
+  book.addEventListener(
+    'transitionend',
+    () => {
+      book.style.transition = 'transform 0.6s ease';
+      autoInterval = startAutoRotate();
+    },
+    { once: true }
+  );
+}
+
+if ('IntersectionObserver' in window) {
+  const observer = new IntersectionObserver((entries, obs) => {
+    if (entries[0].isIntersecting) {
+      obs.disconnect();
+      initialSpin();
+    }
+  });
+  observer.observe(book);
+} else {
+  initialSpin();
 }
 
 book.addEventListener('mousedown', e => {


### PR DESCRIPTION
## Summary
- spin book 360° when it first enters the viewport
- restore easing and start auto-rotation after spin

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898e1a4bb908325b50b463f1383e15f