### PR TITLE
Restore hero scripts without auto scroll

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1055,6 +1055,10 @@ input:checked + .toggle-slider::before {
   background: url("https://picsum.photos/1920/1080?image=903") center/cover;
   transition: height 0.3s;
 }
+
+.hero-static {
+  background: url("https://picsum.photos/1920/1080?image=903") center/cover;
+}
 @media (max-width: 768px) {
   .hero-demos .hero h1 {
     font-size: 2rem;

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
     <!-- ⚙️ Site Maintenance Landing Page for DarenPrince.com -->
 
     <!-- 1. Hero Section -->
-    <section id="autoScaleHero" class="hero hero-auto-scale text-center">
+    <section id="staticHero" class="hero hero-static text-center">
       <div class="container max-width-adaptive-lg">
         <h1 style="display:none;">Game On!</h1>
         <a href="#book-viewer" class="btn btn--primary hero-cta">Buy Now</a>
@@ -237,7 +237,7 @@
   <script type="module" src="./js/profile-dropdown.js"></script>
   <script src="./js/trailer-modal.js"></script>
   <script src="./js/theme-toggle.js"></script>
-  <script src="./js/hero-demos.js"></script>
+  <script src="./js/hero-static.js"></script>
   <script type="module" src="./js/book-3d-viewer.js"></script>
   <script src="./js/book-details.js"></script>
   <script type="module" src="./js/main.js"></script>

--- a/js/hero-static.js
+++ b/js/hero-static.js
@@ -1,0 +1,23 @@
+// Handles scroll-triggered video hero without auto page scroll behavior
+
+document.addEventListener('DOMContentLoaded', () => {
+  const videoHero = document.getElementById('scrollVideoHero');
+  const video = document.getElementById('videoBg');
+
+  function handleScroll() {
+    // Fade in and play background video
+    if (videoHero) {
+      const trigger = window.innerHeight / 3;
+      if (window.scrollY > trigger) {
+        videoHero.classList.add('loaded');
+        if (video && video.paused) {
+          video.play();
+          videoHero.classList.add('playing');
+        }
+      }
+    }
+  }
+
+  window.addEventListener('scroll', handleScroll);
+  handleScroll();
+});

--- a/scss/components/_hero-demos.scss
+++ b/scss/components/_hero-demos.scss
@@ -155,6 +155,10 @@
     transition: height 0.3s;
   }
 
+  .hero-static {
+    background: url('https://picsum.photos/1920/1080?image=903') center/cover;
+  }
+
   @media (max-width: 768px) {
     .hero {
       h1 {


### PR DESCRIPTION
## Summary
- Introduce `hero-static.js` to provide hero demo effects without automatic page scrolling
- Update homepage to use `hero-static` class and include new script
- Add `.hero-static` styling for consistent appearance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68990cc9968083259c90665405d82055