### PR TITLE
feat: add book control rail component

### DIFF
--- a/components/book-control-rail/book-control-rail.css
+++ b/components/book-control-rail/book-control-rail.css
@@ -1,0 +1,86 @@
+.book-rail {
+  --radius-rail: 12px;
+  --radius-btn: 10px;
+  --brand-1: #87BD72;
+  --brand-2: #456F3A;
+  --ink: #FAFAFA;
+  --ink-muted: #B8BAB7;
+  --surface: rgba(33,33,33,.75);
+  --border: rgba(255,255,255,.08);
+  --shadow: 0 10px 28px rgba(0,0,0,.35);
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-rail);
+  box-shadow: var(--shadow);
+  padding: 0.5rem;
+}
+
+.book-rail__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.book-rail__btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: transparent;
+  color: var(--ink);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-btn);
+  font: inherit;
+  cursor: pointer;
+  transition: background 180ms cubic-bezier(.2,.7,.2,1), box-shadow 180ms cubic-bezier(.2,.7,.2,1), transform 180ms cubic-bezier(.2,.7,.2,1);
+}
+
+.book-rail__btn svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  stroke: currentColor;
+}
+
+.book-rail__label {
+  white-space: nowrap;
+}
+
+.book-rail__btn:hover,
+.book-rail__btn:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0,0,0,.3), 0 0 0 1px var(--brand-1) inset;
+}
+
+.book-rail__btn:focus-visible {
+  outline: 2px solid var(--brand-1);
+  outline-offset: 2px;
+}
+
+.book-rail__btn--active {
+  background: rgba(135,189,114,.08);
+  box-shadow: 0 0 0 2px var(--brand-1);
+}
+
+.book-rail__btn[disabled] {
+  opacity: .4;
+  cursor: not-allowed;
+}
+
+.book-rail--compact .book-rail__label {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .book-rail__btn {
+    transition: none;
+  }
+  .book-rail__btn:hover,
+  .book-rail__btn:focus-visible {
+    transform: none;
+  }
+}

--- a/components/book-control-rail/book-control-rail.html
+++ b/components/book-control-rail/book-control-rail.html
@@ -1,0 +1,63 @@
+<!-- Mount/animate .book-rail -->
+<nav class="book-rail" aria-label="Book controls">
+  <ul class="book-rail__list">
+    <li class="book-rail__item">
+      <button type="button" class="book-rail__btn" data-tool="zoom" aria-label="Zoom" title="Zoom">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M10 3a7 7 0 1 0 0 14 7 7 0 0 0 0-14z"/>
+          <path d="M7 10h6"/>
+          <path d="M10 7v6"/>
+          <path d="M21 21l-6-6"/>
+        </svg>
+        <span class="book-rail__label">Zoom</span>
+      </button>
+    </li>
+    <li class="book-rail__item">
+      <button type="button" class="book-rail__btn" data-tool="front" aria-label="Front view" title="Front">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M6 4h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2H6a2 2 0 0 1 -2 -2V6a2 2 0 0 1 2 -2z"/>
+          <path d="M6 4v16"/>
+        </svg>
+        <span class="book-rail__label">Front</span>
+      </button>
+    </li>
+    <li class="book-rail__item">
+      <button type="button" class="book-rail__btn" data-tool="back" aria-label="Back view" title="Back">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M4 4h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2H4a2 2 0 0 1 -2 -2V6a2 2 0 0 1 2 -2z"/>
+          <path d="M16 4v16"/>
+        </svg>
+        <span class="book-rail__label">Back</span>
+      </button>
+    </li>
+    <li class="book-rail__item">
+      <button type="button" class="book-rail__btn" data-tool="spin360" aria-label="Rotate 360 degrees" title="360°">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M20 11a8.1 8.1 0 0 0 -15.5 -2M4 5v4h4"/>
+          <path d="M4 13a8.1 8.1 0 0 0 15.5 2M20 19v-4h-4"/>
+        </svg>
+        <span class="book-rail__label">360°</span>
+      </button>
+    </li>
+    <li class="book-rail__item">
+      <button type="button" class="book-rail__btn" data-tool="buy" aria-label="Buy" title="Buy">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M3 3h2l2 12h9a2 2 0 0 0 2-2l1-7H6"/>
+          <path d="M9 19m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0"/>
+          <path d="M17 19m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0"/>
+        </svg>
+        <span class="book-rail__label">Buy</span>
+      </button>
+    </li>
+    <li class="book-rail__item">
+      <button type="button" class="book-rail__btn" data-tool="compact" aria-label="Toggle labels" title="Toggle labels">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M4 7h16"/>
+          <path d="M4 12h16"/>
+          <path d="M4 17h16"/>
+        </svg>
+        <span class="book-rail__label">Labels</span>
+      </button>
+    </li>
+  </ul>
+</nav>

--- a/components/book-control-rail/book-control-rail.js
+++ b/components/book-control-rail/book-control-rail.js
@@ -1,0 +1,48 @@
+export let onZoom = () => {};
+export let onViewFront = () => {};
+export let onViewBack = () => {};
+export let onToggleSpin360 = () => {};
+export let onBuyClick = () => {};
+
+const root = document.querySelector('.book-rail');
+const buttons = {
+  zoom: root?.querySelector('[data-tool="zoom"]'),
+  front: root?.querySelector('[data-tool="front"]'),
+  back: root?.querySelector('[data-tool="back"]'),
+  spin360: root?.querySelector('[data-tool="spin360"]'),
+  buy: root?.querySelector('[data-tool="buy"]'),
+  compact: root?.querySelector('[data-tool="compact"]'),
+};
+
+export function setActiveTool(name) {
+  ['front', 'back', 'spin360'].forEach(tool => {
+    buttons[tool]?.classList.toggle('book-rail__btn--active', tool === name);
+  });
+}
+
+buttons.zoom?.addEventListener('click', () => onZoom());
+buttons.front?.addEventListener('click', () => {
+  setActiveTool('front');
+  onViewFront();
+});
+buttons.back?.addEventListener('click', () => {
+  setActiveTool('back');
+  onViewBack();
+});
+buttons.spin360?.addEventListener('click', () => {
+  setActiveTool('spin360');
+  onToggleSpin360();
+});
+buttons.buy?.addEventListener('click', () => onBuyClick());
+
+const compactClass = 'book-rail--compact';
+(function loadCompact() {
+  const compact = sessionStorage.getItem('bookRailCompact') === '1';
+  root?.classList.toggle(compactClass, compact);
+})();
+
+buttons.compact?.addEventListener('click', () => {
+  const compact = !root.classList.contains(compactClass);
+  root.classList.toggle(compactClass, compact);
+  sessionStorage.setItem('bookRailCompact', compact ? '1' : '0');
+});


### PR DESCRIPTION
## Summary
- add book control rail markup with inline SVG icons
- style rail and buttons with brand tokens and rounded rectangles
- wire up ES6 module for hooks, active state, and label persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b15831a308325b6bb95598453e577