### PR TITLE
Use page-level gray backdrop for swatch catalog

### DIFF
--- a/assets/css/canva-swatches.generated.css
+++ b/assets/css/canva-swatches.generated.css
@@ -1,0 +1,3727 @@
+/* AUTO-GENERATED FROM SCREENSHOT GRID — DO NOT EDIT BY HAND */
+:root { --gradient-img_6314_001: linear-gradient(180deg, #f7f7f7 0%, #dcdcdc 100%); --border-img_6314_001: #cccdcf; --text-img_6314_001: #b4b4b4; }
+.btn-img_6314_001 { background-image: var(--gradient-img_6314_001); border:1px solid var(--border-img_6314_001); color:var(--text-img_6314_001); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_001 { background-image: var(--gradient-img_6314_001); border:1px solid var(--border-img_6314_001); color:var(--text-img_6314_001); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_002: linear-gradient(180deg, #f7f7f7 0%, #e6e6e6 100%); --border-img_6314_002: #d3d3d3; --text-img_6314_002: #b4b4b4; }
+.btn-img_6314_002 { background-image: var(--gradient-img_6314_002); border:1px solid var(--border-img_6314_002); color:var(--text-img_6314_002); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_002 { background-image: var(--gradient-img_6314_002); border:1px solid var(--border-img_6314_002); color:var(--text-img_6314_002); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_003: linear-gradient(180deg, #f7f7f7 0%, #e6e6e6 100%); --border-img_6314_003: #d1d1d1; --text-img_6314_003: #b4b4b4; }
+.btn-img_6314_003 { background-image: var(--gradient-img_6314_003); border:1px solid var(--border-img_6314_003); color:var(--text-img_6314_003); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_003 { background-image: var(--gradient-img_6314_003); border:1px solid var(--border-img_6314_003); color:var(--text-img_6314_003); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_004: linear-gradient(180deg, #f7f7f7 0%, #e6e6e6 100%); --border-img_6314_004: #d5d5d5; --text-img_6314_004: #b4b4b4; }
+.btn-img_6314_004 { background-image: var(--gradient-img_6314_004); border:1px solid var(--border-img_6314_004); color:var(--text-img_6314_004); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_004 { background-image: var(--gradient-img_6314_004); border:1px solid var(--border-img_6314_004); color:var(--text-img_6314_004); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_005: linear-gradient(180deg, #f7f7f7 0%, #dfdfdf 100%); --border-img_6314_005: #cacdcf; --text-img_6314_005: #b3b3b3; }
+.btn-img_6314_005 { background-image: var(--gradient-img_6314_005); border:1px solid var(--border-img_6314_005); color:var(--text-img_6314_005); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_005 { background-image: var(--gradient-img_6314_005); border:1px solid var(--border-img_6314_005); color:var(--text-img_6314_005); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_006: linear-gradient(180deg, #f7f7f7 0%, #e0e0e0 100%); --border-img_6314_006: #cacbcc; --text-img_6314_006: #838383; }
+.btn-img_6314_006 { background-image: var(--gradient-img_6314_006); border:1px solid var(--border-img_6314_006); color:var(--text-img_6314_006); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_006 { background-image: var(--gradient-img_6314_006); border:1px solid var(--border-img_6314_006); color:var(--text-img_6314_006); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_007: linear-gradient(180deg, #f7f7f7 0%, #e0e0e0 100%); --border-img_6314_007: #d6d6d6; --text-img_6314_007: #838383; }
+.btn-img_6314_007 { background-image: var(--gradient-img_6314_007); border:1px solid var(--border-img_6314_007); color:var(--text-img_6314_007); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_007 { background-image: var(--gradient-img_6314_007); border:1px solid var(--border-img_6314_007); color:var(--text-img_6314_007); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_008: linear-gradient(180deg, #dfebf8 0%, #e0e0e0 100%); --border-img_6314_008: #cbcdce; --text-img_6314_008: #838383; }
+.btn-img_6314_008 { background-image: var(--gradient-img_6314_008); border:1px solid var(--border-img_6314_008); color:var(--text-img_6314_008); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_008 { background-image: var(--gradient-img_6314_008); border:1px solid var(--border-img_6314_008); color:var(--text-img_6314_008); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_009: linear-gradient(180deg, #f7f7f7 0%, #6f6f6f 100%); --border-img_6314_009: #c7c8c9; --text-img_6314_009: #616161; }
+.btn-img_6314_009 { background-image: var(--gradient-img_6314_009); border:1px solid var(--border-img_6314_009); color:var(--text-img_6314_009); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_009 { background-image: var(--gradient-img_6314_009); border:1px solid var(--border-img_6314_009); color:var(--text-img_6314_009); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_010: linear-gradient(180deg, #f1f1f1 0%, #d7d7d7 100%); --border-img_6314_010: #d0d0d0; --text-img_6314_010: #616161; }
+.btn-img_6314_010 { background-image: var(--gradient-img_6314_010); border:1px solid var(--border-img_6314_010); color:var(--text-img_6314_010); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_010 { background-image: var(--gradient-img_6314_010); border:1px solid var(--border-img_6314_010); color:var(--text-img_6314_010); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_011: linear-gradient(180deg, #f7f7f7 0%, #d7d7d7 100%); --border-img_6314_011: #cfcfcf; --text-img_6314_011: #616161; }
+.btn-img_6314_011 { background-image: var(--gradient-img_6314_011); border:1px solid var(--border-img_6314_011); color:var(--text-img_6314_011); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_011 { background-image: var(--gradient-img_6314_011); border:1px solid var(--border-img_6314_011); color:var(--text-img_6314_011); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_012: linear-gradient(180deg, #e9f0f7 0%, #859582 100%); --border-img_6314_012: #c3c5c6; --text-img_6314_012: #616161; }
+.btn-img_6314_012 { background-image: var(--gradient-img_6314_012); border:1px solid var(--border-img_6314_012); color:var(--text-img_6314_012); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_012 { background-image: var(--gradient-img_6314_012); border:1px solid var(--border-img_6314_012); color:var(--text-img_6314_012); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_013: linear-gradient(180deg, #cccdcd 0%, #cccccc 100%); --border-img_6314_013: #9e9e9e; --text-img_6314_013: #dddddd; }
+.btn-img_6314_013 { background-image: var(--gradient-img_6314_013); border:1px solid var(--border-img_6314_013); color:var(--text-img_6314_013); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_013 { background-image: var(--gradient-img_6314_013); border:1px solid var(--border-img_6314_013); color:var(--text-img_6314_013); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_014: linear-gradient(180deg, #d4d4d5 0%, #c6c6c5 100%); --border-img_6314_014: #d4d4d4; --text-img_6314_014: #dedede; }
+.btn-img_6314_014 { background-image: var(--gradient-img_6314_014); border:1px solid var(--border-img_6314_014); color:var(--text-img_6314_014); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_014 { background-image: var(--gradient-img_6314_014); border:1px solid var(--border-img_6314_014); color:var(--text-img_6314_014); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_015: linear-gradient(180deg, #d4d5d5 0%, #e0e0e0 100%); --border-img_6314_015: #d9d9d9; --text-img_6314_015: #dedfdf; }
+.btn-img_6314_015 { background-image: var(--gradient-img_6314_015); border:1px solid var(--border-img_6314_015); color:var(--text-img_6314_015); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_015 { background-image: var(--gradient-img_6314_015); border:1px solid var(--border-img_6314_015); color:var(--text-img_6314_015); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_016: linear-gradient(180deg, #d4d4d5 0%, #e0e0e0 100%); --border-img_6314_016: #dbdbdb; --text-img_6314_016: #dedede; }
+.btn-img_6314_016 { background-image: var(--gradient-img_6314_016); border:1px solid var(--border-img_6314_016); color:var(--text-img_6314_016); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_016 { background-image: var(--gradient-img_6314_016); border:1px solid var(--border-img_6314_016); color:var(--text-img_6314_016); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_017: linear-gradient(180deg, #a3aca2 0%, #d8d8d8 100%); --border-img_6314_017: #a5a8a4; --text-img_6314_017: #dddddd; }
+.btn-img_6314_017 { background-image: var(--gradient-img_6314_017); border:1px solid var(--border-img_6314_017); color:var(--text-img_6314_017); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_017 { background-image: var(--gradient-img_6314_017); border:1px solid var(--border-img_6314_017); color:var(--text-img_6314_017); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_018: linear-gradient(180deg, #cccccc 0%, #e0e0e0 100%); --border-img_6314_018: #bababa; --text-img_6314_018: #b6b6b6; }
+.btn-img_6314_018 { background-image: var(--gradient-img_6314_018); border:1px solid var(--border-img_6314_018); color:var(--text-img_6314_018); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_018 { background-image: var(--gradient-img_6314_018); border:1px solid var(--border-img_6314_018); color:var(--text-img_6314_018); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_019: linear-gradient(180deg, #cccccc 0%, #aeaeae 100%); --border-img_6314_019: #d8d8d8; --text-img_6314_019: #b9b9b9; }
+.btn-img_6314_019 { background-image: var(--gradient-img_6314_019); border:1px solid var(--border-img_6314_019); color:var(--text-img_6314_019); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_019 { background-image: var(--gradient-img_6314_019); border:1px solid var(--border-img_6314_019); color:var(--text-img_6314_019); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_020: linear-gradient(180deg, #cccccc 0%, #cbd4c8 100%); --border-img_6314_020: #bcbdbc; --text-img_6314_020: #dedede; }
+.btn-img_6314_020 { background-image: var(--gradient-img_6314_020); border:1px solid var(--border-img_6314_020); color:var(--text-img_6314_020); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_020 { background-image: var(--gradient-img_6314_020); border:1px solid var(--border-img_6314_020); color:var(--text-img_6314_020); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_021: linear-gradient(180deg, #dddddd 0%, #9e9e9e 100%); --border-img_6314_021: #a3a3a3; --text-img_6314_021: #dadada; }
+.btn-img_6314_021 { background-image: var(--gradient-img_6314_021); border:1px solid var(--border-img_6314_021); color:var(--text-img_6314_021); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_021 { background-image: var(--gradient-img_6314_021); border:1px solid var(--border-img_6314_021); color:var(--text-img_6314_021); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_022: linear-gradient(180deg, #dedede 0%, #4f4f4f 100%); --border-img_6314_022: #b2b5b2; --text-img_6314_022: #e0e0e0; }
+.btn-img_6314_022 { background-image: var(--gradient-img_6314_022); border:1px solid var(--border-img_6314_022); color:var(--text-img_6314_022); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_022 { background-image: var(--gradient-img_6314_022); border:1px solid var(--border-img_6314_022); color:var(--text-img_6314_022); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_023: linear-gradient(180deg, #dedede 0%, #8aba7d 100%); --border-img_6314_023: #b8cbb3; --text-img_6314_023: #cecece; }
+.btn-img_6314_023 { background-image: var(--gradient-img_6314_023); border:1px solid var(--border-img_6314_023); color:var(--text-img_6314_023); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_023 { background-image: var(--gradient-img_6314_023); border:1px solid var(--border-img_6314_023); color:var(--text-img_6314_023); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_024: linear-gradient(180deg, #dddddd 0%, #adc4a7 100%); --border-img_6314_024: #a3ada1; --text-img_6314_024: #dfdfdf; }
+.btn-img_6314_024 { background-image: var(--gradient-img_6314_024); border:1px solid var(--border-img_6314_024); color:var(--text-img_6314_024); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_024 { background-image: var(--gradient-img_6314_024); border:1px solid var(--border-img_6314_024); color:var(--text-img_6314_024); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_025: linear-gradient(180deg, #d5d5d5 0%, #d7d7d7 100%); --border-img_6314_025: #a5a5a5; --text-img_6314_025: #e1e1e1; }
+.btn-img_6314_025 { background-image: var(--gradient-img_6314_025); border:1px solid var(--border-img_6314_025); color:var(--text-img_6314_025); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_025 { background-image: var(--gradient-img_6314_025); border:1px solid var(--border-img_6314_025); color:var(--text-img_6314_025); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_026: linear-gradient(180deg, #e1e1e1 0%, #e5e5e5 100%); --border-img_6314_026: #aeaeae; --text-img_6314_026: #4b4b4b; }
+.btn-img_6314_026 { background-image: var(--gradient-img_6314_026); border:1px solid var(--border-img_6314_026); color:var(--text-img_6314_026); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_026 { background-image: var(--gradient-img_6314_026); border:1px solid var(--border-img_6314_026); color:var(--text-img_6314_026); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_027: linear-gradient(180deg, #e2e2e2 0%, #94b78b 100%); --border-img_6314_027: #aab5a7; --text-img_6314_027: #8bc37c; }
+.btn-img_6314_027 { background-image: var(--gradient-img_6314_027); border:1px solid var(--border-img_6314_027); color:var(--text-img_6314_027); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_027 { background-image: var(--gradient-img_6314_027); border:1px solid var(--border-img_6314_027); color:var(--text-img_6314_027); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_028: linear-gradient(180deg, #e1e1e1 0%, #587451 100%); --border-img_6314_028: #b5c5b0; --text-img_6314_028: #638f57; }
+.btn-img_6314_028 { background-image: var(--gradient-img_6314_028); border:1px solid var(--border-img_6314_028); color:var(--text-img_6314_028); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_028 { background-image: var(--gradient-img_6314_028); border:1px solid var(--border-img_6314_028); color:var(--text-img_6314_028); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_029: linear-gradient(180deg, #d9d9d9 0%, #d2d4d2 100%); --border-img_6314_029: #9ea69b; --text-img_6314_029: #e1e1e1; }
+.btn-img_6314_029 { background-image: var(--gradient-img_6314_029); border:1px solid var(--border-img_6314_029); color:var(--text-img_6314_029); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_029 { background-image: var(--gradient-img_6314_029); border:1px solid var(--border-img_6314_029); color:var(--text-img_6314_029); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_030: linear-gradient(180deg, #777777 0%, #d6d6d6 100%); --border-img_6314_030: #969696; --text-img_6314_030: #838383; }
+.btn-img_6314_030 { background-image: var(--gradient-img_6314_030); border:1px solid var(--border-img_6314_030); color:var(--text-img_6314_030); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_030 { background-image: var(--gradient-img_6314_030); border:1px solid var(--border-img_6314_030); color:var(--text-img_6314_030); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_031: linear-gradient(180deg, #83b078 0%, #e5e6e5 100%); --border-img_6314_031: #b1bbae; --text-img_6314_031: #8eba84; }
+.btn-img_6314_031 { background-image: var(--gradient-img_6314_031); border:1px solid var(--border-img_6314_031); color:var(--text-img_6314_031); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_031 { background-image: var(--gradient-img_6314_031); border:1px solid var(--border-img_6314_031); color:var(--text-img_6314_031); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_032: linear-gradient(180deg, #89ae81 0%, #cecdcd 100%); --border-img_6314_032: #9aa896; --text-img_6314_032: #6a7b66; }
+.btn-img_6314_032 { background-image: var(--gradient-img_6314_032); border:1px solid var(--border-img_6314_032); color:var(--text-img_6314_032); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_032 { background-image: var(--gradient-img_6314_032); border:1px solid var(--border-img_6314_032); color:var(--text-img_6314_032); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_033: linear-gradient(180deg, #9a9a9a 0%, #d5d5d5 100%); --border-img_6314_033: #a4a3a4; --text-img_6314_033: #d8d8d8; }
+.btn-img_6314_033 { background-image: var(--gradient-img_6314_033); border:1px solid var(--border-img_6314_033); color:var(--text-img_6314_033); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_033 { background-image: var(--gradient-img_6314_033); border:1px solid var(--border-img_6314_033); color:var(--text-img_6314_033); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_034: linear-gradient(180deg, #444444 0%, #eaeae9 100%); --border-img_6314_034: #b3b8b1; --text-img_6314_034: #d3d1d1; }
+.btn-img_6314_034 { background-image: var(--gradient-img_6314_034); border:1px solid var(--border-img_6314_034); color:var(--text-img_6314_034); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_034 { background-image: var(--gradient-img_6314_034); border:1px solid var(--border-img_6314_034); color:var(--text-img_6314_034); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_035: linear-gradient(180deg, #789d6f 0%, #e5e4e3 100%); --border-img_6314_035: #b2c2ae; --text-img_6314_035: #cccaca; }
+.btn-img_6314_035 { background-image: var(--gradient-img_6314_035); border:1px solid var(--border-img_6314_035); color:var(--text-img_6314_035); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_035 { background-image: var(--gradient-img_6314_035); border:1px solid var(--border-img_6314_035); color:var(--text-img_6314_035); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_036: linear-gradient(180deg, #9fa99d 0%, #d3d2d2 100%); --border-img_6314_036: #a4a8a2; --text-img_6314_036: #d5d4d4; }
+.btn-img_6314_036 { background-image: var(--gradient-img_6314_036); border:1px solid var(--border-img_6314_036); color:var(--text-img_6314_036); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_036 { background-image: var(--gradient-img_6314_036); border:1px solid var(--border-img_6314_036); color:var(--text-img_6314_036); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_037: linear-gradient(180deg, #d2d2d2 0%, #d4d4d4 100%); --border-img_6314_037: #adacac; --text-img_6314_037: #e6e6e6; }
+.btn-img_6314_037 { background-image: var(--gradient-img_6314_037); border:1px solid var(--border-img_6314_037); color:var(--text-img_6314_037); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_037 { background-image: var(--gradient-img_6314_037); border:1px solid var(--border-img_6314_037); color:var(--text-img_6314_037); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_038: linear-gradient(180deg, #cccbcb 0%, #fefefe 100%); --border-img_6314_038: #d5d4d4; --text-img_6314_038: #9a9999; }
+.btn-img_6314_038 { background-image: var(--gradient-img_6314_038); border:1px solid var(--border-img_6314_038); color:var(--text-img_6314_038); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_038 { background-image: var(--gradient-img_6314_038); border:1px solid var(--border-img_6314_038); color:var(--text-img_6314_038); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_039: linear-gradient(180deg, #d6d3d3 0%, #fefefe 100%); --border-img_6314_039: #d9d9d7; --text-img_6314_039: #85b679; }
+.btn-img_6314_039 { background-image: var(--gradient-img_6314_039); border:1px solid var(--border-img_6314_039); color:var(--text-img_6314_039); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_039 { background-image: var(--gradient-img_6314_039); border:1px solid var(--border-img_6314_039); color:var(--text-img_6314_039); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_040: linear-gradient(180deg, #bbb9b9 0%, #fefefe 100%); --border-img_6314_040: #cecccc; --text-img_6314_040: #5f5f5f; }
+.btn-img_6314_040 { background-image: var(--gradient-img_6314_040); border:1px solid var(--border-img_6314_040); color:var(--text-img_6314_040); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_040 { background-image: var(--gradient-img_6314_040); border:1px solid var(--border-img_6314_040); color:var(--text-img_6314_040); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_041: linear-gradient(180deg, #d4d4d4 0%, #d9d9d9 100%); --border-img_6314_041: #a9a8a8; --text-img_6314_041: #e6e6e6; }
+.btn-img_6314_041 { background-image: var(--gradient-img_6314_041); border:1px solid var(--border-img_6314_041); color:var(--text-img_6314_041); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_041 { background-image: var(--gradient-img_6314_041); border:1px solid var(--border-img_6314_041); color:var(--text-img_6314_041); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_042: linear-gradient(180deg, #c9c9c9 0%, #a4cf98 100%); --border-img_6314_042: #aeb6ac; --text-img_6314_042: #c0c0c0; }
+.btn-img_6314_042 { background-image: var(--gradient-img_6314_042); border:1px solid var(--border-img_6314_042); color:var(--text-img_6314_042); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_042 { background-image: var(--gradient-img_6314_042); border:1px solid var(--border-img_6314_042); color:var(--text-img_6314_042); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_043: linear-gradient(180deg, #95bf8b 0%, #e9e9e9 100%); --border-img_6314_043: #dce0da; --text-img_6314_043: #dddcdb; }
+.btn-img_6314_043 { background-image: var(--gradient-img_6314_043); border:1px solid var(--border-img_6314_043); color:var(--text-img_6314_043); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_043 { background-image: var(--gradient-img_6314_043); border:1px solid var(--border-img_6314_043); color:var(--text-img_6314_043); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_044: linear-gradient(180deg, #c2c1c1 0%, #e9e9e9 100%); --border-img_6314_044: #b9b8b8; --text-img_6314_044: #c2c0c0; }
+.btn-img_6314_044 { background-image: var(--gradient-img_6314_044); border:1px solid var(--border-img_6314_044); color:var(--text-img_6314_044); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_044 { background-image: var(--gradient-img_6314_044); border:1px solid var(--border-img_6314_044); color:var(--text-img_6314_044); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_045: linear-gradient(180deg, #d7d7d7 0%, #949494 100%); --border-img_6314_045: #939b91; --text-img_6314_045: #b3d1ac; }
+.btn-img_6314_045 { background-image: var(--gradient-img_6314_045); border:1px solid var(--border-img_6314_045); color:var(--text-img_6314_045); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_045 { background-image: var(--gradient-img_6314_045); border:1px solid var(--border-img_6314_045); color:var(--text-img_6314_045); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_046: linear-gradient(180deg, #cecccc 0%, #b7cdb1 100%); --border-img_6314_046: #cbd4c8; --text-img_6314_046: #cdcdcd; }
+.btn-img_6314_046 { background-image: var(--gradient-img_6314_046); border:1px solid var(--border-img_6314_046); color:var(--text-img_6314_046); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_046 { background-image: var(--gradient-img_6314_046); border:1px solid var(--border-img_6314_046); color:var(--text-img_6314_046); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_047: linear-gradient(180deg, #d4d1d1 0%, #d7dcd5 100%); --border-img_6314_047: #cad4c6; --text-img_6314_047: #cecece; }
+.btn-img_6314_047 { background-image: var(--gradient-img_6314_047); border:1px solid var(--border-img_6314_047); color:var(--text-img_6314_047); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_047 { background-image: var(--gradient-img_6314_047); border:1px solid var(--border-img_6314_047); color:var(--text-img_6314_047); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_048: linear-gradient(180deg, #dad9d9 0%, #ebebeb 100%); --border-img_6314_048: #bdbcbc; --text-img_6314_048: #eaeaea; }
+.btn-img_6314_048 { background-image: var(--gradient-img_6314_048); border:1px solid var(--border-img_6314_048); color:var(--text-img_6314_048); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_048 { background-image: var(--gradient-img_6314_048); border:1px solid var(--border-img_6314_048); color:var(--text-img_6314_048); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_049: linear-gradient(180deg, #dcdcdc 0%, #c5c5c5 100%); --border-img_6314_049: #a0a79f; --text-img_6314_049: #e9e9e9; }
+.btn-img_6314_049 { background-image: var(--gradient-img_6314_049); border:1px solid var(--border-img_6314_049); color:var(--text-img_6314_049); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_049 { background-image: var(--gradient-img_6314_049); border:1px solid var(--border-img_6314_049); color:var(--text-img_6314_049); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_050: linear-gradient(180deg, #ebebeb 0%, #e6e6e6 100%); --border-img_6314_050: #ccd6ca; --text-img_6314_050: #e7e7e7; }
+.btn-img_6314_050 { background-image: var(--gradient-img_6314_050); border:1px solid var(--border-img_6314_050); color:var(--text-img_6314_050); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_050 { background-image: var(--gradient-img_6314_050); border:1px solid var(--border-img_6314_050); color:var(--text-img_6314_050); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_051: linear-gradient(180deg, #ececec 0%, #67a658 100%); --border-img_6314_051: #cad6c7; --text-img_6314_051: #bebebe; }
+.btn-img_6314_051 { background-image: var(--gradient-img_6314_051); border:1px solid var(--border-img_6314_051); color:var(--text-img_6314_051); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_051 { background-image: var(--gradient-img_6314_051); border:1px solid var(--border-img_6314_051); color:var(--text-img_6314_051); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_052: linear-gradient(180deg, #ebebeb 0%, #e4e3e3 100%); --border-img_6314_052: #e5e5e5; --text-img_6314_052: #cfcece; }
+.btn-img_6314_052 { background-image: var(--gradient-img_6314_052); border:1px solid var(--border-img_6314_052); color:var(--text-img_6314_052); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_052 { background-image: var(--gradient-img_6314_052); border:1px solid var(--border-img_6314_052); color:var(--text-img_6314_052); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_053: linear-gradient(180deg, #e1e1e1 0%, #e3e3e3 100%); --border-img_6314_053: #bfbfbf; --text-img_6314_053: #e9e9e9; }
+.btn-img_6314_053 { background-image: var(--gradient-img_6314_053); border:1px solid var(--border-img_6314_053); color:var(--text-img_6314_053); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_053 { background-image: var(--gradient-img_6314_053); border:1px solid var(--border-img_6314_053); color:var(--text-img_6314_053); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_054: linear-gradient(180deg, #97c08e 0%, #c3e8bb 100%); --border-img_6314_054: #b3c0b0; --text-img_6314_054: #638959; }
+.btn-img_6314_054 { background-image: var(--gradient-img_6314_054); border:1px solid var(--border-img_6314_054); color:var(--text-img_6314_054); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_054 { background-image: var(--gradient-img_6314_054); border:1px solid var(--border-img_6314_054); color:var(--text-img_6314_054); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_055: linear-gradient(180deg, #e6e5e5 0%, #67a658 100%); --border-img_6314_055: #cdd7c9; --text-img_6314_055: #67a658; }
+.btn-img_6314_055 { background-image: var(--gradient-img_6314_055); border:1px solid var(--border-img_6314_055); color:var(--text-img_6314_055); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_055 { background-image: var(--gradient-img_6314_055); border:1px solid var(--border-img_6314_055); color:var(--text-img_6314_055); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_056: linear-gradient(180deg, #e9e8e8 0%, #e7e7e7 100%); --border-img_6314_056: #c2c4c1; --text-img_6314_056: #ececec; }
+.btn-img_6314_056 { background-image: var(--gradient-img_6314_056); border:1px solid var(--border-img_6314_056); color:var(--text-img_6314_056); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_056 { background-image: var(--gradient-img_6314_056); border:1px solid var(--border-img_6314_056); color:var(--text-img_6314_056); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_057: linear-gradient(180deg, #b6b6b5 0%, #cfd9cc 100%); --border-img_6314_057: #9ba798; --text-img_6314_057: #ececec; }
+.btn-img_6314_057 { background-image: var(--gradient-img_6314_057); border:1px solid var(--border-img_6314_057); color:var(--text-img_6314_057); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_057 { background-image: var(--gradient-img_6314_057); border:1px solid var(--border-img_6314_057); color:var(--text-img_6314_057); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_058: linear-gradient(180deg, #e2e2e1 0%, #e1dfdf 100%); --border-img_6314_058: #b6c9b1; --text-img_6314_058: #dedbdb; }
+.btn-img_6314_058 { background-image: var(--gradient-img_6314_058); border:1px solid var(--border-img_6314_058); color:var(--text-img_6314_058); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_058 { background-image: var(--gradient-img_6314_058); border:1px solid var(--border-img_6314_058); color:var(--text-img_6314_058); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_059: linear-gradient(180deg, #67a658 0%, #dad7d7 100%); --border-img_6314_059: #a8c5a0; --text-img_6314_059: #b8cab2; }
+.btn-img_6314_059 { background-image: var(--gradient-img_6314_059); border:1px solid var(--border-img_6314_059); color:var(--text-img_6314_059); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_059 { background-image: var(--gradient-img_6314_059); border:1px solid var(--border-img_6314_059); color:var(--text-img_6314_059); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_060: linear-gradient(180deg, #a7c49f 0%, #dad7d7 100%); --border-img_6314_060: #c8d5c4; --text-img_6314_060: #dcdbda; }
+.btn-img_6314_060 { background-image: var(--gradient-img_6314_060); border:1px solid var(--border-img_6314_060); color:var(--text-img_6314_060); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_060 { background-image: var(--gradient-img_6314_060); border:1px solid var(--border-img_6314_060); color:var(--text-img_6314_060); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_061: linear-gradient(180deg, #e3e3e3 0%, #e4e4e4 100%); --border-img_6314_061: #c1c1c1; --text-img_6314_061: #ececec; }
+.btn-img_6314_061 { background-image: var(--gradient-img_6314_061); border:1px solid var(--border-img_6314_061); color:var(--text-img_6314_061); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_061 { background-image: var(--gradient-img_6314_061); border:1px solid var(--border-img_6314_061); color:var(--text-img_6314_061); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_062: linear-gradient(180deg, #ececec 0%, #ececec 100%); --border-img_6314_062: #a3aaa2; --text-img_6314_062: #cce2c7; }
+.btn-img_6314_062 { background-image: var(--gradient-img_6314_062); border:1px solid var(--border-img_6314_062); color:var(--text-img_6314_062); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_062 { background-image: var(--gradient-img_6314_062); border:1px solid var(--border-img_6314_062); color:var(--text-img_6314_062); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_063: linear-gradient(180deg, #81b275 0%, #f2f2f2 100%); --border-img_6314_063: #d0ddcc; --text-img_6314_063: #d8d6d6; }
+.btn-img_6314_063 { background-image: var(--gradient-img_6314_063); border:1px solid var(--border-img_6314_063); color:var(--text-img_6314_063); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_063 { background-image: var(--gradient-img_6314_063); border:1px solid var(--border-img_6314_063); color:var(--text-img_6314_063); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_064: linear-gradient(180deg, #67a658 0%, #f2f2f2 100%); --border-img_6314_064: #c7d7c3; --text-img_6314_064: #d9d7d7; }
+.btn-img_6314_064 { background-image: var(--gradient-img_6314_064); border:1px solid var(--border-img_6314_064); color:var(--text-img_6314_064); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_064 { background-image: var(--gradient-img_6314_064); border:1px solid var(--border-img_6314_064); color:var(--text-img_6314_064); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_065: linear-gradient(180deg, #ececec 0%, #ececec 100%); --border-img_6314_065: #c2c1c1; --text-img_6314_065: #ededed; }
+.btn-img_6314_065 { background-image: var(--gradient-img_6314_065); border:1px solid var(--border-img_6314_065); color:var(--text-img_6314_065); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_065 { background-image: var(--gradient-img_6314_065); border:1px solid var(--border-img_6314_065); color:var(--text-img_6314_065); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_066: linear-gradient(180deg, #b2dba8 0%, #ededed 100%); --border-img_6314_066: #c0c6bf; --text-img_6314_066: #ededed; }
+.btn-img_6314_066 { background-image: var(--gradient-img_6314_066); border:1px solid var(--border-img_6314_066); color:var(--text-img_6314_066); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_066 { background-image: var(--gradient-img_6314_066); border:1px solid var(--border-img_6314_066); color:var(--text-img_6314_066); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_067: linear-gradient(180deg, #dbd8d8 0%, #f1f1f1 100%); --border-img_6314_067: #e8e8e7; --text-img_6314_067: #f3f3f3; }
+.btn-img_6314_067 { background-image: var(--gradient-img_6314_067); border:1px solid var(--border-img_6314_067); color:var(--text-img_6314_067); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_067 { background-image: var(--gradient-img_6314_067); border:1px solid var(--border-img_6314_067); color:var(--text-img_6314_067); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_068: linear-gradient(180deg, #e7e6e6 0%, #ededed 100%); --border-img_6314_068: #cacaca; --text-img_6314_068: #ededed; }
+.btn-img_6314_068 { background-image: var(--gradient-img_6314_068); border:1px solid var(--border-img_6314_068); color:var(--text-img_6314_068); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_068 { background-image: var(--gradient-img_6314_068); border:1px solid var(--border-img_6314_068); color:var(--text-img_6314_068); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_069: linear-gradient(180deg, #e0e0e0 0%, #e2e2e2 100%); --border-img_6314_069: #c2c2c2; --text-img_6314_069: #ebebeb; }
+.btn-img_6314_069 { background-image: var(--gradient-img_6314_069); border:1px solid var(--border-img_6314_069); color:var(--text-img_6314_069); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_069 { background-image: var(--gradient-img_6314_069); border:1px solid var(--border-img_6314_069); color:var(--text-img_6314_069); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_070: linear-gradient(180deg, #f0f0f0 0%, #b5b5b5 100%); --border-img_6314_070: #e5e5e5; --text-img_6314_070: #efefef; }
+.btn-img_6314_070 { background-image: var(--gradient-img_6314_070); border:1px solid var(--border-img_6314_070); color:var(--text-img_6314_070); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_070 { background-image: var(--gradient-img_6314_070); border:1px solid var(--border-img_6314_070); color:var(--text-img_6314_070); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_071: linear-gradient(180deg, #f3f4f3 0%, #f6f7f6 100%); --border-img_6314_071: #eaeee9; --text-img_6314_071: #f2f2f2; }
+.btn-img_6314_071 { background-image: var(--gradient-img_6314_071); border:1px solid var(--border-img_6314_071); color:var(--text-img_6314_071); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_071 { background-image: var(--gradient-img_6314_071); border:1px solid var(--border-img_6314_071); color:var(--text-img_6314_071); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_072: linear-gradient(180deg, #f0f0f0 0%, #fbfbfb 100%); --border-img_6314_072: #f4f4f4; --text-img_6314_072: #efeff0; }
+.btn-img_6314_072 { background-image: var(--gradient-img_6314_072); border:1px solid var(--border-img_6314_072); color:var(--text-img_6314_072); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_072 { background-image: var(--gradient-img_6314_072); border:1px solid var(--border-img_6314_072); color:var(--text-img_6314_072); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_073: linear-gradient(180deg, #e4e4e4 0%, #e7e8e7 100%); --border-img_6314_073: #c4c4c4; --text-img_6314_073: #ebebeb; }
+.btn-img_6314_073 { background-image: var(--gradient-img_6314_073); border:1px solid var(--border-img_6314_073); color:var(--text-img_6314_073); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_073 { background-image: var(--gradient-img_6314_073); border:1px solid var(--border-img_6314_073); color:var(--text-img_6314_073); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_074: linear-gradient(180deg, #ececec 0%, #e9e9e9 100%); --border-img_6314_074: #c3c3c3; --text-img_6314_074: #f2f2f2; }
+.btn-img_6314_074 { background-image: var(--gradient-img_6314_074); border:1px solid var(--border-img_6314_074); color:var(--text-img_6314_074); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_074 { background-image: var(--gradient-img_6314_074); border:1px solid var(--border-img_6314_074); color:var(--text-img_6314_074); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_075: linear-gradient(180deg, #f0f0f0 0%, #f7f7f7 100%); --border-img_6314_075: #eeeeee; --text-img_6314_075: #f7f7f7; }
+.btn-img_6314_075 { background-image: var(--gradient-img_6314_075); border:1px solid var(--border-img_6314_075); color:var(--text-img_6314_075); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_075 { background-image: var(--gradient-img_6314_075); border:1px solid var(--border-img_6314_075); color:var(--text-img_6314_075); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_076: linear-gradient(180deg, #f0f0f0 0%, #f0f0f0 100%); --border-img_6314_076: #f2f2f2; --text-img_6314_076: #f6f7f6; }
+.btn-img_6314_076 { background-image: var(--gradient-img_6314_076); border:1px solid var(--border-img_6314_076); color:var(--text-img_6314_076); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_076 { background-image: var(--gradient-img_6314_076); border:1px solid var(--border-img_6314_076); color:var(--text-img_6314_076); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_077: linear-gradient(180deg, #ececec 0%, #ececec 100%); --border-img_6314_077: #c7c7c7; --text-img_6314_077: #f1f3f1; }
+.btn-img_6314_077 { background-image: var(--gradient-img_6314_077); border:1px solid var(--border-img_6314_077); color:var(--text-img_6314_077); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_077 { background-image: var(--gradient-img_6314_077); border:1px solid var(--border-img_6314_077); color:var(--text-img_6314_077); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_078: linear-gradient(180deg, #f2f2f2 0%, #f3f3f3 100%); --border-img_6314_078: #c9c9c9; --text-img_6314_078: #f6f6f6; }
+.btn-img_6314_078 { background-image: var(--gradient-img_6314_078); border:1px solid var(--border-img_6314_078); color:var(--text-img_6314_078); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_078 { background-image: var(--gradient-img_6314_078); border:1px solid var(--border-img_6314_078); color:var(--text-img_6314_078); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_079: linear-gradient(180deg, #caddc6 0%, #ecedec 100%); --border-img_6314_079: #f1f2f1; --text-img_6314_079: #f0f1f0; }
+.btn-img_6314_079 { background-image: var(--gradient-img_6314_079); border:1px solid var(--border-img_6314_079); color:var(--text-img_6314_079); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_079 { background-image: var(--gradient-img_6314_079); border:1px solid var(--border-img_6314_079); color:var(--text-img_6314_079); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_080: linear-gradient(180deg, #f6f7f6 0%, #ebebeb 100%); --border-img_6314_080: #d1d1d1; --text-img_6314_080: #f3f3f3; }
+.btn-img_6314_080 { background-image: var(--gradient-img_6314_080); border:1px solid var(--border-img_6314_080); color:var(--text-img_6314_080); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_080 { background-image: var(--gradient-img_6314_080); border:1px solid var(--border-img_6314_080); color:var(--text-img_6314_080); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_081: linear-gradient(180deg, #e2e2e2 0%, #e1e0e0 100%); --border-img_6314_081: #c3c2c2; --text-img_6314_081: #e8e8e8; }
+.btn-img_6314_081 { background-image: var(--gradient-img_6314_081); border:1px solid var(--border-img_6314_081); color:var(--text-img_6314_081); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_081 { background-image: var(--gradient-img_6314_081); border:1px solid var(--border-img_6314_081); color:var(--text-img_6314_081); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_082: linear-gradient(180deg, #f2f3f2 0%, #e9eae9 100%); --border-img_6314_082: #f1f2f1; --text-img_6314_082: #edefed; }
+.btn-img_6314_082 { background-image: var(--gradient-img_6314_082); border:1px solid var(--border-img_6314_082); color:var(--text-img_6314_082); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_082 { background-image: var(--gradient-img_6314_082); border:1px solid var(--border-img_6314_082); color:var(--text-img_6314_082); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_083: linear-gradient(180deg, #f6f6f6 0%, #eaeaea 100%); --border-img_6314_083: #f0f0f0; --text-img_6314_083: #f0f0f0; }
+.btn-img_6314_083 { background-image: var(--gradient-img_6314_083); border:1px solid var(--border-img_6314_083); color:var(--text-img_6314_083); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_083 { background-image: var(--gradient-img_6314_083); border:1px solid var(--border-img_6314_083); color:var(--text-img_6314_083); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_084: linear-gradient(180deg, #e5e6e5 0%, #e0e0e0 100%); --border-img_6314_084: #c2c3c2; --text-img_6314_084: #e6e8e6; }
+.btn-img_6314_084 { background-image: var(--gradient-img_6314_084); border:1px solid var(--border-img_6314_084); color:var(--text-img_6314_084); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_084 { background-image: var(--gradient-img_6314_084); border:1px solid var(--border-img_6314_084); color:var(--text-img_6314_084); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_085: linear-gradient(180deg, #f0f0f0 0%, #f6f6f6 100%); --border-img_6314_085: #cbd2ca; --text-img_6314_085: #c8e3c2; }
+.btn-img_6314_085 { background-image: var(--gradient-img_6314_085); border:1px solid var(--border-img_6314_085); color:var(--text-img_6314_085); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_085 { background-image: var(--gradient-img_6314_085); border:1px solid var(--border-img_6314_085); color:var(--text-img_6314_085); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_086: linear-gradient(180deg, #f7f7f7 0%, #f6f6f6 100%); --border-img_6314_086: #e6eae5; --text-img_6314_086: #b9e6b0; }
+.btn-img_6314_086 { background-image: var(--gradient-img_6314_086); border:1px solid var(--border-img_6314_086); color:var(--text-img_6314_086); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_086 { background-image: var(--gradient-img_6314_086); border:1px solid var(--border-img_6314_086); color:var(--text-img_6314_086); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_087: linear-gradient(180deg, #e9e9e9 0%, #f6f6f6 100%); --border-img_6314_087: #d4d5d5; --text-img_6314_087: #949494; }
+.btn-img_6314_087 { background-image: var(--gradient-img_6314_087); border:1px solid var(--border-img_6314_087); color:var(--text-img_6314_087); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_087 { background-image: var(--gradient-img_6314_087); border:1px solid var(--border-img_6314_087); color:var(--text-img_6314_087); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_088: linear-gradient(180deg, #e7e8e7 0%, #f6f6f6 100%); --border-img_6314_088: #c4c4c4; --text-img_6314_088: #aaaaaa; }
+.btn-img_6314_088 { background-image: var(--gradient-img_6314_088); border:1px solid var(--border-img_6314_088); color:var(--text-img_6314_088); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_088 { background-image: var(--gradient-img_6314_088); border:1px solid var(--border-img_6314_088); color:var(--text-img_6314_088); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_089: linear-gradient(180deg, #f4f4f4 0%, #f6f6f6 100%); --border-img_6314_089: #d2d6d1; --text-img_6314_089: #ade9a0; }
+.btn-img_6314_089 { background-image: var(--gradient-img_6314_089); border:1px solid var(--border-img_6314_089); color:var(--text-img_6314_089); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_089 { background-image: var(--gradient-img_6314_089); border:1px solid var(--border-img_6314_089); color:var(--text-img_6314_089); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_090: linear-gradient(180deg, #e9e9e9 0%, #f6f6f6 100%); --border-img_6314_090: #dee4dc; --text-img_6314_090: #919191; }
+.btn-img_6314_090 { background-image: var(--gradient-img_6314_090); border:1px solid var(--border-img_6314_090); color:var(--text-img_6314_090); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_090 { background-image: var(--gradient-img_6314_090); border:1px solid var(--border-img_6314_090); color:var(--text-img_6314_090); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_091: linear-gradient(180deg, #e6e6e6 0%, #f6f6f6 100%); --border-img_6314_091: #cacbcc; --text-img_6314_091: #7b7b7b; }
+.btn-img_6314_091 { background-image: var(--gradient-img_6314_091); border:1px solid var(--border-img_6314_091); color:var(--text-img_6314_091); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_091 { background-image: var(--gradient-img_6314_091); border:1px solid var(--border-img_6314_091); color:var(--text-img_6314_091); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_092: linear-gradient(180deg, #cfcfcf 0%, #f6f7f7 100%); --border-img_6314_092: #c9d2c8; --text-img_6314_092: #e5e5e5; }
+.btn-img_6314_092 { background-image: var(--gradient-img_6314_092); border:1px solid var(--border-img_6314_092); color:var(--text-img_6314_092); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_092 { background-image: var(--gradient-img_6314_092); border:1px solid var(--border-img_6314_092); color:var(--text-img_6314_092); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_093: linear-gradient(180deg, #c0c0c0 0%, #f6f6f6 100%); --border-img_6314_093: #e0f0dd; --text-img_6314_093: #687e63; }
+.btn-img_6314_093 { background-image: var(--gradient-img_6314_093); border:1px solid var(--border-img_6314_093); color:var(--text-img_6314_093); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_093 { background-image: var(--gradient-img_6314_093); border:1px solid var(--border-img_6314_093); color:var(--text-img_6314_093); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_094: linear-gradient(180deg, #e9e9e9 0%, #f6f6f6 100%); --border-img_6314_094: #d5ded4; --text-img_6314_094: #797979; }
+.btn-img_6314_094 { background-image: var(--gradient-img_6314_094); border:1px solid var(--border-img_6314_094); color:var(--text-img_6314_094); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_094 { background-image: var(--gradient-img_6314_094); border:1px solid var(--border-img_6314_094); color:var(--text-img_6314_094); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_095: linear-gradient(180deg, #e9e8e9 0%, #f6f6f6 100%); --border-img_6314_095: #cbccce; --text-img_6314_095: #7a7a7a; }
+.btn-img_6314_095 { background-image: var(--gradient-img_6314_095); border:1px solid var(--border-img_6314_095); color:var(--text-img_6314_095); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_095 { background-image: var(--gradient-img_6314_095); border:1px solid var(--border-img_6314_095); color:var(--text-img_6314_095); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6314_096: linear-gradient(180deg, #dfdfdf 0%, #f6f6f6 100%); --border-img_6314_096: #bdbfc1; --text-img_6314_096: #deddde; }
+.btn-img_6314_096 { background-image: var(--gradient-img_6314_096); border:1px solid var(--border-img_6314_096); color:var(--text-img_6314_096); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6314_096 { background-image: var(--gradient-img_6314_096); border:1px solid var(--border-img_6314_096); color:var(--text-img_6314_096); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_097: linear-gradient(180deg, #5e6367 0%, #9d9d9d 100%); --border-img_6318_097: #6e7072; --text-img_6318_097: #45494c; }
+.btn-img_6318_097 { background-image: var(--gradient-img_6318_097); border:1px solid var(--border-img_6318_097); color:var(--text-img_6318_097); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_097 { background-image: var(--gradient-img_6318_097); border:1px solid var(--border-img_6318_097); color:var(--text-img_6318_097); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_098: linear-gradient(180deg, #5e6367 0%, #2e2e2e 100%); --border-img_6318_098: #444748; --text-img_6318_098: #45494c; }
+.btn-img_6318_098 { background-image: var(--gradient-img_6318_098); border:1px solid var(--border-img_6318_098); color:var(--text-img_6318_098); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_098 { background-image: var(--gradient-img_6318_098); border:1px solid var(--border-img_6318_098); color:var(--text-img_6318_098); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_099: linear-gradient(180deg, #5e6367 0%, #2e2e2e 100%); --border-img_6318_099: #46484a; --text-img_6318_099: #45494c; }
+.btn-img_6318_099 { background-image: var(--gradient-img_6318_099); border:1px solid var(--border-img_6318_099); color:var(--text-img_6318_099); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_099 { background-image: var(--gradient-img_6318_099); border:1px solid var(--border-img_6318_099); color:var(--text-img_6318_099); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_100: linear-gradient(180deg, #5e6367 0%, #2e2e2e 100%); --border-img_6318_100: #424547; --text-img_6318_100: #45494c; }
+.btn-img_6318_100 { background-image: var(--gradient-img_6318_100); border:1px solid var(--border-img_6318_100); color:var(--text-img_6318_100); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_100 { background-image: var(--gradient-img_6318_100); border:1px solid var(--border-img_6318_100); color:var(--text-img_6318_100); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_101: linear-gradient(180deg, #5e6367 0%, #2e2e2e 100%); --border-img_6318_101: #434647; --text-img_6318_101: #45494c; }
+.btn-img_6318_101 { background-image: var(--gradient-img_6318_101); border:1px solid var(--border-img_6318_101); color:var(--text-img_6318_101); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_101 { background-image: var(--gradient-img_6318_101); border:1px solid var(--border-img_6318_101); color:var(--text-img_6318_101); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_102: linear-gradient(180deg, #5e6367 0%, #747474 100%); --border-img_6318_102: #696c6d; --text-img_6318_102: #36383a; }
+.btn-img_6318_102 { background-image: var(--gradient-img_6318_102); border:1px solid var(--border-img_6318_102); color:var(--text-img_6318_102); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_102 { background-image: var(--gradient-img_6318_102); border:1px solid var(--border-img_6318_102); color:var(--text-img_6318_102); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_103: linear-gradient(180deg, #5e6367 0%, #2c2c2c 100%); --border-img_6318_103: #454749; --text-img_6318_103: #36383a; }
+.btn-img_6318_103 { background-image: var(--gradient-img_6318_103); border:1px solid var(--border-img_6318_103); color:var(--text-img_6318_103); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_103 { background-image: var(--gradient-img_6318_103); border:1px solid var(--border-img_6318_103); color:var(--text-img_6318_103); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_104: linear-gradient(180deg, #5e6367 0%, #2c2c2c 100%); --border-img_6318_104: #454749; --text-img_6318_104: #36383a; }
+.btn-img_6318_104 { background-image: var(--gradient-img_6318_104); border:1px solid var(--border-img_6318_104); color:var(--text-img_6318_104); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_104 { background-image: var(--gradient-img_6318_104); border:1px solid var(--border-img_6318_104); color:var(--text-img_6318_104); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_105: linear-gradient(180deg, #5e6367 0%, #454545 100%); --border-img_6318_105: #545658; --text-img_6318_105: #313232; }
+.btn-img_6318_105 { background-image: var(--gradient-img_6318_105); border:1px solid var(--border-img_6318_105); color:var(--text-img_6318_105); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_105 { background-image: var(--gradient-img_6318_105); border:1px solid var(--border-img_6318_105); color:var(--text-img_6318_105); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_106: linear-gradient(180deg, #5e6367 0%, #292929 100%); --border-img_6318_106: #434547; --text-img_6318_106: #313232; }
+.btn-img_6318_106 { background-image: var(--gradient-img_6318_106); border:1px solid var(--border-img_6318_106); color:var(--text-img_6318_106); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_106 { background-image: var(--gradient-img_6318_106); border:1px solid var(--border-img_6318_106); color:var(--text-img_6318_106); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_107: linear-gradient(180deg, #5e6367 0%, #292929 100%); --border-img_6318_107: #444748; --text-img_6318_107: #313232; }
+.btn-img_6318_107 { background-image: var(--gradient-img_6318_107); border:1px solid var(--border-img_6318_107); color:var(--text-img_6318_107); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_107 { background-image: var(--gradient-img_6318_107); border:1px solid var(--border-img_6318_107); color:var(--text-img_6318_107); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_108: linear-gradient(180deg, #5e6367 0%, #292929 100%); --border-img_6318_108: #434547; --text-img_6318_108: #313232; }
+.btn-img_6318_108 { background-image: var(--gradient-img_6318_108); border:1px solid var(--border-img_6318_108); color:var(--text-img_6318_108); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_108 { background-image: var(--gradient-img_6318_108); border:1px solid var(--border-img_6318_108); color:var(--text-img_6318_108); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_109: linear-gradient(180deg, #282828 0%, #414141 100%); --border-img_6318_109: #414141; --text-img_6318_109: #292929; }
+.btn-img_6318_109 { background-image: var(--gradient-img_6318_109); border:1px solid var(--border-img_6318_109); color:var(--text-img_6318_109); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_109 { background-image: var(--gradient-img_6318_109); border:1px solid var(--border-img_6318_109); color:var(--text-img_6318_109); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_110: linear-gradient(180deg, #282828 0%, #414141 100%); --border-img_6318_110: #333333; --text-img_6318_110: #292929; }
+.btn-img_6318_110 { background-image: var(--gradient-img_6318_110); border:1px solid var(--border-img_6318_110); color:var(--text-img_6318_110); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_110 { background-image: var(--gradient-img_6318_110); border:1px solid var(--border-img_6318_110); color:var(--text-img_6318_110); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_111: linear-gradient(180deg, #282828 0%, #414141 100%); --border-img_6318_111: #333333; --text-img_6318_111: #292929; }
+.btn-img_6318_111 { background-image: var(--gradient-img_6318_111); border:1px solid var(--border-img_6318_111); color:var(--text-img_6318_111); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_111 { background-image: var(--gradient-img_6318_111); border:1px solid var(--border-img_6318_111); color:var(--text-img_6318_111); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_112: linear-gradient(180deg, #282828 0%, #414141 100%); --border-img_6318_112: #333333; --text-img_6318_112: #292929; }
+.btn-img_6318_112 { background-image: var(--gradient-img_6318_112); border:1px solid var(--border-img_6318_112); color:var(--text-img_6318_112); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_112 { background-image: var(--gradient-img_6318_112); border:1px solid var(--border-img_6318_112); color:var(--text-img_6318_112); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_113: linear-gradient(180deg, #282828 0%, #414141 100%); --border-img_6318_113: #333333; --text-img_6318_113: #292929; }
+.btn-img_6318_113 { background-image: var(--gradient-img_6318_113); border:1px solid var(--border-img_6318_113); color:var(--text-img_6318_113); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_113 { background-image: var(--gradient-img_6318_113); border:1px solid var(--border-img_6318_113); color:var(--text-img_6318_113); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_114: linear-gradient(180deg, #262626 0%, #414141 100%); --border-img_6318_114: #353535; --text-img_6318_114: #414141; }
+.btn-img_6318_114 { background-image: var(--gradient-img_6318_114); border:1px solid var(--border-img_6318_114); color:var(--text-img_6318_114); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_114 { background-image: var(--gradient-img_6318_114); border:1px solid var(--border-img_6318_114); color:var(--text-img_6318_114); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_115: linear-gradient(180deg, #262626 0%, #414141 100%); --border-img_6318_115: #353535; --text-img_6318_115: #414141; }
+.btn-img_6318_115 { background-image: var(--gradient-img_6318_115); border:1px solid var(--border-img_6318_115); color:var(--text-img_6318_115); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_115 { background-image: var(--gradient-img_6318_115); border:1px solid var(--border-img_6318_115); color:var(--text-img_6318_115); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_116: linear-gradient(180deg, #262626 0%, #414141 100%); --border-img_6318_116: #353535; --text-img_6318_116: #414141; }
+.btn-img_6318_116 { background-image: var(--gradient-img_6318_116); border:1px solid var(--border-img_6318_116); color:var(--text-img_6318_116); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_116 { background-image: var(--gradient-img_6318_116); border:1px solid var(--border-img_6318_116); color:var(--text-img_6318_116); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_117: linear-gradient(180deg, #222222 0%, #414141 100%); --border-img_6318_117: #393b39; --text-img_6318_117: #414141; }
+.btn-img_6318_117 { background-image: var(--gradient-img_6318_117); border:1px solid var(--border-img_6318_117); color:var(--text-img_6318_117); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_117 { background-image: var(--gradient-img_6318_117); border:1px solid var(--border-img_6318_117); color:var(--text-img_6318_117); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_118: linear-gradient(180deg, #222222 0%, #414141 100%); --border-img_6318_118: #393b39; --text-img_6318_118: #414141; }
+.btn-img_6318_118 { background-image: var(--gradient-img_6318_118); border:1px solid var(--border-img_6318_118); color:var(--text-img_6318_118); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_118 { background-image: var(--gradient-img_6318_118); border:1px solid var(--border-img_6318_118); color:var(--text-img_6318_118); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_119: linear-gradient(180deg, #222222 0%, #414141 100%); --border-img_6318_119: #393b39; --text-img_6318_119: #414141; }
+.btn-img_6318_119 { background-image: var(--gradient-img_6318_119); border:1px solid var(--border-img_6318_119); color:var(--text-img_6318_119); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_119 { background-image: var(--gradient-img_6318_119); border:1px solid var(--border-img_6318_119); color:var(--text-img_6318_119); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_120: linear-gradient(180deg, #222222 0%, #414141 100%); --border-img_6318_120: #393b39; --text-img_6318_120: #414141; }
+.btn-img_6318_120 { background-image: var(--gradient-img_6318_120); border:1px solid var(--border-img_6318_120); color:var(--text-img_6318_120); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_120 { background-image: var(--gradient-img_6318_120); border:1px solid var(--border-img_6318_120); color:var(--text-img_6318_120); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_121: linear-gradient(180deg, #414141 0%, #a6e398 100%); --border-img_6318_121: #76956f; --text-img_6318_121: #84ad7c; }
+.btn-img_6318_121 { background-image: var(--gradient-img_6318_121); border:1px solid var(--border-img_6318_121); color:var(--text-img_6318_121); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_121 { background-image: var(--gradient-img_6318_121); border:1px solid var(--border-img_6318_121); color:var(--text-img_6318_121); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_122: linear-gradient(180deg, #414141 0%, #a6e398 100%); --border-img_6318_122: #76956f; --text-img_6318_122: #84ad7c; }
+.btn-img_6318_122 { background-image: var(--gradient-img_6318_122); border:1px solid var(--border-img_6318_122); color:var(--text-img_6318_122); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_122 { background-image: var(--gradient-img_6318_122); border:1px solid var(--border-img_6318_122); color:var(--text-img_6318_122); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_123: linear-gradient(180deg, #414141 0%, #a6e398 100%); --border-img_6318_123: #76956f; --text-img_6318_123: #84ad7c; }
+.btn-img_6318_123 { background-image: var(--gradient-img_6318_123); border:1px solid var(--border-img_6318_123); color:var(--text-img_6318_123); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_123 { background-image: var(--gradient-img_6318_123); border:1px solid var(--border-img_6318_123); color:var(--text-img_6318_123); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_124: linear-gradient(180deg, #414141 0%, #a6e398 100%); --border-img_6318_124: #76956f; --text-img_6318_124: #84ad7c; }
+.btn-img_6318_124 { background-image: var(--gradient-img_6318_124); border:1px solid var(--border-img_6318_124); color:var(--text-img_6318_124); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_124 { background-image: var(--gradient-img_6318_124); border:1px solid var(--border-img_6318_124); color:var(--text-img_6318_124); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_125: linear-gradient(180deg, #414141 0%, #a6e398 100%); --border-img_6318_125: #75946e; --text-img_6318_125: #84ad7c; }
+.btn-img_6318_125 { background-image: var(--gradient-img_6318_125); border:1px solid var(--border-img_6318_125); color:var(--text-img_6318_125); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_125 { background-image: var(--gradient-img_6318_125); border:1px solid var(--border-img_6318_125); color:var(--text-img_6318_125); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_126: linear-gradient(180deg, #414141 0%, #484d46 100%); --border-img_6318_126: #6f8c68; --text-img_6318_126: #a7e49a; }
+.btn-img_6318_126 { background-image: var(--gradient-img_6318_126); border:1px solid var(--border-img_6318_126); color:var(--text-img_6318_126); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_126 { background-image: var(--gradient-img_6318_126); border:1px solid var(--border-img_6318_126); color:var(--text-img_6318_126); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_127: linear-gradient(180deg, #414141 0%, #789771 100%); --border-img_6318_127: #73916d; --text-img_6318_127: #a7e49a; }
+.btn-img_6318_127 { background-image: var(--gradient-img_6318_127); border:1px solid var(--border-img_6318_127); color:var(--text-img_6318_127); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_127 { background-image: var(--gradient-img_6318_127); border:1px solid var(--border-img_6318_127); color:var(--text-img_6318_127); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_128: linear-gradient(180deg, #414141 0%, #7d9f74 100%); --border-img_6318_128: #779970; --text-img_6318_128: #a7e49a; }
+.btn-img_6318_128 { background-image: var(--gradient-img_6318_128); border:1px solid var(--border-img_6318_128); color:var(--text-img_6318_128); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_128 { background-image: var(--gradient-img_6318_128); border:1px solid var(--border-img_6318_128); color:var(--text-img_6318_128); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_129: linear-gradient(180deg, #a8e59b 0%, #8fd07f 100%); --border-img_6318_129: #96d188; --text-img_6318_129: #4a5148; }
+.btn-img_6318_129 { background-image: var(--gradient-img_6318_129); border:1px solid var(--border-img_6318_129); color:var(--text-img_6318_129); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_129 { background-image: var(--gradient-img_6318_129); border:1px solid var(--border-img_6318_129); color:var(--text-img_6318_129); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_130: linear-gradient(180deg, #a8e59b 0%, #8fd07f 100%); --border-img_6318_130: #96d089; --text-img_6318_130: #85ae7b; }
+.btn-img_6318_130 { background-image: var(--gradient-img_6318_130); border:1px solid var(--border-img_6318_130); color:var(--text-img_6318_130); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_130 { background-image: var(--gradient-img_6318_130); border:1px solid var(--border-img_6318_130); color:var(--text-img_6318_130); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_131: linear-gradient(180deg, #a8e59b 0%, #8fd07f 100%); --border-img_6318_131: #95cf88; --text-img_6318_131: #7da074; }
+.btn-img_6318_131 { background-image: var(--gradient-img_6318_131); border:1px solid var(--border-img_6318_131); color:var(--text-img_6318_131); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_131 { background-image: var(--gradient-img_6318_131); border:1px solid var(--border-img_6318_131); color:var(--text-img_6318_131); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_132: linear-gradient(180deg, #a8e59b 0%, #8fd07f 100%); --border-img_6318_132: #99d58b; --text-img_6318_132: #7ea276; }
+.btn-img_6318_132 { background-image: var(--gradient-img_6318_132); border:1px solid var(--border-img_6318_132); color:var(--text-img_6318_132); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_132 { background-image: var(--gradient-img_6318_132); border:1px solid var(--border-img_6318_132); color:var(--text-img_6318_132); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_133: linear-gradient(180deg, #81ab76 0%, #7ab16e 100%); --border-img_6318_133: #709367; --text-img_6318_133: #94d484; }
+.btn-img_6318_133 { background-image: var(--gradient-img_6318_133); border:1px solid var(--border-img_6318_133); color:var(--text-img_6318_133); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_133 { background-image: var(--gradient-img_6318_133); border:1px solid var(--border-img_6318_133); color:var(--text-img_6318_133); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_134: linear-gradient(180deg, #99d28b 0%, #7ab16e 100%); --border-img_6318_134: #769c6d; --text-img_6318_134: #94d484; }
+.btn-img_6318_134 { background-image: var(--gradient-img_6318_134); border:1px solid var(--border-img_6318_134); color:var(--text-img_6318_134); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_134 { background-image: var(--gradient-img_6318_134); border:1px solid var(--border-img_6318_134); color:var(--text-img_6318_134); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_135: linear-gradient(180deg, #748f6e 0%, #7ab16e 100%); --border-img_6318_135: #779e6e; --text-img_6318_135: #94d484; }
+.btn-img_6318_135 { background-image: var(--gradient-img_6318_135); border:1px solid var(--border-img_6318_135); color:var(--text-img_6318_135); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_135 { background-image: var(--gradient-img_6318_135); border:1px solid var(--border-img_6318_135); color:var(--text-img_6318_135); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_136: linear-gradient(180deg, #76916f 0%, #7ab16e 100%); --border-img_6318_136: #72946a; --text-img_6318_136: #94d484; }
+.btn-img_6318_136 { background-image: var(--gradient-img_6318_136); border:1px solid var(--border-img_6318_136); color:var(--text-img_6318_136); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_136 { background-image: var(--gradient-img_6318_136); border:1px solid var(--border-img_6318_136); color:var(--text-img_6318_136); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_137: linear-gradient(180deg, #8ebd82 0%, #7ab16e 100%); --border-img_6318_137: #789e6e; --text-img_6318_137: #94d484; }
+.btn-img_6318_137 { background-image: var(--gradient-img_6318_137); border:1px solid var(--border-img_6318_137); color:var(--text-img_6318_137); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_137 { background-image: var(--gradient-img_6318_137); border:1px solid var(--border-img_6318_137); color:var(--text-img_6318_137); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_138: linear-gradient(180deg, #93d383 0%, #404040 100%); --border-img_6318_138: #63855b; --text-img_6318_138: #474e46; }
+.btn-img_6318_138 { background-image: var(--gradient-img_6318_138); border:1px solid var(--border-img_6318_138); color:var(--text-img_6318_138); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_138 { background-image: var(--gradient-img_6318_138); border:1px solid var(--border-img_6318_138); color:var(--text-img_6318_138); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_139: linear-gradient(180deg, #93d383 0%, #404040 100%); --border-img_6318_139: #6e8c66; --text-img_6318_139: #474e46; }
+.btn-img_6318_139 { background-image: var(--gradient-img_6318_139); border:1px solid var(--border-img_6318_139); color:var(--text-img_6318_139); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_139 { background-image: var(--gradient-img_6318_139); border:1px solid var(--border-img_6318_139); color:var(--text-img_6318_139); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_140: linear-gradient(180deg, #93d383 0%, #404040 100%); --border-img_6318_140: #6b8963; --text-img_6318_140: #474e46; }
+.btn-img_6318_140 { background-image: var(--gradient-img_6318_140); border:1px solid var(--border-img_6318_140); color:var(--text-img_6318_140); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_140 { background-image: var(--gradient-img_6318_140); border:1px solid var(--border-img_6318_140); color:var(--text-img_6318_140); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_141: linear-gradient(180deg, #404040 0%, #7daa71 100%); --border-img_6318_141: #5b6a57; --text-img_6318_141: #569348; }
+.btn-img_6318_141 { background-image: var(--gradient-img_6318_141); border:1px solid var(--border-img_6318_141); color:var(--text-img_6318_141); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_141 { background-image: var(--gradient-img_6318_141); border:1px solid var(--border-img_6318_141); color:var(--text-img_6318_141); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_142: linear-gradient(180deg, #404040 0%, #4d6448 100%); --border-img_6318_142: #496343; --text-img_6318_142: #3f413e; }
+.btn-img_6318_142 { background-image: var(--gradient-img_6318_142); border:1px solid var(--border-img_6318_142); color:var(--text-img_6318_142); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_142 { background-image: var(--gradient-img_6318_142); border:1px solid var(--border-img_6318_142); color:var(--text-img_6318_142); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_143: linear-gradient(180deg, #404040 0%, #8dab86 100%); --border-img_6318_143: #5e7159; --text-img_6318_143: #5b8152; }
+.btn-img_6318_143 { background-image: var(--gradient-img_6318_143); border:1px solid var(--border-img_6318_143); color:var(--text-img_6318_143); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_143 { background-image: var(--gradient-img_6318_143); border:1px solid var(--border-img_6318_143); color:var(--text-img_6318_143); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_144: linear-gradient(180deg, #404040 0%, #4e7644 100%); --border-img_6318_144: #566053; --text-img_6318_144: #537a49; }
+.btn-img_6318_144 { background-image: var(--gradient-img_6318_144); border:1px solid var(--border-img_6318_144); color:var(--text-img_6318_144); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_144 { background-image: var(--gradient-img_6318_144); border:1px solid var(--border-img_6318_144); color:var(--text-img_6318_144); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_145: linear-gradient(180deg, #404040 0%, #569647 100%); --border-img_6318_145: #4b6145; --text-img_6318_145: #5c9c4d; }
+.btn-img_6318_145 { background-image: var(--gradient-img_6318_145); border:1px solid var(--border-img_6318_145); color:var(--text-img_6318_145); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_145 { background-image: var(--gradient-img_6318_145); border:1px solid var(--border-img_6318_145); color:var(--text-img_6318_145); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_146: linear-gradient(180deg, #404040 0%, #569647 100%); --border-img_6318_146: #485e42; --text-img_6318_146: #5c9c4d; }
+.btn-img_6318_146 { background-image: var(--gradient-img_6318_146); border:1px solid var(--border-img_6318_146); color:var(--text-img_6318_146); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_146 { background-image: var(--gradient-img_6318_146); border:1px solid var(--border-img_6318_146); color:var(--text-img_6318_146); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_147: linear-gradient(180deg, #404040 0%, #4a793d 100%); --border-img_6318_147: #495945; --text-img_6318_147: #537c49; }
+.btn-img_6318_147 { background-image: var(--gradient-img_6318_147); border:1px solid var(--border-img_6318_147); color:var(--text-img_6318_147); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_147 { background-image: var(--gradient-img_6318_147); border:1px solid var(--border-img_6318_147); color:var(--text-img_6318_147); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_148: linear-gradient(180deg, #404040 0%, #4f7d43 100%); --border-img_6318_148: #465642; --text-img_6318_148: #547c49; }
+.btn-img_6318_148 { background-image: var(--gradient-img_6318_148); border:1px solid var(--border-img_6318_148); color:var(--text-img_6318_148); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_148 { background-image: var(--gradient-img_6318_148); border:1px solid var(--border-img_6318_148); color:var(--text-img_6318_148); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_149: linear-gradient(180deg, #404040 0%, #4a793d 100%); --border-img_6318_149: #485843; --text-img_6318_149: #4e7843; }
+.btn-img_6318_149 { background-image: var(--gradient-img_6318_149); border:1px solid var(--border-img_6318_149); color:var(--text-img_6318_149); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_149 { background-image: var(--gradient-img_6318_149); border:1px solid var(--border-img_6318_149); color:var(--text-img_6318_149); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_150: linear-gradient(180deg, #5b9c4c 0%, #468237 100%); --border-img_6318_150: #4e7e42; --text-img_6318_150: #eae8e7; }
+.btn-img_6318_150 { background-image: var(--gradient-img_6318_150); border:1px solid var(--border-img_6318_150); color:var(--text-img_6318_150); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_150 { background-image: var(--gradient-img_6318_150); border:1px solid var(--border-img_6318_150); color:var(--text-img_6318_150); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_151: linear-gradient(180deg, #4e7643 0%, #558548 100%); --border-img_6318_151: #55714e; --text-img_6318_151: #89a981; }
+.btn-img_6318_151 { background-image: var(--gradient-img_6318_151); border:1px solid var(--border-img_6318_151); color:var(--text-img_6318_151); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_151 { background-image: var(--gradient-img_6318_151); border:1px solid var(--border-img_6318_151); color:var(--text-img_6318_151); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_152: linear-gradient(180deg, #4c6246 0%, #4f6a49 100%); --border-img_6318_152: #5f8356; --text-img_6318_152: #51694b; }
+.btn-img_6318_152 { background-image: var(--gradient-img_6318_152); border:1px solid var(--border-img_6318_152); color:var(--text-img_6318_152); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_152 { background-image: var(--gradient-img_6318_152); border:1px solid var(--border-img_6318_152); color:var(--text-img_6318_152); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_153: linear-gradient(180deg, #aac2a1 0%, #403f3f 100%); --border-img_6318_153: #626f5d; --text-img_6318_153: #458136; }
+.btn-img_6318_153 { background-image: var(--gradient-img_6318_153); border:1px solid var(--border-img_6318_153); color:var(--text-img_6318_153); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_153 { background-image: var(--gradient-img_6318_153); border:1px solid var(--border-img_6318_153); color:var(--text-img_6318_153); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_154: linear-gradient(180deg, #a3be9a 0%, #403f3f 100%); --border-img_6318_154: #616e5c; --text-img_6318_154: #458136; }
+.btn-img_6318_154 { background-image: var(--gradient-img_6318_154); border:1px solid var(--border-img_6318_154); color:var(--text-img_6318_154); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_154 { background-image: var(--gradient-img_6318_154); border:1px solid var(--border-img_6318_154); color:var(--text-img_6318_154); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_155: linear-gradient(180deg, #b8cbb4 0%, #403f3f 100%); --border-img_6318_155: #6a7667; --text-img_6318_155: #508842; }
+.btn-img_6318_155 { background-image: var(--gradient-img_6318_155); border:1px solid var(--border-img_6318_155); color:var(--text-img_6318_155); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_155 { background-image: var(--gradient-img_6318_155); border:1px solid var(--border-img_6318_155); color:var(--text-img_6318_155); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_156: linear-gradient(180deg, #a2bb9b 0%, #403f3f 100%); --border-img_6318_156: #667262; --text-img_6318_156: #508842; }
+.btn-img_6318_156 { background-image: var(--gradient-img_6318_156); border:1px solid var(--border-img_6318_156); color:var(--text-img_6318_156); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_156 { background-image: var(--gradient-img_6318_156); border:1px solid var(--border-img_6318_156); color:var(--text-img_6318_156); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_157: linear-gradient(180deg, #b6c9b1 0%, #403f3f 100%); --border-img_6318_157: #697565; --text-img_6318_157: #508842; }
+.btn-img_6318_157 { background-image: var(--gradient-img_6318_157); border:1px solid var(--border-img_6318_157); color:var(--text-img_6318_157); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_157 { background-image: var(--gradient-img_6318_157); border:1px solid var(--border-img_6318_157); color:var(--text-img_6318_157); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_158: linear-gradient(180deg, #4a863a 0%, #436b38 100%); --border-img_6318_158: #5d7257; --text-img_6318_158: #3b5634; }
+.btn-img_6318_158 { background-image: var(--gradient-img_6318_158); border:1px solid var(--border-img_6318_158); color:var(--text-img_6318_158); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_158 { background-image: var(--gradient-img_6318_158); border:1px solid var(--border-img_6318_158); color:var(--text-img_6318_158); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_159: linear-gradient(180deg, #4a6045 0%, #44593f 100%); --border-img_6318_159: #506f47; --text-img_6318_159: #403f3f; }
+.btn-img_6318_159 { background-image: var(--gradient-img_6318_159); border:1px solid var(--border-img_6318_159); color:var(--text-img_6318_159); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_159 { background-image: var(--gradient-img_6318_159); border:1px solid var(--border-img_6318_159); color:var(--text-img_6318_159); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_160: linear-gradient(180deg, #4f8441 0%, #436b38 100%); --border-img_6318_160: #6f8d67; --text-img_6318_160: #5e7858; }
+.btn-img_6318_160 { background-image: var(--gradient-img_6318_160); border:1px solid var(--border-img_6318_160); color:var(--text-img_6318_160); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_160 { background-image: var(--gradient-img_6318_160); border:1px solid var(--border-img_6318_160); color:var(--text-img_6318_160); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_161: linear-gradient(180deg, #517d46 0%, #4a6942 100%); --border-img_6318_161: #5c6d57; --text-img_6318_161: #56704f; }
+.btn-img_6318_161 { background-image: var(--gradient-img_6318_161); border:1px solid var(--border-img_6318_161); color:var(--text-img_6318_161); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_161 { background-image: var(--gradient-img_6318_161); border:1px solid var(--border-img_6318_161); color:var(--text-img_6318_161); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_162: linear-gradient(180deg, #40403f 0%, #3f6335 100%); --border-img_6318_162: #486540; --text-img_6318_162: #426838; }
+.btn-img_6318_162 { background-image: var(--gradient-img_6318_162); border:1px solid var(--border-img_6318_162); color:var(--text-img_6318_162); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_162 { background-image: var(--gradient-img_6318_162); border:1px solid var(--border-img_6318_162); color:var(--text-img_6318_162); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_163: linear-gradient(180deg, #a8b0a6 0%, #42653a 100%); --border-img_6318_163: #4f6a48; --text-img_6318_163: #4f7c43; }
+.btn-img_6318_163 { background-image: var(--gradient-img_6318_163); border:1px solid var(--border-img_6318_163); color:var(--text-img_6318_163); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_163 { background-image: var(--gradient-img_6318_163); border:1px solid var(--border-img_6318_163); color:var(--text-img_6318_163); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_164: linear-gradient(180deg, #5c6459 0%, #475a42 100%); --border-img_6318_164: #506c49; --text-img_6318_164: #545d51; }
+.btn-img_6318_164 { background-image: var(--gradient-img_6318_164); border:1px solid var(--border-img_6318_164); color:var(--text-img_6318_164); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_164 { background-image: var(--gradient-img_6318_164); border:1px solid var(--border-img_6318_164); color:var(--text-img_6318_164); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_165: linear-gradient(180deg, #436b39 0%, #97a693 100%); --border-img_6318_165: #646f61; --text-img_6318_165: #406536; }
+.btn-img_6318_165 { background-image: var(--gradient-img_6318_165); border:1px solid var(--border-img_6318_165); color:var(--text-img_6318_165); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_165 { background-image: var(--gradient-img_6318_165); border:1px solid var(--border-img_6318_165); color:var(--text-img_6318_165); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_166: linear-gradient(180deg, #446d39 0%, #9caa98 100%); --border-img_6318_166: #616d5e; --text-img_6318_166: #406536; }
+.btn-img_6318_166 { background-image: var(--gradient-img_6318_166); border:1px solid var(--border-img_6318_166); color:var(--text-img_6318_166); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_166 { background-image: var(--gradient-img_6318_166); border:1px solid var(--border-img_6318_166); color:var(--text-img_6318_166); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_167: linear-gradient(180deg, #46703b 0%, #9ec694 100%); --border-img_6318_167: #6f8d67; --text-img_6318_167: #406536; }
+.btn-img_6318_167 { background-image: var(--gradient-img_6318_167); border:1px solid var(--border-img_6318_167); color:var(--text-img_6318_167); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_167 { background-image: var(--gradient-img_6318_167); border:1px solid var(--border-img_6318_167); color:var(--text-img_6318_167); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_168: linear-gradient(180deg, #4c7641 0%, #88b07e 100%); --border-img_6318_168: #65805e; --text-img_6318_168: #406536; }
+.btn-img_6318_168 { background-image: var(--gradient-img_6318_168); border:1px solid var(--border-img_6318_168); color:var(--text-img_6318_168); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_168 { background-image: var(--gradient-img_6318_168); border:1px solid var(--border-img_6318_168); color:var(--text-img_6318_168); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_169: linear-gradient(180deg, #48703e 0%, #acb6a7 100%); --border-img_6318_169: #7d847a; --text-img_6318_169: #406536; }
+.btn-img_6318_169 { background-image: var(--gradient-img_6318_169); border:1px solid var(--border-img_6318_169); color:var(--text-img_6318_169); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_169 { background-image: var(--gradient-img_6318_169); border:1px solid var(--border-img_6318_169); color:var(--text-img_6318_169); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_170: linear-gradient(180deg, #5d7a55 0%, #3f3f3f 100%); --border-img_6318_170: #4c5849; --text-img_6318_170: #536d4d; }
+.btn-img_6318_170 { background-image: var(--gradient-img_6318_170); border:1px solid var(--border-img_6318_170); color:var(--text-img_6318_170); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_170 { background-image: var(--gradient-img_6318_170); border:1px solid var(--border-img_6318_170); color:var(--text-img_6318_170); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_171: linear-gradient(180deg, #43563e 0%, #3f3f3f 100%); --border-img_6318_171: #485b43; --text-img_6318_171: #3c443a; }
+.btn-img_6318_171 { background-image: var(--gradient-img_6318_171); border:1px solid var(--border-img_6318_171); color:var(--text-img_6318_171); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_171 { background-image: var(--gradient-img_6318_171); border:1px solid var(--border-img_6318_171); color:var(--text-img_6318_171); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_172: linear-gradient(180deg, #6e9464 0%, #3f3f3f 100%); --border-img_6318_172: #4b6445; --text-img_6318_172: #5c7e54; }
+.btn-img_6318_172 { background-image: var(--gradient-img_6318_172); border:1px solid var(--border-img_6318_172); color:var(--text-img_6318_172); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_172 { background-image: var(--gradient-img_6318_172); border:1px solid var(--border-img_6318_172); color:var(--text-img_6318_172); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_173: linear-gradient(180deg, #47633f 0%, #3f3f3f 100%); --border-img_6318_173: #525b4f; --text-img_6318_173: #3b5a33; }
+.btn-img_6318_173 { background-image: var(--gradient-img_6318_173); border:1px solid var(--border-img_6318_173); color:var(--text-img_6318_173); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_173 { background-image: var(--gradient-img_6318_173); border:1px solid var(--border-img_6318_173); color:var(--text-img_6318_173); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_174: linear-gradient(180deg, #d7d9d6 0%, #3f3f3f 100%); --border-img_6318_174: #677164; --text-img_6318_174: #37522f; }
+.btn-img_6318_174 { background-image: var(--gradient-img_6318_174); border:1px solid var(--border-img_6318_174); color:var(--text-img_6318_174); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_174 { background-image: var(--gradient-img_6318_174); border:1px solid var(--border-img_6318_174); color:var(--text-img_6318_174); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_175: linear-gradient(180deg, #9ac191 0%, #3f3f3f 100%); --border-img_6318_175: #5c6b58; --text-img_6318_175: #37532f; }
+.btn-img_6318_175 { background-image: var(--gradient-img_6318_175); border:1px solid var(--border-img_6318_175); color:var(--text-img_6318_175); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_175 { background-image: var(--gradient-img_6318_175); border:1px solid var(--border-img_6318_175); color:var(--text-img_6318_175); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_176: linear-gradient(180deg, #687264 0%, #3f3f3f 100%); --border-img_6318_176: #596455; --text-img_6318_176: #4e594c; }
+.btn-img_6318_176 { background-image: var(--gradient-img_6318_176); border:1px solid var(--border-img_6318_176); color:var(--text-img_6318_176); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_176 { background-image: var(--gradient-img_6318_176); border:1px solid var(--border-img_6318_176); color:var(--text-img_6318_176); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_177: linear-gradient(180deg, #385631 0%, #78b967 100%); --border-img_6318_177: #4b6444; --text-img_6318_177: #3c423a; }
+.btn-img_6318_177 { background-image: var(--gradient-img_6318_177); border:1px solid var(--border-img_6318_177); color:var(--text-img_6318_177); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_177 { background-image: var(--gradient-img_6318_177); border:1px solid var(--border-img_6318_177); color:var(--text-img_6318_177); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_178: linear-gradient(180deg, #385631 0%, #7dc46a 100%); --border-img_6318_178: #4c6745; --text-img_6318_178: #3c423a; }
+.btn-img_6318_178 { background-image: var(--gradient-img_6318_178); border:1px solid var(--border-img_6318_178); color:var(--text-img_6318_178); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_178 { background-image: var(--gradient-img_6318_178); border:1px solid var(--border-img_6318_178); color:var(--text-img_6318_178); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_179: linear-gradient(180deg, #395631 0%, #88ca77 100%); --border-img_6318_179: #506b49; --text-img_6318_179: #4c6047; }
+.btn-img_6318_179 { background-image: var(--gradient-img_6318_179); border:1px solid var(--border-img_6318_179); color:var(--text-img_6318_179); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_179 { background-image: var(--gradient-img_6318_179); border:1px solid var(--border-img_6318_179); color:var(--text-img_6318_179); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_180: linear-gradient(180deg, #3c5b34 0%, #87c975 100%); --border-img_6318_180: #506a49; --text-img_6318_180: #4c6047; }
+.btn-img_6318_180 { background-image: var(--gradient-img_6318_180); border:1px solid var(--border-img_6318_180); color:var(--text-img_6318_180); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_180 { background-image: var(--gradient-img_6318_180); border:1px solid var(--border-img_6318_180); color:var(--text-img_6318_180); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_181: linear-gradient(180deg, #395631 0%, #84c972 100%); --border-img_6318_181: #4f6948; --text-img_6318_181: #565c54; }
+.btn-img_6318_181 { background-image: var(--gradient-img_6318_181); border:1px solid var(--border-img_6318_181); color:var(--text-img_6318_181); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_181 { background-image: var(--gradient-img_6318_181); border:1px solid var(--border-img_6318_181); color:var(--text-img_6318_181); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_182: linear-gradient(180deg, #7cc26a 0%, #343739 100%); --border-img_6318_182: #62795d; --text-img_6318_182: #83c074; }
+.btn-img_6318_182 { background-image: var(--gradient-img_6318_182); border:1px solid var(--border-img_6318_182); color:var(--text-img_6318_182); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_182 { background-image: var(--gradient-img_6318_182); border:1px solid var(--border-img_6318_182); color:var(--text-img_6318_182); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_183: linear-gradient(180deg, #597751 0%, #343739 100%); --border-img_6318_183: #698f61; --text-img_6318_183: #516a4b; }
+.btn-img_6318_183 { background-image: var(--gradient-img_6318_183); border:1px solid var(--border-img_6318_183); color:var(--text-img_6318_183); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_183 { background-image: var(--gradient-img_6318_183); border:1px solid var(--border-img_6318_183); color:var(--text-img_6318_183); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_184: linear-gradient(180deg, #7dc36a 0%, #343739 100%); --border-img_6318_184: #719c67; --text-img_6318_184: #9fb699; }
+.btn-img_6318_184 { background-image: var(--gradient-img_6318_184); border:1px solid var(--border-img_6318_184); color:var(--text-img_6318_184); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_184 { background-image: var(--gradient-img_6318_184); border:1px solid var(--border-img_6318_184); color:var(--text-img_6318_184); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_185: linear-gradient(180deg, #71a663 0%, #343739 100%); --border-img_6318_185: #647961; --text-img_6318_185: #74b863; }
+.btn-img_6318_185 { background-image: var(--gradient-img_6318_185); border:1px solid var(--border-img_6318_185); color:var(--text-img_6318_185); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_185 { background-image: var(--gradient-img_6318_185); border:1px solid var(--border-img_6318_185); color:var(--text-img_6318_185); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_186: linear-gradient(180deg, #79bf67 0%, #343739 100%); --border-img_6318_186: #5c7856; --text-img_6318_186: #f6faf5; }
+.btn-img_6318_186 { background-image: var(--gradient-img_6318_186); border:1px solid var(--border-img_6318_186); color:var(--text-img_6318_186); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_186 { background-image: var(--gradient-img_6318_186); border:1px solid var(--border-img_6318_186); color:var(--text-img_6318_186); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_187: linear-gradient(180deg, #78b168 0%, #3c4042 100%); --border-img_6318_187: #64855e; --text-img_6318_187: #6e9e62; }
+.btn-img_6318_187 { background-image: var(--gradient-img_6318_187); border:1px solid var(--border-img_6318_187); color:var(--text-img_6318_187); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_187 { background-image: var(--gradient-img_6318_187); border:1px solid var(--border-img_6318_187); color:var(--text-img_6318_187); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_188: linear-gradient(180deg, #688b5e 0%, #343739 100%); --border-img_6318_188: #72906c; --text-img_6318_188: #5d7956; }
+.btn-img_6318_188 { background-image: var(--gradient-img_6318_188); border:1px solid var(--border-img_6318_188); color:var(--text-img_6318_188); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_188 { background-image: var(--gradient-img_6318_188); border:1px solid var(--border-img_6318_188); color:var(--text-img_6318_188); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_189: linear-gradient(180deg, #76bb65 0%, #343739 100%); --border-img_6318_189: #63775f; --text-img_6318_189: #84be76; }
+.btn-img_6318_189 { background-image: var(--gradient-img_6318_189); border:1px solid var(--border-img_6318_189); color:var(--text-img_6318_189); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_189 { background-image: var(--gradient-img_6318_189); border:1px solid var(--border-img_6318_189); color:var(--text-img_6318_189); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_190: linear-gradient(180deg, #77bd66 0%, #343739 100%); --border-img_6318_190: #647a61; --text-img_6318_190: #d0e6ca; }
+.btn-img_6318_190 { background-image: var(--gradient-img_6318_190); border:1px solid var(--border-img_6318_190); color:var(--text-img_6318_190); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_190 { background-image: var(--gradient-img_6318_190); border:1px solid var(--border-img_6318_190); color:var(--text-img_6318_190); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_191: linear-gradient(180deg, #77bd66 0%, #494d50 100%); --border-img_6318_191: #667a63; --text-img_6318_191: #73926b; }
+.btn-img_6318_191 { background-image: var(--gradient-img_6318_191); border:1px solid var(--border-img_6318_191); color:var(--text-img_6318_191); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_191 { background-image: var(--gradient-img_6318_191); border:1px solid var(--border-img_6318_191); color:var(--text-img_6318_191); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_192: linear-gradient(180deg, #77bd66 0%, #343739 100%); --border-img_6318_192: #697d65; --text-img_6318_192: #95ad90; }
+.btn-img_6318_192 { background-image: var(--gradient-img_6318_192); border:1px solid var(--border-img_6318_192); color:var(--text-img_6318_192); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_192 { background-image: var(--gradient-img_6318_192); border:1px solid var(--border-img_6318_192); color:var(--text-img_6318_192); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6318_193: linear-gradient(180deg, #78bd66 0%, #343739 100%); --border-img_6318_193: #657b62; --text-img_6318_193: #8cc37f; }
+.btn-img_6318_193 { background-image: var(--gradient-img_6318_193); border:1px solid var(--border-img_6318_193); color:var(--text-img_6318_193); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6318_193 { background-image: var(--gradient-img_6318_193); border:1px solid var(--border-img_6318_193); color:var(--text-img_6318_193); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_194: linear-gradient(180deg, #343739 0%, #3f463e 100%); --border-img_6319_194: #404d3f; --text-img_6319_194: #404040; }
+.btn-img_6319_194 { background-image: var(--gradient-img_6319_194); border:1px solid var(--border-img_6319_194); color:var(--text-img_6319_194); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_194 { background-image: var(--gradient-img_6319_194); border:1px solid var(--border-img_6319_194); color:var(--text-img_6319_194); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_195: linear-gradient(180deg, #4a4d4e 0%, #5a9a4b 100%); --border-img_6319_195: #4e6e48; --text-img_6319_195: #3f503b; }
+.btn-img_6319_195 { background-image: var(--gradient-img_6319_195); border:1px solid var(--border-img_6319_195); color:var(--text-img_6319_195); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_195 { background-image: var(--gradient-img_6319_195); border:1px solid var(--border-img_6319_195); color:var(--text-img_6319_195); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_196: linear-gradient(180deg, #626466 0%, #4c574a 100%); --border-img_6319_196: #53674f; --text-img_6319_196: #404040; }
+.btn-img_6319_196 { background-image: var(--gradient-img_6319_196); border:1px solid var(--border-img_6319_196); color:var(--text-img_6319_196); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_196 { background-image: var(--gradient-img_6319_196); border:1px solid var(--border-img_6319_196); color:var(--text-img_6319_196); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_197: linear-gradient(180deg, #46484a 0%, #48763c 100%); --border-img_6319_197: #495f45; --text-img_6319_197: #5f655d; }
+.btn-img_6319_197 { background-image: var(--gradient-img_6319_197); border:1px solid var(--border-img_6319_197); color:var(--text-img_6319_197); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_197 { background-image: var(--gradient-img_6319_197); border:1px solid var(--border-img_6319_197); color:var(--text-img_6319_197); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_198: linear-gradient(180deg, #343739 0%, #4d574b 100%); --border-img_6319_198: #435441; --text-img_6319_198: #404040; }
+.btn-img_6319_198 { background-image: var(--gradient-img_6319_198); border:1px solid var(--border-img_6319_198); color:var(--text-img_6319_198); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_198 { background-image: var(--gradient-img_6319_198); border:1px solid var(--border-img_6319_198); color:var(--text-img_6319_198); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_199: linear-gradient(180deg, #343739 0%, #4e7843 100%); --border-img_6319_199: #42553f; --text-img_6319_199: #46663f; }
+.btn-img_6319_199 { background-image: var(--gradient-img_6319_199); border:1px solid var(--border-img_6319_199); color:var(--text-img_6319_199); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_199 { background-image: var(--gradient-img_6319_199); border:1px solid var(--border-img_6319_199); color:var(--text-img_6319_199); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_200: linear-gradient(180deg, #898b8c 0%, #4e6b47 100%); --border-img_6319_200: #597154; --text-img_6319_200: #404040; }
+.btn-img_6319_200 { background-image: var(--gradient-img_6319_200); border:1px solid var(--border-img_6319_200); color:var(--text-img_6319_200); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_200 { background-image: var(--gradient-img_6319_200); border:1px solid var(--border-img_6319_200); color:var(--text-img_6319_200); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_201: linear-gradient(180deg, #343739 0%, #4d6f45 100%); --border-img_6319_201: #445841; --text-img_6319_201: #5e7359; }
+.btn-img_6319_201 { background-image: var(--gradient-img_6319_201); border:1px solid var(--border-img_6319_201); color:var(--text-img_6319_201); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_201 { background-image: var(--gradient-img_6319_201); border:1px solid var(--border-img_6319_201); color:var(--text-img_6319_201); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_202: linear-gradient(180deg, #343739 0%, #455d3f 100%); --border-img_6319_202: #435441; --text-img_6319_202: #3d433c; }
+.btn-img_6319_202 { background-image: var(--gradient-img_6319_202); border:1px solid var(--border-img_6319_202); color:var(--text-img_6319_202); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_202 { background-image: var(--gradient-img_6319_202); border:1px solid var(--border-img_6319_202); color:var(--text-img_6319_202); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_203: linear-gradient(180deg, #343739 0%, #619a52 100%); --border-img_6319_203: #61735e; --text-img_6319_203: #589649; }
+.btn-img_6319_203 { background-image: var(--gradient-img_6319_203); border:1px solid var(--border-img_6319_203); color:var(--text-img_6319_203); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_203 { background-image: var(--gradient-img_6319_203); border:1px solid var(--border-img_6319_203); color:var(--text-img_6319_203); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_204: linear-gradient(180deg, #343739 0%, #638d58 100%); --border-img_6319_204: #667164; --text-img_6319_204: #5b8251; }
+.btn-img_6319_204 { background-image: var(--gradient-img_6319_204); border:1px solid var(--border-img_6319_204); color:var(--text-img_6319_204); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_204 { background-image: var(--gradient-img_6319_204); border:1px solid var(--border-img_6319_204); color:var(--text-img_6319_204); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_205: linear-gradient(180deg, #343739 0%, #4e6548 100%); --border-img_6319_205: #445a41; --text-img_6319_205: #5b6659; }
+.btn-img_6319_205 { background-image: var(--gradient-img_6319_205); border:1px solid var(--border-img_6319_205); color:var(--text-img_6319_205); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_205 { background-image: var(--gradient-img_6319_205); border:1px solid var(--border-img_6319_205); color:var(--text-img_6319_205); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_206: linear-gradient(180deg, #3f453d 0%, #3d413c 100%); --border-img_6319_206: #435a3d; --text-img_6319_206: #404040; }
+.btn-img_6319_206 { background-image: var(--gradient-img_6319_206); border:1px solid var(--border-img_6319_206); color:var(--text-img_6319_206); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_206 { background-image: var(--gradient-img_6319_206); border:1px solid var(--border-img_6319_206); color:var(--text-img_6319_206); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_207: linear-gradient(180deg, #d1dacc 0%, #417b32 100%); --border-img_6319_207: #709d64; --text-img_6319_207: #84aa79; }
+.btn-img_6319_207 { background-image: var(--gradient-img_6319_207); border:1px solid var(--border-img_6319_207); color:var(--text-img_6319_207); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_207 { background-image: var(--gradient-img_6319_207); border:1px solid var(--border-img_6319_207); color:var(--text-img_6319_207); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_208: linear-gradient(180deg, #4b5649 0%, #454d43 100%); --border-img_6319_208: #4c7641; --text-img_6319_208: #404040; }
+.btn-img_6319_208 { background-image: var(--gradient-img_6319_208); border:1px solid var(--border-img_6319_208); color:var(--text-img_6319_208); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_208 { background-image: var(--gradient-img_6319_208); border:1px solid var(--border-img_6319_208); color:var(--text-img_6319_208); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_209: linear-gradient(180deg, #dde4db 0%, #528c44 100%); --border-img_6319_209: #769f6b; --text-img_6319_209: #93b28a; }
+.btn-img_6319_209 { background-image: var(--gradient-img_6319_209); border:1px solid var(--border-img_6319_209); color:var(--text-img_6319_209); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_209 { background-image: var(--gradient-img_6319_209); border:1px solid var(--border-img_6319_209); color:var(--text-img_6319_209); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_210: linear-gradient(180deg, #4e584b 0%, #4f584d 100%); --border-img_6319_210: #537849; --text-img_6319_210: #404040; }
+.btn-img_6319_210 { background-image: var(--gradient-img_6319_210); border:1px solid var(--border-img_6319_210); color:var(--text-img_6319_210); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_210 { background-image: var(--gradient-img_6319_210); border:1px solid var(--border-img_6319_210); color:var(--text-img_6319_210); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_211: linear-gradient(180deg, #7c9076 0%, #403f3f 100%); --border-img_6319_211: #5c6659; --text-img_6319_211: #427c34; }
+.btn-img_6319_211 { background-image: var(--gradient-img_6319_211); border:1px solid var(--border-img_6319_211); color:var(--text-img_6319_211); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_211 { background-image: var(--gradient-img_6319_211); border:1px solid var(--border-img_6319_211); color:var(--text-img_6319_211); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_212: linear-gradient(180deg, #4c6945 0%, #403f3f 100%); --border-img_6319_212: #64795f; --text-img_6319_212: #404040; }
+.btn-img_6319_212 { background-image: var(--gradient-img_6319_212); border:1px solid var(--border-img_6319_212); color:var(--text-img_6319_212); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_212 { background-image: var(--gradient-img_6319_212); border:1px solid var(--border-img_6319_212); color:var(--text-img_6319_212); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_213: linear-gradient(180deg, #94a48f 0%, #403f3f 100%); --border-img_6319_213: #677a62; --text-img_6319_213: #518842; }
+.btn-img_6319_213 { background-image: var(--gradient-img_6319_213); border:1px solid var(--border-img_6319_213); color:var(--text-img_6319_213); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_213 { background-image: var(--gradient-img_6319_213); border:1px solid var(--border-img_6319_213); color:var(--text-img_6319_213); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_214: linear-gradient(180deg, #42593c 0%, #404e3c 100%); --border-img_6319_214: #4b5b46; --text-img_6319_214: #3e403d; }
+.btn-img_6319_214 { background-image: var(--gradient-img_6319_214); border:1px solid var(--border-img_6319_214); color:var(--text-img_6319_214); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_214 { background-image: var(--gradient-img_6319_214); border:1px solid var(--border-img_6319_214); color:var(--text-img_6319_214); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_215: linear-gradient(180deg, #4a873b 0%, #436c39 100%); --border-img_6319_215: #5f7458; --text-img_6319_215: #3b6032; }
+.btn-img_6319_215 { background-image: var(--gradient-img_6319_215); border:1px solid var(--border-img_6319_215); color:var(--text-img_6319_215); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_215 { background-image: var(--gradient-img_6319_215); border:1px solid var(--border-img_6319_215); color:var(--text-img_6319_215); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_216: linear-gradient(180deg, #a7c0a1 0%, #436c39 100%); --border-img_6319_216: #657960; --text-img_6319_216: #628459; }
+.btn-img_6319_216 { background-image: var(--gradient-img_6319_216); border:1px solid var(--border-img_6319_216); color:var(--text-img_6319_216); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_216 { background-image: var(--gradient-img_6319_216); border:1px solid var(--border-img_6319_216); color:var(--text-img_6319_216); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_217: linear-gradient(180deg, #50684a 0%, #465c41 100%); --border-img_6319_217: #5b7654; --text-img_6319_217: #535a52; }
+.btn-img_6319_217 { background-image: var(--gradient-img_6319_217); border:1px solid var(--border-img_6319_217); color:var(--text-img_6319_217); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_217 { background-image: var(--gradient-img_6319_217); border:1px solid var(--border-img_6319_217); color:var(--text-img_6319_217); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_218: linear-gradient(180deg, #403f3f 0%, #3f423e 100%); --border-img_6319_218: #3f493d; --text-img_6319_218: #3f3f3f; }
+.btn-img_6319_218 { background-image: var(--gradient-img_6319_218); border:1px solid var(--border-img_6319_218); color:var(--text-img_6319_218); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_218 { background-image: var(--gradient-img_6319_218); border:1px solid var(--border-img_6319_218); color:var(--text-img_6319_218); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_219: linear-gradient(180deg, #403f3f 0%, #b1bcae 100%); --border-img_6319_219: #596b54; --text-img_6319_219: #426938; }
+.btn-img_6319_219 { background-image: var(--gradient-img_6319_219); border:1px solid var(--border-img_6319_219); color:var(--text-img_6319_219); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_219 { background-image: var(--gradient-img_6319_219); border:1px solid var(--border-img_6319_219); color:var(--text-img_6319_219); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_220: linear-gradient(180deg, #403f3f 0%, #445240 100%); --border-img_6319_220: #41563c; --text-img_6319_220: #3f3f3f; }
+.btn-img_6319_220 { background-image: var(--gradient-img_6319_220); border:1px solid var(--border-img_6319_220); color:var(--text-img_6319_220); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_220 { background-image: var(--gradient-img_6319_220); border:1px solid var(--border-img_6319_220); color:var(--text-img_6319_220); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_221: linear-gradient(180deg, #403f3f 0%, #9fc895 100%); --border-img_6319_221: #577150; --text-img_6319_221: #426a38; }
+.btn-img_6319_221 { background-image: var(--gradient-img_6319_221); border:1px solid var(--border-img_6319_221); color:var(--text-img_6319_221); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_221 { background-image: var(--gradient-img_6319_221); border:1px solid var(--border-img_6319_221); color:var(--text-img_6319_221); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_222: linear-gradient(180deg, #403f3f 0%, #455142 100%); --border-img_6319_222: #44583f; --text-img_6319_222: #3f3f3f; }
+.btn-img_6319_222 { background-image: var(--gradient-img_6319_222); border:1px solid var(--border-img_6319_222); color:var(--text-img_6319_222); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_222 { background-image: var(--gradient-img_6319_222); border:1px solid var(--border-img_6319_222); color:var(--text-img_6319_222); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_223: linear-gradient(180deg, #415c3a 0%, #5d6c59 100%); --border-img_6319_223: #4f5f4a; --text-img_6319_223: #3e6035; }
+.btn-img_6319_223 { background-image: var(--gradient-img_6319_223); border:1px solid var(--border-img_6319_223); color:var(--text-img_6319_223); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_223 { background-image: var(--gradient-img_6319_223); border:1px solid var(--border-img_6319_223); color:var(--text-img_6319_223); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_224: linear-gradient(180deg, #445e3e 0%, #40553a 100%); --border-img_6319_224: #56744f; --text-img_6319_224: #3e403d; }
+.btn-img_6319_224 { background-image: var(--gradient-img_6319_224); border:1px solid var(--border-img_6319_224); color:var(--text-img_6319_224); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_224 { background-image: var(--gradient-img_6319_224); border:1px solid var(--border-img_6319_224); color:var(--text-img_6319_224); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_225: linear-gradient(180deg, #46663d 0%, #73916c 100%); --border-img_6319_225: #54724d; --text-img_6319_225: #3f6335; }
+.btn-img_6319_225 { background-image: var(--gradient-img_6319_225); border:1px solid var(--border-img_6319_225); color:var(--text-img_6319_225); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_225 { background-image: var(--gradient-img_6319_225); border:1px solid var(--border-img_6319_225); color:var(--text-img_6319_225); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_226: linear-gradient(180deg, #3f4d3b 0%, #3d413b 100%); --border-img_6319_226: #495347; --text-img_6319_226: #3d433c; }
+.btn-img_6319_226 { background-image: var(--gradient-img_6319_226); border:1px solid var(--border-img_6319_226); color:var(--text-img_6319_226); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_226 { background-image: var(--gradient-img_6319_226); border:1px solid var(--border-img_6319_226); color:var(--text-img_6319_226); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_227: linear-gradient(180deg, #3f6436 0%, #364d2f 100%); --border-img_6319_227: #4d5e49; --text-img_6319_227: #8e9d89; }
+.btn-img_6319_227 { background-image: var(--gradient-img_6319_227); border:1px solid var(--border-img_6319_227); color:var(--text-img_6319_227); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_227 { background-image: var(--gradient-img_6319_227); border:1px solid var(--border-img_6319_227); color:var(--text-img_6319_227); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_228: linear-gradient(180deg, #3f6436 0%, #3a5833 100%); --border-img_6319_228: #51654b; --text-img_6319_228: #8aaf80; }
+.btn-img_6319_228 { background-image: var(--gradient-img_6319_228); border:1px solid var(--border-img_6319_228); color:var(--text-img_6319_228); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_228 { background-image: var(--gradient-img_6319_228); border:1px solid var(--border-img_6319_228); color:var(--text-img_6319_228); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_229: linear-gradient(180deg, #44593f 0%, #445440 100%); --border-img_6319_229: #4c6345; --text-img_6319_229: #4b6445; }
+.btn-img_6319_229 { background-image: var(--gradient-img_6319_229); border:1px solid var(--border-img_6319_229); color:var(--text-img_6319_229); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_229 { background-image: var(--gradient-img_6319_229); border:1px solid var(--border-img_6319_229); color:var(--text-img_6319_229); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_230: linear-gradient(180deg, #3e423d 0%, #3f3f3f 100%); --border-img_6319_230: #3d453b; --text-img_6319_230: #3f3f3f; }
+.btn-img_6319_230 { background-image: var(--gradient-img_6319_230); border:1px solid var(--border-img_6319_230); color:var(--text-img_6319_230); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_230 { background-image: var(--gradient-img_6319_230); border:1px solid var(--border-img_6319_230); color:var(--text-img_6319_230); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_231: linear-gradient(180deg, #e1e1e1 0%, #3f3f3f 100%); --border-img_6319_231: #70786e; --text-img_6319_231: #375330; }
+.btn-img_6319_231 { background-image: var(--gradient-img_6319_231); border:1px solid var(--border-img_6319_231); color:var(--text-img_6319_231); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_231 { background-image: var(--gradient-img_6319_231); border:1px solid var(--border-img_6319_231); color:var(--text-img_6319_231); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_232: linear-gradient(180deg, #435140 0%, #3f3f3f 100%); --border-img_6319_232: #3e4f39; --text-img_6319_232: #3f3f3f; }
+.btn-img_6319_232 { background-image: var(--gradient-img_6319_232); border:1px solid var(--border-img_6319_232); color:var(--text-img_6319_232); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_232 { background-image: var(--gradient-img_6319_232); border:1px solid var(--border-img_6319_232); color:var(--text-img_6319_232); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_233: linear-gradient(180deg, #d3ffc9 0%, #3f3f3f 100%); --border-img_6319_233: #6e8768; --text-img_6319_233: #375430; }
+.btn-img_6319_233 { background-image: var(--gradient-img_6319_233); border:1px solid var(--border-img_6319_233); color:var(--text-img_6319_233); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_233 { background-image: var(--gradient-img_6319_233); border:1px solid var(--border-img_6319_233); color:var(--text-img_6319_233); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_234: linear-gradient(180deg, #445041 0%, #3f3f3f 100%); --border-img_6319_234: #43533e; --text-img_6319_234: #3f3f3f; }
+.btn-img_6319_234 { background-image: var(--gradient-img_6319_234); border:1px solid var(--border-img_6319_234); color:var(--text-img_6319_234); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_234 { background-image: var(--gradient-img_6319_234); border:1px solid var(--border-img_6319_234); color:var(--text-img_6319_234); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_235: linear-gradient(180deg, #394c34 0%, #628b57 100%); --border-img_6319_235: #4b6345; --text-img_6319_235: #40413f; }
+.btn-img_6319_235 { background-image: var(--gradient-img_6319_235); border:1px solid var(--border-img_6319_235); color:var(--text-img_6319_235); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_235 { background-image: var(--gradient-img_6319_235); border:1px solid var(--border-img_6319_235); color:var(--text-img_6319_235); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_236: linear-gradient(180deg, #3e5039 0%, #668a5c 100%); --border-img_6319_236: #567a4d; --text-img_6319_236: #3f3f3f; }
+.btn-img_6319_236 { background-image: var(--gradient-img_6319_236); border:1px solid var(--border-img_6319_236); color:var(--text-img_6319_236); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_236 { background-image: var(--gradient-img_6319_236); border:1px solid var(--border-img_6319_236); color:var(--text-img_6319_236); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_237: linear-gradient(180deg, #3d5436 0%, #74a966 100%); --border-img_6319_237: #5a7a52; --text-img_6319_237: #424141; }
+.btn-img_6319_237 { background-image: var(--gradient-img_6319_237); border:1px solid var(--border-img_6319_237); color:var(--text-img_6319_237); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_237 { background-image: var(--gradient-img_6319_237); border:1px solid var(--border-img_6319_237); color:var(--text-img_6319_237); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_238: linear-gradient(180deg, #464f43 0%, #4d6148 100%); --border-img_6319_238: #596c54; --text-img_6319_238: #3f3e3e; }
+.btn-img_6319_238 { background-image: var(--gradient-img_6319_238); border:1px solid var(--border-img_6319_238); color:var(--text-img_6319_238); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_238 { background-image: var(--gradient-img_6319_238); border:1px solid var(--border-img_6319_238); color:var(--text-img_6319_238); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_239: linear-gradient(180deg, #6ba45c 0%, #e1efde 100%); --border-img_6319_239: #6e9664; --text-img_6319_239: #75ba64; }
+.btn-img_6319_239 { background-image: var(--gradient-img_6319_239); border:1px solid var(--border-img_6319_239); color:var(--text-img_6319_239); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_239 { background-image: var(--gradient-img_6319_239); border:1px solid var(--border-img_6319_239); color:var(--text-img_6319_239); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_240: linear-gradient(180deg, #ddebd9 0%, #263d20 100%); --border-img_6319_240: #63785d; --text-img_6319_240: #588c4b; }
+.btn-img_6319_240 { background-image: var(--gradient-img_6319_240); border:1px solid var(--border-img_6319_240); color:var(--text-img_6319_240); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_240 { background-image: var(--gradient-img_6319_240); border:1px solid var(--border-img_6319_240); color:var(--text-img_6319_240); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_241: linear-gradient(180deg, #858b83 0%, #4c6347 100%); --border-img_6319_241: #6d9164; --text-img_6319_241: #7fa874; }
+.btn-img_6319_241 { background-image: var(--gradient-img_6319_241); border:1px solid var(--border-img_6319_241); color:var(--text-img_6319_241); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_241 { background-image: var(--gradient-img_6319_241); border:1px solid var(--border-img_6319_241); color:var(--text-img_6319_241); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_242: linear-gradient(180deg, #3f3f3e 0%, #3f403f 100%); --border-img_6319_242: #526a4b; --text-img_6319_242: #3f3e3e; }
+.btn-img_6319_242 { background-image: var(--gradient-img_6319_242); border:1px solid var(--border-img_6319_242); color:var(--text-img_6319_242); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_242 { background-image: var(--gradient-img_6319_242); border:1px solid var(--border-img_6319_242); color:var(--text-img_6319_242); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_243: linear-gradient(180deg, #7cc26a 0%, #ffffff 100%); --border-img_6319_243: #aad69e; --text-img_6319_243: #93c985; }
+.btn-img_6319_243 { background-image: var(--gradient-img_6319_243); border:1px solid var(--border-img_6319_243); color:var(--text-img_6319_243); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_243 { background-image: var(--gradient-img_6319_243); border:1px solid var(--border-img_6319_243); color:var(--text-img_6319_243); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_244: linear-gradient(180deg, #4f6149 0%, #4d6048 100%); --border-img_6319_244: #76a569; --text-img_6319_244: #3f3e3e; }
+.btn-img_6319_244 { background-image: var(--gradient-img_6319_244); border:1px solid var(--border-img_6319_244); color:var(--text-img_6319_244); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_244 { background-image: var(--gradient-img_6319_244); border:1px solid var(--border-img_6319_244); color:var(--text-img_6319_244); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_245: linear-gradient(180deg, #7cc36a 0%, #ffffff 100%); --border-img_6319_245: #a5d09a; --text-img_6319_245: #66915c; }
+.btn-img_6319_245 { background-image: var(--gradient-img_6319_245); border:1px solid var(--border-img_6319_245); color:var(--text-img_6319_245); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_245 { background-image: var(--gradient-img_6319_245); border:1px solid var(--border-img_6319_245); color:var(--text-img_6319_245); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_246: linear-gradient(180deg, #5d6f58 0%, #5a6d55 100%); --border-img_6319_246: #74a069; --text-img_6319_246: #494948; }
+.btn-img_6319_246 { background-image: var(--gradient-img_6319_246); border:1px solid var(--border-img_6319_246); color:var(--text-img_6319_246); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_246 { background-image: var(--gradient-img_6319_246); border:1px solid var(--border-img_6319_246); color:var(--text-img_6319_246); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_247: linear-gradient(180deg, #688c5f 0%, #485444 100%); --border-img_6319_247: #63725f; --text-img_6319_247: #649a57; }
+.btn-img_6319_247 { background-image: var(--gradient-img_6319_247); border:1px solid var(--border-img_6319_247); color:var(--text-img_6319_247); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_247 { background-image: var(--gradient-img_6319_247); border:1px solid var(--border-img_6319_247); color:var(--text-img_6319_247); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_248: linear-gradient(180deg, #628659 0%, #474c45 100%); --border-img_6319_248: #6d8c65; --text-img_6319_248: #454e42; }
+.btn-img_6319_248 { background-image: var(--gradient-img_6319_248); border:1px solid var(--border-img_6319_248); color:var(--text-img_6319_248); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_248 { background-image: var(--gradient-img_6319_248); border:1px solid var(--border-img_6319_248); color:var(--text-img_6319_248); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_249: linear-gradient(180deg, #6e9d62 0%, #b1bbae 100%); --border-img_6319_249: #789571; --text-img_6319_249: #6aac5b; }
+.btn-img_6319_249 { background-image: var(--gradient-img_6319_249); border:1px solid var(--border-img_6319_249); color:var(--text-img_6319_249); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_249 { background-image: var(--gradient-img_6319_249); border:1px solid var(--border-img_6319_249); color:var(--text-img_6319_249); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_250: linear-gradient(180deg, #3f403f 0%, #3e3e3e 100%); --border-img_6319_250: #444f42; --text-img_6319_250: #3e3e3e; }
+.btn-img_6319_250 { background-image: var(--gradient-img_6319_250); border:1px solid var(--border-img_6319_250); color:var(--text-img_6319_250); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_250 { background-image: var(--gradient-img_6319_250); border:1px solid var(--border-img_6319_250); color:var(--text-img_6319_250); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_251: linear-gradient(180deg, #69aa5a 0%, #393939 100%); --border-img_6319_251: #506f49; --text-img_6319_251: #495745; }
+.btn-img_6319_251 { background-image: var(--gradient-img_6319_251); border:1px solid var(--border-img_6319_251); color:var(--text-img_6319_251); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_251 { background-image: var(--gradient-img_6319_251); border:1px solid var(--border-img_6319_251); color:var(--text-img_6319_251); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_252: linear-gradient(180deg, #4b5e47 0%, #3c3c3c 100%); --border-img_6319_252: #536a4d; --text-img_6319_252: #3e3e3e; }
+.btn-img_6319_252 { background-image: var(--gradient-img_6319_252); border:1px solid var(--border-img_6319_252); color:var(--text-img_6319_252); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_252 { background-image: var(--gradient-img_6319_252); border:1px solid var(--border-img_6319_252); color:var(--text-img_6319_252); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_253: linear-gradient(180deg, #69aa5a 0%, #393939 100%); --border-img_6319_253: #56744f; --text-img_6319_253: #687265; }
+.btn-img_6319_253 { background-image: var(--gradient-img_6319_253); border:1px solid var(--border-img_6319_253); color:var(--text-img_6319_253); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_253 { background-image: var(--gradient-img_6319_253); border:1px solid var(--border-img_6319_253); color:var(--text-img_6319_253); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_254: linear-gradient(180deg, #586b54 0%, #4d4d4d 100%); --border-img_6319_254: #566f50; --text-img_6319_254: #3e3e3e; }
+.btn-img_6319_254 { background-image: var(--gradient-img_6319_254); border:1px solid var(--border-img_6319_254); color:var(--text-img_6319_254); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_254 { background-image: var(--gradient-img_6319_254); border:1px solid var(--border-img_6319_254); color:var(--text-img_6319_254); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_255: linear-gradient(180deg, #4a5d46 0%, #3b3b3b 100%); --border-img_6319_255: #424b40; --text-img_6319_255: #3e3e3e; }
+.btn-img_6319_255 { background-image: var(--gradient-img_6319_255); border:1px solid var(--border-img_6319_255); color:var(--text-img_6319_255); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_255 { background-image: var(--gradient-img_6319_255); border:1px solid var(--border-img_6319_255); color:var(--text-img_6319_255); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_256: linear-gradient(180deg, #65a657 0%, #363636 100%); --border-img_6319_256: #475b42; --text-img_6319_256: #3a3a3a; }
+.btn-img_6319_256 { background-image: var(--gradient-img_6319_256); border:1px solid var(--border-img_6319_256); color:var(--text-img_6319_256); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_256 { background-image: var(--gradient-img_6319_256); border:1px solid var(--border-img_6319_256); color:var(--text-img_6319_256); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_257: linear-gradient(180deg, #65a657 0%, #373737 100%); --border-img_6319_257: #495845; --text-img_6319_257: #4b4b4b; }
+.btn-img_6319_257 { background-image: var(--gradient-img_6319_257); border:1px solid var(--border-img_6319_257); color:var(--text-img_6319_257); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_257 { background-image: var(--gradient-img_6319_257); border:1px solid var(--border-img_6319_257); color:var(--text-img_6319_257); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_258: linear-gradient(180deg, #5e8056 0%, #3e3e3e 100%); --border-img_6319_258: #4e6149; --text-img_6319_258: #4b4b4b; }
+.btn-img_6319_258 { background-image: var(--gradient-img_6319_258); border:1px solid var(--border-img_6319_258); color:var(--text-img_6319_258); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_258 { background-image: var(--gradient-img_6319_258); border:1px solid var(--border-img_6319_258); color:var(--text-img_6319_258); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_259: linear-gradient(180deg, #3a3a3a 0%, #50634a 100%); --border-img_6319_259: #4b5847; --text-img_6319_259: #373737; }
+.btn-img_6319_259 { background-image: var(--gradient-img_6319_259); border:1px solid var(--border-img_6319_259); color:var(--text-img_6319_259); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_259 { background-image: var(--gradient-img_6319_259); border:1px solid var(--border-img_6319_259); color:var(--text-img_6319_259); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_260: linear-gradient(180deg, #3c3c3c 0%, #424540 100%); --border-img_6319_260: #4a5647; --text-img_6319_260: #3c3c3c; }
+.btn-img_6319_260 { background-image: var(--gradient-img_6319_260); border:1px solid var(--border-img_6319_260); color:var(--text-img_6319_260); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_260 { background-image: var(--gradient-img_6319_260); border:1px solid var(--border-img_6319_260); color:var(--text-img_6319_260); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_261: linear-gradient(180deg, #3e3e3e 0%, #6f8f67 100%); --border-img_6319_261: #586f52; --text-img_6319_261: #333333; }
+.btn-img_6319_261 { background-image: var(--gradient-img_6319_261); border:1px solid var(--border-img_6319_261); color:var(--text-img_6319_261); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_261 { background-image: var(--gradient-img_6319_261); border:1px solid var(--border-img_6319_261); color:var(--text-img_6319_261); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_262: linear-gradient(180deg, #3e3d3e 0%, #3e3d3d 100%); --border-img_6319_262: #3a3a3a; --text-img_6319_262: #3e3d3d; }
+.btn-img_6319_262 { background-image: var(--gradient-img_6319_262); border:1px solid var(--border-img_6319_262); color:var(--text-img_6319_262); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_262 { background-image: var(--gradient-img_6319_262); border:1px solid var(--border-img_6319_262); color:var(--text-img_6319_262); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_263: linear-gradient(180deg, #373737 0%, #323232 100%); --border-img_6319_263: #424d3f; --text-img_6319_263: #8cd579; }
+.btn-img_6319_263 { background-image: var(--gradient-img_6319_263); border:1px solid var(--border-img_6319_263); color:var(--text-img_6319_263); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_263 { background-image: var(--gradient-img_6319_263); border:1px solid var(--border-img_6319_263); color:var(--text-img_6319_263); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_264: linear-gradient(180deg, #333333 0%, #272727 100%); --border-img_6319_264: #3d463b; --text-img_6319_264: #9ddc8e; }
+.btn-img_6319_264 { background-image: var(--gradient-img_6319_264); border:1px solid var(--border-img_6319_264); color:var(--text-img_6319_264); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_264 { background-image: var(--gradient-img_6319_264); border:1px solid var(--border-img_6319_264); color:var(--text-img_6319_264); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_265: linear-gradient(180deg, #434343 0%, #3f3e3e 100%); --border-img_6319_265: #3f453d; --text-img_6319_265: #585757; }
+.btn-img_6319_265 { background-image: var(--gradient-img_6319_265); border:1px solid var(--border-img_6319_265); color:var(--text-img_6319_265); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_265 { background-image: var(--gradient-img_6319_265); border:1px solid var(--border-img_6319_265); color:var(--text-img_6319_265); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_266: linear-gradient(180deg, #3a3a3a 0%, #3d3d3d 100%); --border-img_6319_266: #464f44; --text-img_6319_266: #3e3d3d; }
+.btn-img_6319_266 { background-image: var(--gradient-img_6319_266); border:1px solid var(--border-img_6319_266); color:var(--text-img_6319_266); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_266 { background-image: var(--gradient-img_6319_266); border:1px solid var(--border-img_6319_266); color:var(--text-img_6319_266); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_267: linear-gradient(180deg, #83c572 0%, #3d3d3d 100%); --border-img_6319_267: #5c7855; --text-img_6319_267: #303030; }
+.btn-img_6319_267 { background-image: var(--gradient-img_6319_267); border:1px solid var(--border-img_6319_267); color:var(--text-img_6319_267); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_267 { background-image: var(--gradient-img_6319_267); border:1px solid var(--border-img_6319_267); color:var(--text-img_6319_267); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_268: linear-gradient(180deg, #73986a 0%, #3d3d3d 100%); --border-img_6319_268: #586555; --text-img_6319_268: #232323; }
+.btn-img_6319_268 { background-image: var(--gradient-img_6319_268); border:1px solid var(--border-img_6319_268); color:var(--text-img_6319_268); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_268 { background-image: var(--gradient-img_6319_268); border:1px solid var(--border-img_6319_268); color:var(--text-img_6319_268); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_269: linear-gradient(180deg, #515d4d 0%, #3d3d3d 100%); --border-img_6319_269: #52604e; --text-img_6319_269: #424242; }
+.btn-img_6319_269 { background-image: var(--gradient-img_6319_269); border:1px solid var(--border-img_6319_269); color:var(--text-img_6319_269); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_269 { background-image: var(--gradient-img_6319_269); border:1px solid var(--border-img_6319_269); color:var(--text-img_6319_269); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_270: linear-gradient(180deg, #363636 0%, #799b72 100%); --border-img_6319_270: #505c4d; --text-img_6319_270: #3d3d3d; }
+.btn-img_6319_270 { background-image: var(--gradient-img_6319_270); border:1px solid var(--border-img_6319_270); color:var(--text-img_6319_270); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_270 { background-image: var(--gradient-img_6319_270); border:1px solid var(--border-img_6319_270); color:var(--text-img_6319_270); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_271: linear-gradient(180deg, #3c3b3b 0%, #6f8969 100%); --border-img_6319_271: #4d584b; --text-img_6319_271: #3d3d3d; }
+.btn-img_6319_271 { background-image: var(--gradient-img_6319_271); border:1px solid var(--border-img_6319_271); color:var(--text-img_6319_271); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_271 { background-image: var(--gradient-img_6319_271); border:1px solid var(--border-img_6319_271); color:var(--text-img_6319_271); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_272: linear-gradient(180deg, #2f2f2f 0%, #424241 100%); --border-img_6319_272: #3f453e; --text-img_6319_272: #474747; }
+.btn-img_6319_272 { background-image: var(--gradient-img_6319_272); border:1px solid var(--border-img_6319_272); color:var(--text-img_6319_272); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_272 { background-image: var(--gradient-img_6319_272); border:1px solid var(--border-img_6319_272); color:var(--text-img_6319_272); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_273: linear-gradient(180deg, #3e3d3d 0%, #3d3d3d 100%); --border-img_6319_273: #4b5449; --text-img_6319_273: #3d3d3d; }
+.btn-img_6319_273 { background-image: var(--gradient-img_6319_273); border:1px solid var(--border-img_6319_273); color:var(--text-img_6319_273); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_273 { background-image: var(--gradient-img_6319_273); border:1px solid var(--border-img_6319_273); color:var(--text-img_6319_273); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_274: linear-gradient(180deg, #2f2f2f 0%, #a9e59c 100%); --border-img_6319_274: #6a8564; --text-img_6319_274: #444a43; }
+.btn-img_6319_274 { background-image: var(--gradient-img_6319_274); border:1px solid var(--border-img_6319_274); color:var(--text-img_6319_274); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_274 { background-image: var(--gradient-img_6319_274); border:1px solid var(--border-img_6319_274); color:var(--text-img_6319_274); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_275: linear-gradient(180deg, #3b3a3a 0%, #637b5e 100%); --border-img_6319_275: #566353; --text-img_6319_275: #3d3d3d; }
+.btn-img_6319_275 { background-image: var(--gradient-img_6319_275); border:1px solid var(--border-img_6319_275); color:var(--text-img_6319_275); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_275 { background-image: var(--gradient-img_6319_275); border:1px solid var(--border-img_6319_275); color:var(--text-img_6319_275); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_276: linear-gradient(180deg, #212121 0%, #3b3b3b 100%); --border-img_6319_276: #383938; --text-img_6319_276: #474946; }
+.btn-img_6319_276 { background-image: var(--gradient-img_6319_276); border:1px solid var(--border-img_6319_276); color:var(--text-img_6319_276); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_276 { background-image: var(--gradient-img_6319_276); border:1px solid var(--border-img_6319_276); color:var(--text-img_6319_276); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_277: linear-gradient(180deg, #414141 0%, #444544 100%); --border-img_6319_277: #40443f; --text-img_6319_277: #3d3d3d; }
+.btn-img_6319_277 { background-image: var(--gradient-img_6319_277); border:1px solid var(--border-img_6319_277); color:var(--text-img_6319_277); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_277 { background-image: var(--gradient-img_6319_277); border:1px solid var(--border-img_6319_277); color:var(--text-img_6319_277); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_278: linear-gradient(180deg, #556552 0%, #51604c 100%); --border-img_6319_278: #61785b; --text-img_6319_278: #3d3d3d; }
+.btn-img_6319_278 { background-image: var(--gradient-img_6319_278); border:1px solid var(--border-img_6319_278); color:var(--text-img_6319_278); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_278 { background-image: var(--gradient-img_6319_278); border:1px solid var(--border-img_6319_278); color:var(--text-img_6319_278); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_279: linear-gradient(180deg, #a8e49a 0%, #8fd07f 100%); --border-img_6319_279: #93cc86; --text-img_6319_279: #484c45; }
+.btn-img_6319_279 { background-image: var(--gradient-img_6319_279); border:1px solid var(--border-img_6319_279); color:var(--text-img_6319_279); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_279 { background-image: var(--gradient-img_6319_279); border:1px solid var(--border-img_6319_279); color:var(--text-img_6319_279); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_280: linear-gradient(180deg, #3e3f3e 0%, #333433 100%); --border-img_6319_280: #464d45; --text-img_6319_280: #799972; }
+.btn-img_6319_280 { background-image: var(--gradient-img_6319_280); border:1px solid var(--border-img_6319_280); color:var(--text-img_6319_280); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_280 { background-image: var(--gradient-img_6319_280); border:1px solid var(--border-img_6319_280); color:var(--text-img_6319_280); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_281: linear-gradient(180deg, #414241 0%, #3a3b3a 100%); --border-img_6319_281: #464e44; --text-img_6319_281: #484c48; }
+.btn-img_6319_281 { background-image: var(--gradient-img_6319_281); border:1px solid var(--border-img_6319_281); color:var(--text-img_6319_281); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_281 { background-image: var(--gradient-img_6319_281); border:1px solid var(--border-img_6319_281); color:var(--text-img_6319_281); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_282: linear-gradient(180deg, #75986e 0%, #6a8e61 100%); --border-img_6319_282: #637e5d; --text-img_6319_282: #7aa56f; }
+.btn-img_6319_282 { background-image: var(--gradient-img_6319_282); border:1px solid var(--border-img_6319_282); color:var(--text-img_6319_282); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_282 { background-image: var(--gradient-img_6319_282); border:1px solid var(--border-img_6319_282); color:var(--text-img_6319_282); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_283: linear-gradient(180deg, #6c8766 0%, #637f5b 100%); --border-img_6319_283: #678460; --text-img_6319_283: #556851; }
+.btn-img_6319_283 { background-image: var(--gradient-img_6319_283); border:1px solid var(--border-img_6319_283); color:var(--text-img_6319_283); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_283 { background-image: var(--gradient-img_6319_283); border:1px solid var(--border-img_6319_283); color:var(--text-img_6319_283); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_284: linear-gradient(180deg, #3e3e3d 0%, #353635 100%); --border-img_6319_284: #566753; --text-img_6319_284: #6e8a68; }
+.btn-img_6319_284 { background-image: var(--gradient-img_6319_284); border:1px solid var(--border-img_6319_284); color:var(--text-img_6319_284); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_284 { background-image: var(--gradient-img_6319_284); border:1px solid var(--border-img_6319_284); color:var(--text-img_6319_284); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_285: linear-gradient(180deg, #3d3d3d 0%, #3d3c3c 100%); --border-img_6319_285: #5b7056; --text-img_6319_285: #3d3c3d; }
+.btn-img_6319_285 { background-image: var(--gradient-img_6319_285); border:1px solid var(--border-img_6319_285); color:var(--text-img_6319_285); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_285 { background-image: var(--gradient-img_6319_285); border:1px solid var(--border-img_6319_285); color:var(--text-img_6319_285); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_286: linear-gradient(180deg, #72916a 0%, #8ecf7e 100%); --border-img_6319_286: #8ac07d; --text-img_6319_286: #515d4d; }
+.btn-img_6319_286 { background-image: var(--gradient-img_6319_286); border:1px solid var(--border-img_6319_286); color:var(--text-img_6319_286); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_286 { background-image: var(--gradient-img_6319_286); border:1px solid var(--border-img_6319_286); color:var(--text-img_6319_286); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_287: linear-gradient(180deg, #61795c 0%, #5a7254 100%); --border-img_6319_287: #5f7959; --text-img_6319_287: #485145; }
+.btn-img_6319_287 { background-image: var(--gradient-img_6319_287); border:1px solid var(--border-img_6319_287); color:var(--text-img_6319_287); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_287 { background-image: var(--gradient-img_6319_287); border:1px solid var(--border-img_6319_287); color:var(--text-img_6319_287); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_288: linear-gradient(180deg, #87ad7e 0%, #2e2e2e 100%); --border-img_6319_288: #475045; --text-img_6319_288: #81a579; }
+.btn-img_6319_288 { background-image: var(--gradient-img_6319_288); border:1px solid var(--border-img_6319_288); color:var(--text-img_6319_288); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_288 { background-image: var(--gradient-img_6319_288); border:1px solid var(--border-img_6319_288); color:var(--text-img_6319_288); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6319_289: linear-gradient(180deg, #424442 0%, #3f403f 100%); --border-img_6319_289: #424840; --text-img_6319_289: #535752; }
+.btn-img_6319_289 { background-image: var(--gradient-img_6319_289); border:1px solid var(--border-img_6319_289); color:var(--text-img_6319_289); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6319_289 { background-image: var(--gradient-img_6319_289); border:1px solid var(--border-img_6319_289); color:var(--text-img_6319_289); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_290: linear-gradient(180deg, #343739 0%, #4c6745 100%); --border-img_6320_290: #3f4c3e; --text-img_6320_290: #464846; }
+.btn-img_6320_290 { background-image: var(--gradient-img_6320_290); border:1px solid var(--border-img_6320_290); color:var(--text-img_6320_290); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_290 { background-image: var(--gradient-img_6320_290); border:1px solid var(--border-img_6320_290); color:var(--text-img_6320_290); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_291: linear-gradient(180deg, #4a4d4e 0%, #48763c 100%); --border-img_6320_291: #485e44; --text-img_6320_291: #535d51; }
+.btn-img_6320_291 { background-image: var(--gradient-img_6320_291); border:1px solid var(--border-img_6320_291); color:var(--text-img_6320_291); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_291 { background-image: var(--gradient-img_6320_291); border:1px solid var(--border-img_6320_291); color:var(--text-img_6320_291); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_292: linear-gradient(180deg, #626466 0%, #455e3e 100%); --border-img_6320_292: #505e4e; --text-img_6320_292: #404140; }
+.btn-img_6320_292 { background-image: var(--gradient-img_6320_292); border:1px solid var(--border-img_6320_292); color:var(--text-img_6320_292); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_292 { background-image: var(--gradient-img_6320_292); border:1px solid var(--border-img_6320_292); color:var(--text-img_6320_292); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_293: linear-gradient(180deg, #46484a 0%, #48763c 100%); --border-img_6320_293: #465d42; --text-img_6320_293: #43583f; }
+.btn-img_6320_293 { background-image: var(--gradient-img_6320_293); border:1px solid var(--border-img_6320_293); color:var(--text-img_6320_293); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_293 { background-image: var(--gradient-img_6320_293); border:1px solid var(--border-img_6320_293); color:var(--text-img_6320_293); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_294: linear-gradient(180deg, #343739 0%, #4e6449 100%); --border-img_6320_294: #465a43; --text-img_6320_294: #404040; }
+.btn-img_6320_294 { background-image: var(--gradient-img_6320_294); border:1px solid var(--border-img_6320_294); color:var(--text-img_6320_294); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_294 { background-image: var(--gradient-img_6320_294); border:1px solid var(--border-img_6320_294); color:var(--text-img_6320_294); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_295: linear-gradient(180deg, #343739 0%, #4d7a41 100%); --border-img_6320_295: #40513e; --text-img_6320_295: #536c4c; }
+.btn-img_6320_295 { background-image: var(--gradient-img_6320_295); border:1px solid var(--border-img_6320_295); color:var(--text-img_6320_295); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_295 { background-image: var(--gradient-img_6320_295); border:1px solid var(--border-img_6320_295); color:var(--text-img_6320_295); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_296: linear-gradient(180deg, #898b8c 0%, #476141 100%); --border-img_6320_296: #556a51; --text-img_6320_296: #424e3f; }
+.btn-img_6320_296 { background-image: var(--gradient-img_6320_296); border:1px solid var(--border-img_6320_296); color:var(--text-img_6320_296); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_296 { background-image: var(--gradient-img_6320_296); border:1px solid var(--border-img_6320_296); color:var(--text-img_6320_296); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_297: linear-gradient(180deg, #343739 0%, #45603f 100%); --border-img_6320_297: #455c41; --text-img_6320_297: #424e3f; }
+.btn-img_6320_297 { background-image: var(--gradient-img_6320_297); border:1px solid var(--border-img_6320_297); color:var(--text-img_6320_297); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_297 { background-image: var(--gradient-img_6320_297); border:1px solid var(--border-img_6320_297); color:var(--text-img_6320_297); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_298: linear-gradient(180deg, #343739 0%, #4e7344 100%); --border-img_6320_298: #4f5b4e; --text-img_6320_298: #547b49; }
+.btn-img_6320_298 { background-image: var(--gradient-img_6320_298); border:1px solid var(--border-img_6320_298); color:var(--text-img_6320_298); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_298 { background-image: var(--gradient-img_6320_298); border:1px solid var(--border-img_6320_298); color:var(--text-img_6320_298); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_299: linear-gradient(180deg, #343739 0%, #4e7744 100%); --border-img_6320_299: #546252; --text-img_6320_299: #537b49; }
+.btn-img_6320_299 { background-image: var(--gradient-img_6320_299); border:1px solid var(--border-img_6320_299); color:var(--text-img_6320_299); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_299 { background-image: var(--gradient-img_6320_299); border:1px solid var(--border-img_6320_299); color:var(--text-img_6320_299); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_300: linear-gradient(180deg, #343739 0%, #9fb899 100%); --border-img_6320_300: #647960; --text-img_6320_300: #47763b; }
+.btn-img_6320_300 { background-image: var(--gradient-img_6320_300); border:1px solid var(--border-img_6320_300); color:var(--text-img_6320_300); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_300 { background-image: var(--gradient-img_6320_300); border:1px solid var(--border-img_6320_300); color:var(--text-img_6320_300); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_301: linear-gradient(180deg, #343739 0%, #485b43 100%); --border-img_6320_301: #475f42; --text-img_6320_301: #404040; }
+.btn-img_6320_301 { background-image: var(--gradient-img_6320_301); border:1px solid var(--border-img_6320_301); color:var(--text-img_6320_301); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_301 { background-image: var(--gradient-img_6320_301); border:1px solid var(--border-img_6320_301); color:var(--text-img_6320_301); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_302: linear-gradient(180deg, #4d6a46 0%, #517149 100%); --border-img_6320_302: #5c7156; --text-img_6320_302: #5f8855; }
+.btn-img_6320_302 { background-image: var(--gradient-img_6320_302); border:1px solid var(--border-img_6320_302); color:var(--text-img_6320_302); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_302 { background-image: var(--gradient-img_6320_302); border:1px solid var(--border-img_6320_302); color:var(--text-img_6320_302); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_303: linear-gradient(180deg, #82a47a 0%, #528c44 100%); --border-img_6320_303: #719c66; --text-img_6320_303: #93b28a; }
+.btn-img_6320_303 { background-image: var(--gradient-img_6320_303); border:1px solid var(--border-img_6320_303); color:var(--text-img_6320_303); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_303 { background-image: var(--gradient-img_6320_303); border:1px solid var(--border-img_6320_303); color:var(--text-img_6320_303); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_304: linear-gradient(180deg, #46613f 0%, #486541 100%); --border-img_6320_304: #5f7958; --text-img_6320_304: #48693f; }
+.btn-img_6320_304 { background-image: var(--gradient-img_6320_304); border:1px solid var(--border-img_6320_304); color:var(--text-img_6320_304); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_304 { background-image: var(--gradient-img_6320_304); border:1px solid var(--border-img_6320_304); color:var(--text-img_6320_304); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_305: linear-gradient(180deg, #9ab493 0%, #528c44 100%); --border-img_6320_305: #719c66; --text-img_6320_305: #8bae83; }
+.btn-img_6320_305 { background-image: var(--gradient-img_6320_305); border:1px solid var(--border-img_6320_305); color:var(--text-img_6320_305); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_305 { background-image: var(--gradient-img_6320_305); border:1px solid var(--border-img_6320_305); color:var(--text-img_6320_305); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_306: linear-gradient(180deg, #4a5c46 0%, #41493e 100%); --border-img_6320_306: #55734e; --text-img_6320_306: #434a41; }
+.btn-img_6320_306 { background-image: var(--gradient-img_6320_306); border:1px solid var(--border-img_6320_306); color:var(--text-img_6320_306); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_306 { background-image: var(--gradient-img_6320_306); border:1px solid var(--border-img_6320_306); color:var(--text-img_6320_306); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_307: linear-gradient(180deg, #b8c9b3 0%, #403f3f 100%); --border-img_6320_307: #697366; --text-img_6320_307: #518842; }
+.btn-img_6320_307 { background-image: var(--gradient-img_6320_307); border:1px solid var(--border-img_6320_307); color:var(--text-img_6320_307); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_307 { background-image: var(--gradient-img_6320_307); border:1px solid var(--border-img_6320_307); color:var(--text-img_6320_307); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_308: linear-gradient(180deg, #62765d 0%, #403f3f 100%); --border-img_6320_308: #60765a; --text-img_6320_308: #486740; }
+.btn-img_6320_308 { background-image: var(--gradient-img_6320_308); border:1px solid var(--border-img_6320_308); color:var(--text-img_6320_308); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_308 { background-image: var(--gradient-img_6320_308); border:1px solid var(--border-img_6320_308); color:var(--text-img_6320_308); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_309: linear-gradient(180deg, #60745b 0%, #403f3f 100%); --border-img_6320_309: #5f715b; --text-img_6320_309: #486640; }
+.btn-img_6320_309 { background-image: var(--gradient-img_6320_309); border:1px solid var(--border-img_6320_309); color:var(--text-img_6320_309); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_309 { background-image: var(--gradient-img_6320_309); border:1px solid var(--border-img_6320_309); color:var(--text-img_6320_309); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_310: linear-gradient(180deg, #6f8e67 0%, #4b6844 100%); --border-img_6320_310: #5c6d57; --text-img_6320_310: #597b50; }
+.btn-img_6320_310 { background-image: var(--gradient-img_6320_310); border:1px solid var(--border-img_6320_310); color:var(--text-img_6320_310); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_310 { background-image: var(--gradient-img_6320_310); border:1px solid var(--border-img_6320_310); color:var(--text-img_6320_310); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_311: linear-gradient(180deg, #7b9a73 0%, #4b6a43 100%); --border-img_6320_311: #5d6f58; --text-img_6320_311: #597d50; }
+.btn-img_6320_311 { background-image: var(--gradient-img_6320_311); border:1px solid var(--border-img_6320_311); color:var(--text-img_6320_311); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_311 { background-image: var(--gradient-img_6320_311); border:1px solid var(--border-img_6320_311); color:var(--text-img_6320_311); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_312: linear-gradient(180deg, #4f8441 0%, #436c39 100%); --border-img_6320_312: #6c8a64; --text-img_6320_312: #4c7641; }
+.btn-img_6320_312 { background-image: var(--gradient-img_6320_312); border:1px solid var(--border-img_6320_312); color:var(--text-img_6320_312); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_312 { background-image: var(--gradient-img_6320_312); border:1px solid var(--border-img_6320_312); color:var(--text-img_6320_312); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_313: linear-gradient(180deg, #465741 0%, #434d40 100%); --border-img_6320_313: #4e6747; --text-img_6320_313: #403f3f; }
+.btn-img_6320_313 { background-image: var(--gradient-img_6320_313); border:1px solid var(--border-img_6320_313); color:var(--text-img_6320_313); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_313 { background-image: var(--gradient-img_6320_313); border:1px solid var(--border-img_6320_313); color:var(--text-img_6320_313); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_314: linear-gradient(180deg, #403f3f 0%, #495c44 100%); --border-img_6320_314: #465143; --text-img_6320_314: #607959; }
+.btn-img_6320_314 { background-image: var(--gradient-img_6320_314); border:1px solid var(--border-img_6320_314); color:var(--text-img_6320_314); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_314 { background-image: var(--gradient-img_6320_314); border:1px solid var(--border-img_6320_314); color:var(--text-img_6320_314); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_315: linear-gradient(180deg, #403f3f 0%, #698361 100%); --border-img_6320_315: #586a53; --text-img_6320_315: #426a38; }
+.btn-img_6320_315 { background-image: var(--gradient-img_6320_315); border:1px solid var(--border-img_6320_315); color:var(--text-img_6320_315); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_315 { background-image: var(--gradient-img_6320_315); border:1px solid var(--border-img_6320_315); color:var(--text-img_6320_315); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_316: linear-gradient(180deg, #403f3f 0%, #40543b 100%); --border-img_6320_316: #495646; --text-img_6320_316: #445d3e; }
+.btn-img_6320_316 { background-image: var(--gradient-img_6320_316); border:1px solid var(--border-img_6320_316); color:var(--text-img_6320_316); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_316 { background-image: var(--gradient-img_6320_316); border:1px solid var(--border-img_6320_316); color:var(--text-img_6320_316); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_317: linear-gradient(180deg, #403f3f 0%, #84987d 100%); --border-img_6320_317: #586b52; --text-img_6320_317: #426a38; }
+.btn-img_6320_317 { background-image: var(--gradient-img_6320_317); border:1px solid var(--border-img_6320_317); color:var(--text-img_6320_317); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_317 { background-image: var(--gradient-img_6320_317); border:1px solid var(--border-img_6320_317); color:var(--text-img_6320_317); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_318: linear-gradient(180deg, #403f3f 0%, #41493f 100%); --border-img_6320_318: #42513e; --text-img_6320_318: #414440; }
+.btn-img_6320_318 { background-image: var(--gradient-img_6320_318); border:1px solid var(--border-img_6320_318); color:var(--text-img_6320_318); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_318 { background-image: var(--gradient-img_6320_318); border:1px solid var(--border-img_6320_318); color:var(--text-img_6320_318); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_319: linear-gradient(180deg, #496e3f 0%, #a5afa0 100%); --border-img_6320_319: #4d6248; --text-img_6320_319: #47693d; }
+.btn-img_6320_319 { background-image: var(--gradient-img_6320_319); border:1px solid var(--border-img_6320_319); color:var(--text-img_6320_319); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_319 { background-image: var(--gradient-img_6320_319); border:1px solid var(--border-img_6320_319); color:var(--text-img_6320_319); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_320: linear-gradient(180deg, #44593f 0%, #495845 100%); --border-img_6320_320: #536d4c; --text-img_6320_320: #42563c; }
+.btn-img_6320_320 { background-image: var(--gradient-img_6320_320); border:1px solid var(--border-img_6320_320); color:var(--text-img_6320_320); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_320 { background-image: var(--gradient-img_6320_320); border:1px solid var(--border-img_6320_320); color:var(--text-img_6320_320); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_321: linear-gradient(180deg, #42573c 0%, #465642 100%); --border-img_6320_321: #51674b; --text-img_6320_321: #42563c; }
+.btn-img_6320_321 { background-image: var(--gradient-img_6320_321); border:1px solid var(--border-img_6320_321); color:var(--text-img_6320_321); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_321 { background-image: var(--gradient-img_6320_321); border:1px solid var(--border-img_6320_321); color:var(--text-img_6320_321); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_322: linear-gradient(180deg, #476240 0%, #475743 100%); --border-img_6320_322: #555f52; --text-img_6320_322: #3f5e36; }
+.btn-img_6320_322 { background-image: var(--gradient-img_6320_322); border:1px solid var(--border-img_6320_322); color:var(--text-img_6320_322); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_322 { background-image: var(--gradient-img_6320_322); border:1px solid var(--border-img_6320_322); color:var(--text-img_6320_322); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_323: linear-gradient(180deg, #476540 0%, #475842 100%); --border-img_6320_323: #545e50; --text-img_6320_323: #486540; }
+.btn-img_6320_323 { background-image: var(--gradient-img_6320_323); border:1px solid var(--border-img_6320_323); color:var(--text-img_6320_323); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_323 { background-image: var(--gradient-img_6320_323); border:1px solid var(--border-img_6320_323); color:var(--text-img_6320_323); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_324: linear-gradient(180deg, #3f6436 0%, #35502e 100%); --border-img_6320_324: #4a6144; --text-img_6320_324: #93a18e; }
+.btn-img_6320_324 { background-image: var(--gradient-img_6320_324); border:1px solid var(--border-img_6320_324); color:var(--text-img_6320_324); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_324 { background-image: var(--gradient-img_6320_324); border:1px solid var(--border-img_6320_324); color:var(--text-img_6320_324); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_325: linear-gradient(180deg, #414d3f 0%, #40433f 100%); --border-img_6320_325: #4a5945; --text-img_6320_325: #3f3f3f; }
+.btn-img_6320_325 { background-image: var(--gradient-img_6320_325); border:1px solid var(--border-img_6320_325); color:var(--text-img_6320_325); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_325 { background-image: var(--gradient-img_6320_325); border:1px solid var(--border-img_6320_325); color:var(--text-img_6320_325); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_326: linear-gradient(180deg, #52624e 0%, #3f3f3f 100%); --border-img_6320_326: #535951; --text-img_6320_326: #586b54; }
+.btn-img_6320_326 { background-image: var(--gradient-img_6320_326); border:1px solid var(--border-img_6320_326); color:var(--text-img_6320_326); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_326 { background-image: var(--gradient-img_6320_326); border:1px solid var(--border-img_6320_326); color:var(--text-img_6320_326); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_327: linear-gradient(180deg, #ece9e9 0%, #3f3f3f 100%); --border-img_6320_327: #6b7567; --text-img_6320_327: #375430; }
+.btn-img_6320_327 { background-image: var(--gradient-img_6320_327); border:1px solid var(--border-img_6320_327); color:var(--text-img_6320_327); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_327 { background-image: var(--gradient-img_6320_327); border:1px solid var(--border-img_6320_327); color:var(--text-img_6320_327); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_328: linear-gradient(180deg, #3f513a 0%, #3f3f3f 100%); --border-img_6320_328: #565d53; --text-img_6320_328: #41563c; }
+.btn-img_6320_328 { background-image: var(--gradient-img_6320_328); border:1px solid var(--border-img_6320_328); color:var(--text-img_6320_328); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_328 { background-image: var(--gradient-img_6320_328); border:1px solid var(--border-img_6320_328); color:var(--text-img_6320_328); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_329: linear-gradient(180deg, #ece9e9 0%, #3f3f3f 100%); --border-img_6320_329: #6b7567; --text-img_6320_329: #375330; }
+.btn-img_6320_329 { background-image: var(--gradient-img_6320_329); border:1px solid var(--border-img_6320_329); color:var(--text-img_6320_329); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_329 { background-image: var(--gradient-img_6320_329); border:1px solid var(--border-img_6320_329); color:var(--text-img_6320_329); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_330: linear-gradient(180deg, #40463e 0%, #3f3f3f 100%); --border-img_6320_330: #4a5447; --text-img_6320_330: #40433f; }
+.btn-img_6320_330 { background-image: var(--gradient-img_6320_330); border:1px solid var(--border-img_6320_330); color:var(--text-img_6320_330); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_330 { background-image: var(--gradient-img_6320_330); border:1px solid var(--border-img_6320_330); color:var(--text-img_6320_330); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_331: linear-gradient(180deg, #3e5736 0%, #78b967 100%); --border-img_6320_331: #516d4a; --text-img_6320_331: #3f3f3f; }
+.btn-img_6320_331 { background-image: var(--gradient-img_6320_331); border:1px solid var(--border-img_6320_331); color:var(--text-img_6320_331); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_331 { background-image: var(--gradient-img_6320_331); border:1px solid var(--border-img_6320_331); color:var(--text-img_6320_331); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_332: linear-gradient(180deg, #3f4e3b 0%, #648c5a 100%); --border-img_6320_332: #56794d; --text-img_6320_332: #3f3f3f; }
+.btn-img_6320_332 { background-image: var(--gradient-img_6320_332); border:1px solid var(--border-img_6320_332); color:var(--text-img_6320_332); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_332 { background-image: var(--gradient-img_6320_332); border:1px solid var(--border-img_6320_332); color:var(--text-img_6320_332); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_333: linear-gradient(180deg, #3c4c38 0%, #5f8455 100%); --border-img_6320_333: #53744a; --text-img_6320_333: #3f3f3f; }
+.btn-img_6320_333 { background-image: var(--gradient-img_6320_333); border:1px solid var(--border-img_6320_333); color:var(--text-img_6320_333); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_333 { background-image: var(--gradient-img_6320_333); border:1px solid var(--border-img_6320_333); color:var(--text-img_6320_333); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_334: linear-gradient(180deg, #495047 0%, #85a97d 100%); --border-img_6320_334: #63775e; --text-img_6320_334: #76bb65; }
+.btn-img_6320_334 { background-image: var(--gradient-img_6320_334); border:1px solid var(--border-img_6320_334); color:var(--text-img_6320_334); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_334 { background-image: var(--gradient-img_6320_334); border:1px solid var(--border-img_6320_334); color:var(--text-img_6320_334); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_335: linear-gradient(180deg, #4e574a 0%, #b2d1aa 100%); --border-img_6320_335: #657a60; --text-img_6320_335: #76bb65; }
+.btn-img_6320_335 { background-image: var(--gradient-img_6320_335); border:1px solid var(--border-img_6320_335); color:var(--text-img_6320_335); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_335 { background-image: var(--gradient-img_6320_335); border:1px solid var(--border-img_6320_335); color:var(--text-img_6320_335); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_336: linear-gradient(180deg, #4f5e4a 0%, #fcfdfc 100%); --border-img_6320_336: #719c67; --text-img_6320_336: #79bc68; }
+.btn-img_6320_336 { background-image: var(--gradient-img_6320_336); border:1px solid var(--border-img_6320_336); color:var(--text-img_6320_336); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_336 { background-image: var(--gradient-img_6320_336); border:1px solid var(--border-img_6320_336); color:var(--text-img_6320_336); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_337: linear-gradient(180deg, #3f3e3e 0%, #526b4c 100%); --border-img_6320_337: #648d5a; --text-img_6320_337: #3f3e3e; }
+.btn-img_6320_337 { background-image: var(--gradient-img_6320_337); border:1px solid var(--border-img_6320_337); color:var(--text-img_6320_337); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_337 { background-image: var(--gradient-img_6320_337); border:1px solid var(--border-img_6320_337); color:var(--text-img_6320_337); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_338: linear-gradient(180deg, #638659 0%, #5e8455 100%); --border-img_6320_338: #6d8966; --text-img_6320_338: #719e66; }
+.btn-img_6320_338 { background-image: var(--gradient-img_6320_338); border:1px solid var(--border-img_6320_338); color:var(--text-img_6320_338); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_338 { background-image: var(--gradient-img_6320_338); border:1px solid var(--border-img_6320_338); color:var(--text-img_6320_338); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_339: linear-gradient(180deg, #7dc36a 0%, #ffffff 100%); --border-img_6320_339: #a5d599; --text-img_6320_339: #76bb65; }
+.btn-img_6320_339 { background-image: var(--gradient-img_6320_339); border:1px solid var(--border-img_6320_339); color:var(--text-img_6320_339); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_339 { background-image: var(--gradient-img_6320_339); border:1px solid var(--border-img_6320_339); color:var(--text-img_6320_339); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_340: linear-gradient(180deg, #5c7c53 0%, #597b51 100%); --border-img_6320_340: #7fae74; --text-img_6320_340: #608557; }
+.btn-img_6320_340 { background-image: var(--gradient-img_6320_340); border:1px solid var(--border-img_6320_340); color:var(--text-img_6320_340); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_340 { background-image: var(--gradient-img_6320_340); border:1px solid var(--border-img_6320_340); color:var(--text-img_6320_340); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_341: linear-gradient(180deg, #7dc36a 0%, #ffffff 100%); --border-img_6320_341: #a5d499; --text-img_6320_341: #76bb65; }
+.btn-img_6320_341 { background-image: var(--gradient-img_6320_341); border:1px solid var(--border-img_6320_341); color:var(--text-img_6320_341); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_341 { background-image: var(--gradient-img_6320_341); border:1px solid var(--border-img_6320_341); color:var(--text-img_6320_341); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_342: linear-gradient(180deg, #536a4c 0%, #526c4b 100%); --border-img_6320_342: #659658; --text-img_6320_342: #485545; }
+.btn-img_6320_342 { background-image: var(--gradient-img_6320_342); border:1px solid var(--border-img_6320_342); color:var(--text-img_6320_342); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_342 { background-image: var(--gradient-img_6320_342); border:1px solid var(--border-img_6320_342); color:var(--text-img_6320_342); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_343: linear-gradient(180deg, #a4cb9a 0%, #7fb871 100%); --border-img_6320_343: #677d62; --text-img_6320_343: #77b469; }
+.btn-img_6320_343 { background-image: var(--gradient-img_6320_343); border:1px solid var(--border-img_6320_343); color:var(--text-img_6320_343); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_343 { background-image: var(--gradient-img_6320_343); border:1px solid var(--border-img_6320_343); color:var(--text-img_6320_343); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_344: linear-gradient(180deg, #618857 0%, #556f4e 100%); --border-img_6320_344: #74956c; --text-img_6320_344: #597b51; }
+.btn-img_6320_344 { background-image: var(--gradient-img_6320_344); border:1px solid var(--border-img_6320_344); color:var(--text-img_6320_344); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_344 { background-image: var(--gradient-img_6320_344); border:1px solid var(--border-img_6320_344); color:var(--text-img_6320_344); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_345: linear-gradient(180deg, #5c8052 0%, #546f4e 100%); --border-img_6320_345: #688c5f; --text-img_6320_345: #597a51; }
+.btn-img_6320_345 { background-image: var(--gradient-img_6320_345); border:1px solid var(--border-img_6320_345); color:var(--text-img_6320_345); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_345 { background-image: var(--gradient-img_6320_345); border:1px solid var(--border-img_6320_345); color:var(--text-img_6320_345); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_346: linear-gradient(180deg, #5c8053 0%, #445142 100%); --border-img_6320_346: #4d6048; --text-img_6320_346: #474c45; }
+.btn-img_6320_346 { background-image: var(--gradient-img_6320_346); border:1px solid var(--border-img_6320_346); color:var(--text-img_6320_346); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_346 { background-image: var(--gradient-img_6320_346); border:1px solid var(--border-img_6320_346); color:var(--text-img_6320_346); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_347: linear-gradient(180deg, #69ab5a 0%, #3a3b3a 100%); --border-img_6320_347: #54774d; --text-img_6320_347: #61825a; }
+.btn-img_6320_347 { background-image: var(--gradient-img_6320_347); border:1px solid var(--border-img_6320_347); color:var(--text-img_6320_347); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_347 { background-image: var(--gradient-img_6320_347); border:1px solid var(--border-img_6320_347); color:var(--text-img_6320_347); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_348: linear-gradient(180deg, #57784f 0%, #3c3c3c 100%); --border-img_6320_348: #546e4e; --text-img_6320_348: #414440; }
+.btn-img_6320_348 { background-image: var(--gradient-img_6320_348); border:1px solid var(--border-img_6320_348); color:var(--text-img_6320_348); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_348 { background-image: var(--gradient-img_6320_348); border:1px solid var(--border-img_6320_348); color:var(--text-img_6320_348); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_349: linear-gradient(180deg, #69ab5a 0%, #393939 100%); --border-img_6320_349: #52734b; --text-img_6320_349: #577650; }
+.btn-img_6320_349 { background-image: var(--gradient-img_6320_349); border:1px solid var(--border-img_6320_349); color:var(--text-img_6320_349); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_349 { background-image: var(--gradient-img_6320_349); border:1px solid var(--border-img_6320_349); color:var(--text-img_6320_349); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_350: linear-gradient(180deg, #506a49 0%, #424e3f 100%); --border-img_6320_350: #506f49; --text-img_6320_350: #3e3e3e; }
+.btn-img_6320_350 { background-image: var(--gradient-img_6320_350); border:1px solid var(--border-img_6320_350); color:var(--text-img_6320_350); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_350 { background-image: var(--gradient-img_6320_350); border:1px solid var(--border-img_6320_350); color:var(--text-img_6320_350); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_351: linear-gradient(180deg, #619155 0%, #3c403b 100%); --border-img_6320_351: #4b5a47; --text-img_6320_351: #455142; }
+.btn-img_6320_351 { background-image: var(--gradient-img_6320_351); border:1px solid var(--border-img_6320_351); color:var(--text-img_6320_351); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_351 { background-image: var(--gradient-img_6320_351); border:1px solid var(--border-img_6320_351); color:var(--text-img_6320_351); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_352: linear-gradient(180deg, #68a45a 0%, #3a3f39 100%); --border-img_6320_352: #485844; --text-img_6320_352: #445041; }
+.btn-img_6320_352 { background-image: var(--gradient-img_6320_352); border:1px solid var(--border-img_6320_352); color:var(--text-img_6320_352); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_352 { background-image: var(--gradient-img_6320_352); border:1px solid var(--border-img_6320_352); color:var(--text-img_6320_352); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_353: linear-gradient(180deg, #66a757 0%, #363636 100%); --border-img_6320_353: #496044; --text-img_6320_353: #3a3a3a; }
+.btn-img_6320_353 { background-image: var(--gradient-img_6320_353); border:1px solid var(--border-img_6320_353); color:var(--text-img_6320_353); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_353 { background-image: var(--gradient-img_6320_353); border:1px solid var(--border-img_6320_353); color:var(--text-img_6320_353); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_354: linear-gradient(180deg, #4f684a 0%, #3f483c 100%); --border-img_6320_354: #4b6745; --text-img_6320_354: #3e3e3e; }
+.btn-img_6320_354 { background-image: var(--gradient-img_6320_354); border:1px solid var(--border-img_6320_354); color:var(--text-img_6320_354); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_354 { background-image: var(--gradient-img_6320_354); border:1px solid var(--border-img_6320_354); color:var(--text-img_6320_354); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_355: linear-gradient(180deg, #3e3e3e 0%, #6b995f 100%); --border-img_6320_355: #4d5d49; --text-img_6320_355: #373737; }
+.btn-img_6320_355 { background-image: var(--gradient-img_6320_355); border:1px solid var(--border-img_6320_355); color:var(--text-img_6320_355); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_355 { background-image: var(--gradient-img_6320_355); border:1px solid var(--border-img_6320_355); color:var(--text-img_6320_355); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_356: linear-gradient(180deg, #3c3c3c 0%, #3e433c 100%); --border-img_6320_356: #40483e; --text-img_6320_356: #3b3b3b; }
+.btn-img_6320_356 { background-image: var(--gradient-img_6320_356); border:1px solid var(--border-img_6320_356); color:var(--text-img_6320_356); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_356 { background-image: var(--gradient-img_6320_356); border:1px solid var(--border-img_6320_356); color:var(--text-img_6320_356); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_357: linear-gradient(180deg, #3a3a3a 0%, #3e453c 100%); --border-img_6320_357: #455541; --text-img_6320_357: #383838; }
+.btn-img_6320_357 { background-image: var(--gradient-img_6320_357); border:1px solid var(--border-img_6320_357); color:var(--text-img_6320_357); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_357 { background-image: var(--gradient-img_6320_357); border:1px solid var(--border-img_6320_357); color:var(--text-img_6320_357); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_358: linear-gradient(180deg, #3e443d 0%, #3c423a 100%); --border-img_6320_358: #60675d; --text-img_6320_358: #455641; }
+.btn-img_6320_358 { background-image: var(--gradient-img_6320_358); border:1px solid var(--border-img_6320_358); color:var(--text-img_6320_358); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_358 { background-image: var(--gradient-img_6320_358); border:1px solid var(--border-img_6320_358); color:var(--text-img_6320_358); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_359: linear-gradient(180deg, #373737 0%, #323232 100%); --border-img_6320_359: #3f483d; --text-img_6320_359: #7bb56b; }
+.btn-img_6320_359 { background-image: var(--gradient-img_6320_359); border:1px solid var(--border-img_6320_359); color:var(--text-img_6320_359); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_359 { background-image: var(--gradient-img_6320_359); border:1px solid var(--border-img_6320_359); color:var(--text-img_6320_359); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_360: linear-gradient(180deg, #3b3b3b 0%, #393939 100%); --border-img_6320_360: #445540; --text-img_6320_360: #3c3b3b; }
+.btn-img_6320_360 { background-image: var(--gradient-img_6320_360); border:1px solid var(--border-img_6320_360); color:var(--text-img_6320_360); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_360 { background-image: var(--gradient-img_6320_360); border:1px solid var(--border-img_6320_360); color:var(--text-img_6320_360); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_361: linear-gradient(180deg, #373737 0%, #323232 100%); --border-img_6320_361: #383d37; --text-img_6320_361: #4a6444; }
+.btn-img_6320_361 { background-image: var(--gradient-img_6320_361); border:1px solid var(--border-img_6320_361); color:var(--text-img_6320_361); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_361 { background-image: var(--gradient-img_6320_361); border:1px solid var(--border-img_6320_361); color:var(--text-img_6320_361); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_362: linear-gradient(180deg, #44563f 0%, #44523f 100%); --border-img_6320_362: #485d42; --text-img_6320_362: #3f433e; }
+.btn-img_6320_362 { background-image: var(--gradient-img_6320_362); border:1px solid var(--border-img_6320_362); color:var(--text-img_6320_362); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_362 { background-image: var(--gradient-img_6320_362); border:1px solid var(--border-img_6320_362); color:var(--text-img_6320_362); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_363: linear-gradient(180deg, #546e4d 0%, #3d3d3d 100%); --border-img_6320_363: #566752; --text-img_6320_363: #353a34; }
+.btn-img_6320_363 { background-image: var(--gradient-img_6320_363); border:1px solid var(--border-img_6320_363); color:var(--text-img_6320_363); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_363 { background-image: var(--gradient-img_6320_363); border:1px solid var(--border-img_6320_363); color:var(--text-img_6320_363); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_364: linear-gradient(180deg, #638a58 0%, #3d3d3d 100%); --border-img_6320_364: #556950; --text-img_6320_364: #303030; }
+.btn-img_6320_364 { background-image: var(--gradient-img_6320_364); border:1px solid var(--border-img_6320_364); color:var(--text-img_6320_364); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_364 { background-image: var(--gradient-img_6320_364); border:1px solid var(--border-img_6320_364); color:var(--text-img_6320_364); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_365: linear-gradient(180deg, #4a6444 0%, #3d3d3d 100%); --border-img_6320_365: #3a4039; --text-img_6320_365: #303030; }
+.btn-img_6320_365 { background-image: var(--gradient-img_6320_365); border:1px solid var(--border-img_6320_365); color:var(--text-img_6320_365); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_365 { background-image: var(--gradient-img_6320_365); border:1px solid var(--border-img_6320_365); color:var(--text-img_6320_365); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_366: linear-gradient(180deg, #3e463c 0%, #3d3d3d 100%); --border-img_6320_366: #434f40; --text-img_6320_366: #3e3d3d; }
+.btn-img_6320_366 { background-image: var(--gradient-img_6320_366); border:1px solid var(--border-img_6320_366); color:var(--text-img_6320_366); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_366 { background-image: var(--gradient-img_6320_366); border:1px solid var(--border-img_6320_366); color:var(--text-img_6320_366); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_367: linear-gradient(180deg, #353834 0%, #363935 100%); --border-img_6320_367: #393b38; --text-img_6320_367: #424a40; }
+.btn-img_6320_367 { background-image: var(--gradient-img_6320_367); border:1px solid var(--border-img_6320_367); color:var(--text-img_6320_367); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_367 { background-image: var(--gradient-img_6320_367); border:1px solid var(--border-img_6320_367); color:var(--text-img_6320_367); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_368: linear-gradient(180deg, #3a3d39 0%, #3d3f3d 100%); --border-img_6320_368: #383a38; --text-img_6320_368: #3d3d3d; }
+.btn-img_6320_368 { background-image: var(--gradient-img_6320_368); border:1px solid var(--border-img_6320_368); color:var(--text-img_6320_368); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_368 { background-image: var(--gradient-img_6320_368); border:1px solid var(--border-img_6320_368); color:var(--text-img_6320_368); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_369: linear-gradient(180deg, #373736 0%, #3a3a3a 100%); --border-img_6320_369: #3b4039; --text-img_6320_369: #3d3d3d; }
+.btn-img_6320_369 { background-image: var(--gradient-img_6320_369); border:1px solid var(--border-img_6320_369); color:var(--text-img_6320_369); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_369 { background-image: var(--gradient-img_6320_369); border:1px solid var(--border-img_6320_369); color:var(--text-img_6320_369); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_370: linear-gradient(180deg, #3d443b 0%, #3e433d 100%); --border-img_6320_370: #464a44; --text-img_6320_370: #3d3d3d; }
+.btn-img_6320_370 { background-image: var(--gradient-img_6320_370); border:1px solid var(--border-img_6320_370); color:var(--text-img_6320_370); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_370 { background-image: var(--gradient-img_6320_370); border:1px solid var(--border-img_6320_370); color:var(--text-img_6320_370); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_371: linear-gradient(180deg, #2f3030 0%, #2f2f2f 100%); --border-img_6320_371: #363936; --text-img_6320_371: #494f47; }
+.btn-img_6320_371 { background-image: var(--gradient-img_6320_371); border:1px solid var(--border-img_6320_371); color:var(--text-img_6320_371); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_371 { background-image: var(--gradient-img_6320_371); border:1px solid var(--border-img_6320_371); color:var(--text-img_6320_371); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_372: linear-gradient(180deg, #2f2f2f 0%, #383838 100%); --border-img_6320_372: #363636; --text-img_6320_372: #3c3c3c; }
+.btn-img_6320_372 { background-image: var(--gradient-img_6320_372); border:1px solid var(--border-img_6320_372); color:var(--text-img_6320_372); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_372 { background-image: var(--gradient-img_6320_372); border:1px solid var(--border-img_6320_372); color:var(--text-img_6320_372); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_373: linear-gradient(180deg, #424c3f 0%, #3b3b3b 100%); --border-img_6320_373: #3c413b; --text-img_6320_373: #3d3d3d; }
+.btn-img_6320_373 { background-image: var(--gradient-img_6320_373); border:1px solid var(--border-img_6320_373); color:var(--text-img_6320_373); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_373 { background-image: var(--gradient-img_6320_373); border:1px solid var(--border-img_6320_373); color:var(--text-img_6320_373); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_374: linear-gradient(180deg, #3a3d39 0%, #3a3d39 100%); --border-img_6320_374: #4f514e; --text-img_6320_374: #2f2f2f; }
+.btn-img_6320_374 { background-image: var(--gradient-img_6320_374); border:1px solid var(--border-img_6320_374); color:var(--text-img_6320_374); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_374 { background-image: var(--gradient-img_6320_374); border:1px solid var(--border-img_6320_374); color:var(--text-img_6320_374); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_375: linear-gradient(180deg, #343633 0%, #343633 100%); --border-img_6320_375: #474746; --text-img_6320_375: #848484; }
+.btn-img_6320_375 { background-image: var(--gradient-img_6320_375); border:1px solid var(--border-img_6320_375); color:var(--text-img_6320_375); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_375 { background-image: var(--gradient-img_6320_375); border:1px solid var(--border-img_6320_375); color:var(--text-img_6320_375); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_376: linear-gradient(180deg, #373737 0%, #303030 100%); --border-img_6320_376: #414341; --text-img_6320_376: #e5ffdf; }
+.btn-img_6320_376 { background-image: var(--gradient-img_6320_376); border:1px solid var(--border-img_6320_376); color:var(--text-img_6320_376); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_376 { background-image: var(--gradient-img_6320_376); border:1px solid var(--border-img_6320_376); color:var(--text-img_6320_376); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_377: linear-gradient(180deg, #3a3a3a 0%, #383737 100%); --border-img_6320_377: #3f413f; --text-img_6320_377: #3d3d3d; }
+.btn-img_6320_377 { background-image: var(--gradient-img_6320_377); border:1px solid var(--border-img_6320_377); color:var(--text-img_6320_377); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_377 { background-image: var(--gradient-img_6320_377); border:1px solid var(--border-img_6320_377); color:var(--text-img_6320_377); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_378: linear-gradient(180deg, #353835 0%, #353835 100%); --border-img_6320_378: #424342; --text-img_6320_378: #828282; }
+.btn-img_6320_378 { background-image: var(--gradient-img_6320_378); border:1px solid var(--border-img_6320_378); color:var(--text-img_6320_378); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_378 { background-image: var(--gradient-img_6320_378); border:1px solid var(--border-img_6320_378); color:var(--text-img_6320_378); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_379: linear-gradient(180deg, #3b3d3b 0%, #393a38 100%); --border-img_6320_379: #4d504c; --text-img_6320_379: #3a3a3a; }
+.btn-img_6320_379 { background-image: var(--gradient-img_6320_379); border:1px solid var(--border-img_6320_379); color:var(--text-img_6320_379); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_379 { background-image: var(--gradient-img_6320_379); border:1px solid var(--border-img_6320_379); color:var(--text-img_6320_379); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_380: linear-gradient(180deg, #393939 0%, #363535 100%); --border-img_6320_380: #444644; --text-img_6320_380: #363636; }
+.btn-img_6320_380 { background-image: var(--gradient-img_6320_380); border:1px solid var(--border-img_6320_380); color:var(--text-img_6320_380); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_380 { background-image: var(--gradient-img_6320_380); border:1px solid var(--border-img_6320_380); color:var(--text-img_6320_380); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_381: linear-gradient(180deg, #3e433d 0%, #3f433e 100%); --border-img_6320_381: #5d635b; --text-img_6320_381: #4f5c4c; }
+.btn-img_6320_381 { background-image: var(--gradient-img_6320_381); border:1px solid var(--border-img_6320_381); color:var(--text-img_6320_381); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_381 { background-image: var(--gradient-img_6320_381); border:1px solid var(--border-img_6320_381); color:var(--text-img_6320_381); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_382: linear-gradient(180deg, #767676 0%, #2f2f2f 100%); --border-img_6320_382: #4a4a4a; --text-img_6320_382: #959595; }
+.btn-img_6320_382 { background-image: var(--gradient-img_6320_382); border:1px solid var(--border-img_6320_382); color:var(--text-img_6320_382); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_382 { background-image: var(--gradient-img_6320_382); border:1px solid var(--border-img_6320_382); color:var(--text-img_6320_382); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_383: linear-gradient(180deg, #3a3a3a 0%, #383838 100%); --border-img_6320_383: #424441; --text-img_6320_383: #3b3b3b; }
+.btn-img_6320_383 { background-image: var(--gradient-img_6320_383); border:1px solid var(--border-img_6320_383); color:var(--text-img_6320_383); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_383 { background-image: var(--gradient-img_6320_383); border:1px solid var(--border-img_6320_383); color:var(--text-img_6320_383); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_384: linear-gradient(180deg, #8e9b8b 0%, #303030 100%); --border-img_6320_384: #565b55; --text-img_6320_384: #a1b19d; }
+.btn-img_6320_384 { background-image: var(--gradient-img_6320_384); border:1px solid var(--border-img_6320_384); color:var(--text-img_6320_384); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_384 { background-image: var(--gradient-img_6320_384); border:1px solid var(--border-img_6320_384); color:var(--text-img_6320_384); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6320_385: linear-gradient(180deg, #3a3a3a 0%, #393838 100%); --border-img_6320_385: #373736; --text-img_6320_385: #3d3c3c; }
+.btn-img_6320_385 { background-image: var(--gradient-img_6320_385); border:1px solid var(--border-img_6320_385); color:var(--text-img_6320_385); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6320_385 { background-image: var(--gradient-img_6320_385); border:1px solid var(--border-img_6320_385); color:var(--text-img_6320_385); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_386: linear-gradient(180deg, #343739 0%, #495546 100%); --border-img_6321_386: #40523e; --text-img_6321_386: #404040; }
+.btn-img_6321_386 { background-image: var(--gradient-img_6321_386); border:1px solid var(--border-img_6321_386); color:var(--text-img_6321_386); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_386 { background-image: var(--gradient-img_6321_386); border:1px solid var(--border-img_6321_386); color:var(--text-img_6321_386); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_387: linear-gradient(180deg, #4a4d4e 0%, #48763c 100%); --border-img_6321_387: #465e42; --text-img_6321_387: #44583f; }
+.btn-img_6321_387 { background-image: var(--gradient-img_6321_387); border:1px solid var(--border-img_6321_387); color:var(--text-img_6321_387); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_387 { background-image: var(--gradient-img_6321_387); border:1px solid var(--border-img_6321_387); color:var(--text-img_6321_387); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_388: linear-gradient(180deg, #626466 0%, #44593e 100%); --border-img_6321_388: #50624d; --text-img_6321_388: #404040; }
+.btn-img_6321_388 { background-image: var(--gradient-img_6321_388); border:1px solid var(--border-img_6321_388); color:var(--text-img_6321_388); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_388 { background-image: var(--gradient-img_6321_388); border:1px solid var(--border-img_6321_388); color:var(--text-img_6321_388); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_389: linear-gradient(180deg, #46484a 0%, #69a25b 100%); --border-img_6321_389: #557150; --text-img_6321_389: #434a41; }
+.btn-img_6321_389 { background-image: var(--gradient-img_6321_389); border:1px solid var(--border-img_6321_389); color:var(--text-img_6321_389); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_389 { background-image: var(--gradient-img_6321_389); border:1px solid var(--border-img_6321_389); color:var(--text-img_6321_389); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_390: linear-gradient(180deg, #343739 0%, #536e4c 100%); --border-img_6321_390: #455343; --text-img_6321_390: #404040; }
+.btn-img_6321_390 { background-image: var(--gradient-img_6321_390); border:1px solid var(--border-img_6321_390); color:var(--text-img_6321_390); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_390 { background-image: var(--gradient-img_6321_390); border:1px solid var(--border-img_6321_390); color:var(--text-img_6321_390); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_391: linear-gradient(180deg, #343739 0%, #45613e 100%); --border-img_6321_391: #41563d; --text-img_6321_391: #43543f; }
+.btn-img_6321_391 { background-image: var(--gradient-img_6321_391); border:1px solid var(--border-img_6321_391); color:var(--text-img_6321_391); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_391 { background-image: var(--gradient-img_6321_391); border:1px solid var(--border-img_6321_391); color:var(--text-img_6321_391); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_392: linear-gradient(180deg, #898b8c 0%, #476140 100%); --border-img_6321_392: #597055; --text-img_6321_392: #414840; }
+.btn-img_6321_392 { background-image: var(--gradient-img_6321_392); border:1px solid var(--border-img_6321_392); color:var(--text-img_6321_392); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_392 { background-image: var(--gradient-img_6321_392); border:1px solid var(--border-img_6321_392); color:var(--text-img_6321_392); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_393: linear-gradient(180deg, #343739 0%, #609054 100%); --border-img_6321_393: #475945; --text-img_6321_393: #56774e; }
+.btn-img_6321_393 { background-image: var(--gradient-img_6321_393); border:1px solid var(--border-img_6321_393); color:var(--text-img_6321_393); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_393 { background-image: var(--gradient-img_6321_393); border:1px solid var(--border-img_6321_393); color:var(--text-img_6321_393); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_394: linear-gradient(180deg, #343739 0%, #495b44 100%); --border-img_6321_394: #42593e; --text-img_6321_394: #404040; }
+.btn-img_6321_394 { background-image: var(--gradient-img_6321_394); border:1px solid var(--border-img_6321_394); color:var(--text-img_6321_394); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_394 { background-image: var(--gradient-img_6321_394); border:1px solid var(--border-img_6321_394); color:var(--text-img_6321_394); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_395: linear-gradient(180deg, #343739 0%, #779b6d 100%); --border-img_6321_395: #62785e; --text-img_6321_395: #47763b; }
+.btn-img_6321_395 { background-image: var(--gradient-img_6321_395); border:1px solid var(--border-img_6321_395); color:var(--text-img_6321_395); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_395 { background-image: var(--gradient-img_6321_395); border:1px solid var(--border-img_6321_395); color:var(--text-img_6321_395); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_396: linear-gradient(180deg, #343739 0%, #5c8951 100%); --border-img_6321_396: #636f60; --text-img_6321_396: #689f5a; }
+.btn-img_6321_396 { background-image: var(--gradient-img_6321_396); border:1px solid var(--border-img_6321_396); color:var(--text-img_6321_396); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_396 { background-image: var(--gradient-img_6321_396); border:1px solid var(--border-img_6321_396); color:var(--text-img_6321_396); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_397: linear-gradient(180deg, #343739 0%, #55764c 100%); --border-img_6321_397: #465644; --text-img_6321_397: #608d54; }
+.btn-img_6321_397 { background-image: var(--gradient-img_6321_397); border:1px solid var(--border-img_6321_397); color:var(--text-img_6321_397); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_397 { background-image: var(--gradient-img_6321_397); border:1px solid var(--border-img_6321_397); color:var(--text-img_6321_397); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_398: linear-gradient(180deg, #495646 0%, #4b5848 100%); --border-img_6321_398: #527948; --text-img_6321_398: #404040; }
+.btn-img_6321_398 { background-image: var(--gradient-img_6321_398); border:1px solid var(--border-img_6321_398); color:var(--text-img_6321_398); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_398 { background-image: var(--gradient-img_6321_398); border:1px solid var(--border-img_6321_398); color:var(--text-img_6321_398); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_399: linear-gradient(180deg, #f5f5f5 0%, #528c44 100%); --border-img_6321_399: #769f6b; --text-img_6321_399: #8bae83; }
+.btn-img_6321_399 { background-image: var(--gradient-img_6321_399); border:1px solid var(--border-img_6321_399); color:var(--text-img_6321_399); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_399 { background-image: var(--gradient-img_6321_399); border:1px solid var(--border-img_6321_399); color:var(--text-img_6321_399); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_400: linear-gradient(180deg, #455b3f 0%, #465d40 100%); --border-img_6321_400: #57774f; --text-img_6321_400: #43543f; }
+.btn-img_6321_400 { background-image: var(--gradient-img_6321_400); border:1px solid var(--border-img_6321_400); color:var(--text-img_6321_400); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_400 { background-image: var(--gradient-img_6321_400); border:1px solid var(--border-img_6321_400); color:var(--text-img_6321_400); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_401: linear-gradient(180deg, #c3cebd 0%, #3f543a 100%); --border-img_6321_401: #65805e; --text-img_6321_401: #9dac98; }
+.btn-img_6321_401 { background-image: var(--gradient-img_6321_401); border:1px solid var(--border-img_6321_401); color:var(--text-img_6321_401); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_401 { background-image: var(--gradient-img_6321_401); border:1px solid var(--border-img_6321_401); color:var(--text-img_6321_401); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_402: linear-gradient(180deg, #4d6448 0%, #414c3e 100%); --border-img_6321_402: #53604f; --text-img_6321_402: #475942; }
+.btn-img_6321_402 { background-image: var(--gradient-img_6321_402); border:1px solid var(--border-img_6321_402); color:var(--text-img_6321_402); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_402 { background-image: var(--gradient-img_6321_402); border:1px solid var(--border-img_6321_402); color:var(--text-img_6321_402); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_403: linear-gradient(180deg, #697c64 0%, #403f3f 100%); --border-img_6321_403: #60765a; --text-img_6321_403: #4b7241; }
+.btn-img_6321_403 { background-image: var(--gradient-img_6321_403); border:1px solid var(--border-img_6321_403); color:var(--text-img_6321_403); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_403 { background-image: var(--gradient-img_6321_403); border:1px solid var(--border-img_6321_403); color:var(--text-img_6321_403); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_404: linear-gradient(180deg, #586e52 0%, #403f3f 100%); --border-img_6321_404: #62735d; --text-img_6321_404: #455b40; }
+.btn-img_6321_404 { background-image: var(--gradient-img_6321_404); border:1px solid var(--border-img_6321_404); color:var(--text-img_6321_404); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_404 { background-image: var(--gradient-img_6321_404); border:1px solid var(--border-img_6321_404); color:var(--text-img_6321_404); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_405: linear-gradient(180deg, #a5b29f 0%, #403f3f 100%); --border-img_6321_405: #61685f; --text-img_6321_405: #466140; }
+.btn-img_6321_405 { background-image: var(--gradient-img_6321_405); border:1px solid var(--border-img_6321_405); color:var(--text-img_6321_405); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_405 { background-image: var(--gradient-img_6321_405); border:1px solid var(--border-img_6321_405); color:var(--text-img_6321_405); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_406: linear-gradient(180deg, #4a5d45 0%, #4a5548 100%); --border-img_6321_406: #506f48; --text-img_6321_406: #403f3f; }
+.btn-img_6321_406 { background-image: var(--gradient-img_6321_406); border:1px solid var(--border-img_6321_406); color:var(--text-img_6321_406); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_406 { background-image: var(--gradient-img_6321_406); border:1px solid var(--border-img_6321_406); color:var(--text-img_6321_406); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_407: linear-gradient(180deg, #4f8441 0%, #436c39 100%); --border-img_6321_407: #6a8862; --text-img_6321_407: #4c7641; }
+.btn-img_6321_407 { background-image: var(--gradient-img_6321_407); border:1px solid var(--border-img_6321_407); color:var(--text-img_6321_407); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_407 { background-image: var(--gradient-img_6321_407); border:1px solid var(--border-img_6321_407); color:var(--text-img_6321_407); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_408: linear-gradient(180deg, #8e9f88 0%, #485f43 100%); --border-img_6321_408: #5c6659; --text-img_6321_408: #40523c; }
+.btn-img_6321_408 { background-image: var(--gradient-img_6321_408); border:1px solid var(--border-img_6321_408); color:var(--text-img_6321_408); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_408 { background-image: var(--gradient-img_6321_408); border:1px solid var(--border-img_6321_408); color:var(--text-img_6321_408); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_409: linear-gradient(180deg, #65775f 0%, #465642 100%); --border-img_6321_409: #565f53; --text-img_6321_409: #42513d; }
+.btn-img_6321_409 { background-image: var(--gradient-img_6321_409); border:1px solid var(--border-img_6321_409); color:var(--text-img_6321_409); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_409 { background-image: var(--gradient-img_6321_409); border:1px solid var(--border-img_6321_409); color:var(--text-img_6321_409); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_410: linear-gradient(180deg, #403f3f 0%, #495047 100%); --border-img_6321_410: #43563e; --text-img_6321_410: #3f3f3f; }
+.btn-img_6321_410 { background-image: var(--gradient-img_6321_410); border:1px solid var(--border-img_6321_410); color:var(--text-img_6321_410); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_410 { background-image: var(--gradient-img_6321_410); border:1px solid var(--border-img_6321_410); color:var(--text-img_6321_410); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_411: linear-gradient(180deg, #403f3f 0%, #b9c1b4 100%); --border-img_6321_411: #5b6d55; --text-img_6321_411: #426a38; }
+.btn-img_6321_411 { background-image: var(--gradient-img_6321_411); border:1px solid var(--border-img_6321_411); color:var(--text-img_6321_411); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_411 { background-image: var(--gradient-img_6321_411); border:1px solid var(--border-img_6321_411); color:var(--text-img_6321_411); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_412: linear-gradient(180deg, #403f3f 0%, #40503c 100%); --border-img_6321_412: #41513d; --text-img_6321_412: #434f40; }
+.btn-img_6321_412 { background-image: var(--gradient-img_6321_412); border:1px solid var(--border-img_6321_412); color:var(--text-img_6321_412); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_412 { background-image: var(--gradient-img_6321_412); border:1px solid var(--border-img_6321_412); color:var(--text-img_6321_412); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_413: linear-gradient(180deg, #403f3f 0%, #a7aea3 100%); --border-img_6321_413: #5c6658; --text-img_6321_413: #486042; }
+.btn-img_6321_413 { background-image: var(--gradient-img_6321_413); border:1px solid var(--border-img_6321_413); color:var(--text-img_6321_413); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_413 { background-image: var(--gradient-img_6321_413); border:1px solid var(--border-img_6321_413); color:var(--text-img_6321_413); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_414: linear-gradient(180deg, #403f3f 0%, #414b3f 100%); --border-img_6321_414: #41483f; --text-img_6321_414: #434e41; }
+.btn-img_6321_414 { background-image: var(--gradient-img_6321_414); border:1px solid var(--border-img_6321_414); color:var(--text-img_6321_414); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_414 { background-image: var(--gradient-img_6321_414); border:1px solid var(--border-img_6321_414); color:var(--text-img_6321_414); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_415: linear-gradient(180deg, #42593c 0%, #4e5d4a 100%); --border-img_6321_415: #526c4b; --text-img_6321_415: #425c3b; }
+.btn-img_6321_415 { background-image: var(--gradient-img_6321_415); border:1px solid var(--border-img_6321_415); color:var(--text-img_6321_415); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_415 { background-image: var(--gradient-img_6321_415); border:1px solid var(--border-img_6321_415); color:var(--text-img_6321_415); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_416: linear-gradient(180deg, #42563d 0%, #3f4f3a 100%); --border-img_6321_416: #546a4e; --text-img_6321_416: #42513e; }
+.btn-img_6321_416 { background-image: var(--gradient-img_6321_416); border:1px solid var(--border-img_6321_416); color:var(--text-img_6321_416); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_416 { background-image: var(--gradient-img_6321_416); border:1px solid var(--border-img_6321_416); color:var(--text-img_6321_416); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_417: linear-gradient(180deg, #485e43 0%, #949991 100%); --border-img_6321_417: #515d4e; --text-img_6321_417: #43593e; }
+.btn-img_6321_417 { background-image: var(--gradient-img_6321_417); border:1px solid var(--border-img_6321_417); color:var(--text-img_6321_417); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_417 { background-image: var(--gradient-img_6321_417); border:1px solid var(--border-img_6321_417); color:var(--text-img_6321_417); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_418: linear-gradient(180deg, #485445 0%, #444942 100%); --border-img_6321_418: #495d44; --text-img_6321_418: #3f3f3f; }
+.btn-img_6321_418 { background-image: var(--gradient-img_6321_418); border:1px solid var(--border-img_6321_418); color:var(--text-img_6321_418); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_418 { background-image: var(--gradient-img_6321_418); border:1px solid var(--border-img_6321_418); color:var(--text-img_6321_418); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_419: linear-gradient(180deg, #3f6436 0%, #35502e 100%); --border-img_6321_419: #4d6347; --text-img_6321_419: #93a18e; }
+.btn-img_6321_419 { background-image: var(--gradient-img_6321_419); border:1px solid var(--border-img_6321_419); color:var(--text-img_6321_419); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_419 { background-image: var(--gradient-img_6321_419); border:1px solid var(--border-img_6321_419); color:var(--text-img_6321_419); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_420: linear-gradient(180deg, #44583f 0%, #3a4537 100%); --border-img_6321_420: #525950; --text-img_6321_420: #657160; }
+.btn-img_6321_420 { background-image: var(--gradient-img_6321_420); border:1px solid var(--border-img_6321_420); color:var(--text-img_6321_420); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_420 { background-image: var(--gradient-img_6321_420); border:1px solid var(--border-img_6321_420); color:var(--text-img_6321_420); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_421: linear-gradient(180deg, #43523f 0%, #3c4439 100%); --border-img_6321_421: #4c534a; --text-img_6321_421: #3e4f3a; }
+.btn-img_6321_421 { background-image: var(--gradient-img_6321_421); border:1px solid var(--border-img_6321_421); color:var(--text-img_6321_421); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_421 { background-image: var(--gradient-img_6321_421); border:1px solid var(--border-img_6321_421); color:var(--text-img_6321_421); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_422: linear-gradient(180deg, #484f46 0%, #3f3f3f 100%); --border-img_6321_422: #455341; --text-img_6321_422: #3f3f3f; }
+.btn-img_6321_422 { background-image: var(--gradient-img_6321_422); border:1px solid var(--border-img_6321_422); color:var(--text-img_6321_422); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_422 { background-image: var(--gradient-img_6321_422); border:1px solid var(--border-img_6321_422); color:var(--text-img_6321_422); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_423: linear-gradient(180deg, #ece9e9 0%, #3f3f3f 100%); --border-img_6321_423: #727b6e; --text-img_6321_423: #375330; }
+.btn-img_6321_423 { background-image: var(--gradient-img_6321_423); border:1px solid var(--border-img_6321_423); color:var(--text-img_6321_423); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_423 { background-image: var(--gradient-img_6321_423); border:1px solid var(--border-img_6321_423); color:var(--text-img_6321_423); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_424: linear-gradient(180deg, #3f4e3b 0%, #3f3f3f 100%); --border-img_6321_424: #495345; --text-img_6321_424: #434f40; }
+.btn-img_6321_424 { background-image: var(--gradient-img_6321_424); border:1px solid var(--border-img_6321_424); color:var(--text-img_6321_424); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_424 { background-image: var(--gradient-img_6321_424); border:1px solid var(--border-img_6321_424); color:var(--text-img_6321_424); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_425: linear-gradient(180deg, #ece9e9 0%, #3f3f3f 100%); --border-img_6321_425: #6d726a; --text-img_6321_425: #3a4836; }
+.btn-img_6321_425 { background-image: var(--gradient-img_6321_425); border:1px solid var(--border-img_6321_425); color:var(--text-img_6321_425); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_425 { background-image: var(--gradient-img_6321_425); border:1px solid var(--border-img_6321_425); color:var(--text-img_6321_425); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_426: linear-gradient(180deg, #40483d 0%, #3f3f3f 100%); --border-img_6321_426: #4d514c; --text-img_6321_426: #3f473d; }
+.btn-img_6321_426 { background-image: var(--gradient-img_6321_426); border:1px solid var(--border-img_6321_426); color:var(--text-img_6321_426); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_426 { background-image: var(--gradient-img_6321_426); border:1px solid var(--border-img_6321_426); color:var(--text-img_6321_426); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_427: linear-gradient(180deg, #3c4c37 0%, #628b58 100%); --border-img_6321_427: #56794d; --text-img_6321_427: #3f3f3f; }
+.btn-img_6321_427 { background-image: var(--gradient-img_6321_427); border:1px solid var(--border-img_6321_427); color:var(--text-img_6321_427); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_427 { background-image: var(--gradient-img_6321_427); border:1px solid var(--border-img_6321_427); color:var(--text-img_6321_427); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_428: linear-gradient(180deg, #3d4b38 0%, #5e8455 100%); --border-img_6321_428: #53744a; --text-img_6321_428: #3f3f3f; }
+.btn-img_6321_428 { background-image: var(--gradient-img_6321_428); border:1px solid var(--border-img_6321_428); color:var(--text-img_6321_428); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_428 { background-image: var(--gradient-img_6321_428); border:1px solid var(--border-img_6321_428); color:var(--text-img_6321_428); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_429: linear-gradient(180deg, #3a4737 0%, #73b263 100%); --border-img_6321_429: #4e6648; --text-img_6321_429: #3f3f3f; }
+.btn-img_6321_429 { background-image: var(--gradient-img_6321_429); border:1px solid var(--border-img_6321_429); color:var(--text-img_6321_429); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_429 { background-image: var(--gradient-img_6321_429); border:1px solid var(--border-img_6321_429); color:var(--text-img_6321_429); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_430: linear-gradient(180deg, #3f3e3e 0%, #597652 100%); --border-img_6321_430: #6f9565; --text-img_6321_430: #3f3e3e; }
+.btn-img_6321_430 { background-image: var(--gradient-img_6321_430); border:1px solid var(--border-img_6321_430); color:var(--text-img_6321_430); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_430 { background-image: var(--gradient-img_6321_430); border:1px solid var(--border-img_6321_430); color:var(--text-img_6321_430); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_431: linear-gradient(180deg, #4f5e4a 0%, #fafcf9 100%); --border-img_6321_431: #729c68; --text-img_6321_431: #76bb65; }
+.btn-img_6321_431 { background-image: var(--gradient-img_6321_431); border:1px solid var(--border-img_6321_431); color:var(--text-img_6321_431); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_431 { background-image: var(--gradient-img_6321_431); border:1px solid var(--border-img_6321_431); color:var(--text-img_6321_431); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_432: linear-gradient(180deg, #464e43 0%, #5d974f 100%); --border-img_6321_432: #506b49; --text-img_6321_432: #76bb65; }
+.btn-img_6321_432 { background-image: var(--gradient-img_6321_432); border:1px solid var(--border-img_6321_432); color:var(--text-img_6321_432); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_432 { background-image: var(--gradient-img_6321_432); border:1px solid var(--border-img_6321_432); color:var(--text-img_6321_432); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_433: linear-gradient(180deg, #434841 0%, #59854e 100%); --border-img_6321_433: #506949; --text-img_6321_433: #75b964; }
+.btn-img_6321_433 { background-image: var(--gradient-img_6321_433); border:1px solid var(--border-img_6321_433); color:var(--text-img_6321_433); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_433 { background-image: var(--gradient-img_6321_433); border:1px solid var(--border-img_6321_433); color:var(--text-img_6321_433); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_434: linear-gradient(180deg, #586e52 0%, #567050 100%); --border-img_6321_434: #76a66a; --text-img_6321_434: #4d554a; }
+.btn-img_6321_434 { background-image: var(--gradient-img_6321_434); border:1px solid var(--border-img_6321_434); color:var(--text-img_6321_434); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_434 { background-image: var(--gradient-img_6321_434); border:1px solid var(--border-img_6321_434); color:var(--text-img_6321_434); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_435: linear-gradient(180deg, #7dc36a 0%, #ffffff 100%); --border-img_6321_435: #a6d49a; --text-img_6321_435: #78bc66; }
+.btn-img_6321_435 { background-image: var(--gradient-img_6321_435); border:1px solid var(--border-img_6321_435); color:var(--text-img_6321_435); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_435 { background-image: var(--gradient-img_6321_435); border:1px solid var(--border-img_6321_435); color:var(--text-img_6321_435); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_436: linear-gradient(180deg, #566e4f 0%, #54704d 100%); --border-img_6321_436: #739f68; --text-img_6321_436: #4f5f4b; }
+.btn-img_6321_436 { background-image: var(--gradient-img_6321_436); border:1px solid var(--border-img_6321_436); color:var(--text-img_6321_436); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_436 { background-image: var(--gradient-img_6321_436); border:1px solid var(--border-img_6321_436); color:var(--text-img_6321_436); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_437: linear-gradient(180deg, #7dc36a 0%, #508842 100%); --border-img_6321_437: #6cad5b; --text-img_6321_437: #76bb64; }
+.btn-img_6321_437 { background-image: var(--gradient-img_6321_437); border:1px solid var(--border-img_6321_437); color:var(--text-img_6321_437); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_437 { background-image: var(--gradient-img_6321_437); border:1px solid var(--border-img_6321_437); color:var(--text-img_6321_437); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_438: linear-gradient(180deg, #597851 0%, #57784f 100%); --border-img_6321_438: #55744d; --text-img_6321_438: #597b50; }
+.btn-img_6321_438 { background-image: var(--gradient-img_6321_438); border:1px solid var(--border-img_6321_438); color:var(--text-img_6321_438); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_438 { background-image: var(--gradient-img_6321_438); border:1px solid var(--border-img_6321_438); color:var(--text-img_6321_438); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_439: linear-gradient(180deg, #5f8755 0%, #577550 100%); --border-img_6321_439: #729469; --text-img_6321_439: #608c55; }
+.btn-img_6321_439 { background-image: var(--gradient-img_6321_439); border:1px solid var(--border-img_6321_439); color:var(--text-img_6321_439); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_439 { background-image: var(--gradient-img_6321_439); border:1px solid var(--border-img_6321_439); color:var(--text-img_6321_439); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_440: linear-gradient(180deg, #5c8052 0%, #52694c 100%); --border-img_6321_440: #658a5c; --text-img_6321_440: #52694c; }
+.btn-img_6321_440 { background-image: var(--gradient-img_6321_440); border:1px solid var(--border-img_6321_440); color:var(--text-img_6321_440); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_440 { background-image: var(--gradient-img_6321_440); border:1px solid var(--border-img_6321_440); color:var(--text-img_6321_440); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_441: linear-gradient(180deg, #6aa65b 0%, #5d8c52 100%); --border-img_6321_441: #4e6948; --text-img_6321_441: #69aa59; }
+.btn-img_6321_441 { background-image: var(--gradient-img_6321_441); border:1px solid var(--border-img_6321_441); color:var(--text-img_6321_441); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_441 { background-image: var(--gradient-img_6321_441); border:1px solid var(--border-img_6321_441); color:var(--text-img_6321_441); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_442: linear-gradient(180deg, #546d4e 0%, #455142 100%); --border-img_6321_442: #516d4b; --text-img_6321_442: #3e3e3e; }
+.btn-img_6321_442 { background-image: var(--gradient-img_6321_442); border:1px solid var(--border-img_6321_442); color:var(--text-img_6321_442); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_442 { background-image: var(--gradient-img_6321_442); border:1px solid var(--border-img_6321_442); color:var(--text-img_6321_442); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_443: linear-gradient(180deg, #69ab5a 0%, #393939 100%); --border-img_6321_443: #52734b; --text-img_6321_443: #577650; }
+.btn-img_6321_443 { background-image: var(--gradient-img_6321_443); border:1px solid var(--border-img_6321_443); color:var(--text-img_6321_443); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_443 { background-image: var(--gradient-img_6321_443); border:1px solid var(--border-img_6321_443); color:var(--text-img_6321_443); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_444: linear-gradient(180deg, #526d4c 0%, #3b3b3b 100%); --border-img_6321_444: #4e6748; --text-img_6321_444: #3e3e3e; }
+.btn-img_6321_444 { background-image: var(--gradient-img_6321_444); border:1px solid var(--border-img_6321_444); color:var(--text-img_6321_444); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_444 { background-image: var(--gradient-img_6321_444); border:1px solid var(--border-img_6321_444); color:var(--text-img_6321_444); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_445: linear-gradient(180deg, #69ab5a 0%, #4f8742 100%); --border-img_6321_445: #58894d; --text-img_6321_445: #516d4a; }
+.btn-img_6321_445 { background-image: var(--gradient-img_6321_445); border:1px solid var(--border-img_6321_445); color:var(--text-img_6321_445); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_445 { background-image: var(--gradient-img_6321_445); border:1px solid var(--border-img_6321_445); color:var(--text-img_6321_445); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_446: linear-gradient(180deg, #54754c 0%, #44563f 100%); --border-img_6321_446: #4b6345; --text-img_6321_446: #40423f; }
+.btn-img_6321_446 { background-image: var(--gradient-img_6321_446); border:1px solid var(--border-img_6321_446); color:var(--text-img_6321_446); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_446 { background-image: var(--gradient-img_6321_446); border:1px solid var(--border-img_6321_446); color:var(--text-img_6321_446); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_447: linear-gradient(180deg, #567350 0%, #3f433d 100%); --border-img_6321_447: #495d45; --text-img_6321_447: #3e3e3e; }
+.btn-img_6321_447 { background-image: var(--gradient-img_6321_447); border:1px solid var(--border-img_6321_447); color:var(--text-img_6321_447); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_447 { background-image: var(--gradient-img_6321_447); border:1px solid var(--border-img_6321_447); color:var(--text-img_6321_447); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_448: linear-gradient(180deg, #66a757 0%, #363636 100%); --border-img_6321_448: #495f44; --text-img_6321_448: #3a3a3a; }
+.btn-img_6321_448 { background-image: var(--gradient-img_6321_448); border:1px solid var(--border-img_6321_448); color:var(--text-img_6321_448); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_448 { background-image: var(--gradient-img_6321_448); border:1px solid var(--border-img_6321_448); color:var(--text-img_6321_448); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_449: linear-gradient(180deg, #64a156 0%, #4e7a42 100%); --border-img_6321_449: #4d6b45; --text-img_6321_449: #44583f; }
+.btn-img_6321_449 { background-image: var(--gradient-img_6321_449); border:1px solid var(--border-img_6321_449); color:var(--text-img_6321_449); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_449 { background-image: var(--gradient-img_6321_449); border:1px solid var(--border-img_6321_449); color:var(--text-img_6321_449); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_450: linear-gradient(180deg, #5a8850 0%, #496a41 100%); --border-img_6321_450: #4b6544; --text-img_6321_450: #424f3f; }
+.btn-img_6321_450 { background-image: var(--gradient-img_6321_450); border:1px solid var(--border-img_6321_450); color:var(--text-img_6321_450); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_450 { background-image: var(--gradient-img_6321_450); border:1px solid var(--border-img_6321_450); color:var(--text-img_6321_450); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_451: linear-gradient(180deg, #3b3b3b 0%, #3d423c 100%); --border-img_6321_451: #3e443d; --text-img_6321_451: #3a3a3a; }
+.btn-img_6321_451 { background-image: var(--gradient-img_6321_451); border:1px solid var(--border-img_6321_451); color:var(--text-img_6321_451); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_451 { background-image: var(--gradient-img_6321_451); border:1px solid var(--border-img_6321_451); color:var(--text-img_6321_451); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_452: linear-gradient(180deg, #3b3b3b 0%, #3e463c 100%); --border-img_6321_452: #465742; --text-img_6321_452: #393939; }
+.btn-img_6321_452 { background-image: var(--gradient-img_6321_452); border:1px solid var(--border-img_6321_452); color:var(--text-img_6321_452); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_452 { background-image: var(--gradient-img_6321_452); border:1px solid var(--border-img_6321_452); color:var(--text-img_6321_452); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_453: linear-gradient(180deg, #42503f 0%, #79a170 100%); --border-img_6321_453: #566952; --text-img_6321_453: #4f8142; }
+.btn-img_6321_453 { background-image: var(--gradient-img_6321_453); border:1px solid var(--border-img_6321_453); color:var(--text-img_6321_453); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_453 { background-image: var(--gradient-img_6321_453); border:1px solid var(--border-img_6321_453); color:var(--text-img_6321_453); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_454: linear-gradient(180deg, #373737 0%, #323232 100%); --border-img_6321_454: #363936; --text-img_6321_454: #4b6645; }
+.btn-img_6321_454 { background-image: var(--gradient-img_6321_454); border:1px solid var(--border-img_6321_454); color:var(--text-img_6321_454); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_454 { background-image: var(--gradient-img_6321_454); border:1px solid var(--border-img_6321_454); color:var(--text-img_6321_454); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_455: linear-gradient(180deg, #3a3a3a 0%, #383737 100%); --border-img_6321_455: #404f3c; --text-img_6321_455: #383838; }
+.btn-img_6321_455 { background-image: var(--gradient-img_6321_455); border:1px solid var(--border-img_6321_455); color:var(--text-img_6321_455); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_455 { background-image: var(--gradient-img_6321_455); border:1px solid var(--border-img_6321_455); color:var(--text-img_6321_455); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_456: linear-gradient(180deg, #4f8142 0%, #4e7543 100%); --border-img_6321_456: #56834b; --text-img_6321_456: #9fcc95; }
+.btn-img_6321_456 { background-image: var(--gradient-img_6321_456); border:1px solid var(--border-img_6321_456); color:var(--text-img_6321_456); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_456 { background-image: var(--gradient-img_6321_456); border:1px solid var(--border-img_6321_456); color:var(--text-img_6321_456); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_457: linear-gradient(180deg, #465d40 0%, #455740 100%); --border-img_6321_457: #4c6246; --text-img_6321_457: #44563f; }
+.btn-img_6321_457 { background-image: var(--gradient-img_6321_457); border:1px solid var(--border-img_6321_457); color:var(--text-img_6321_457); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_457 { background-image: var(--gradient-img_6321_457); border:1px solid var(--border-img_6321_457); color:var(--text-img_6321_457); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_458: linear-gradient(180deg, #3e423c 0%, #3d3d3d 100%); --border-img_6321_458: #424940; --text-img_6321_458: #3e3d3d; }
+.btn-img_6321_458 { background-image: var(--gradient-img_6321_458); border:1px solid var(--border-img_6321_458); color:var(--text-img_6321_458); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_458 { background-image: var(--gradient-img_6321_458); border:1px solid var(--border-img_6321_458); color:var(--text-img_6321_458); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_459: linear-gradient(180deg, #4b6645 0%, #3d3d3d 100%); --border-img_6321_459: #3a4139; --text-img_6321_459: #303030; }
+.btn-img_6321_459 { background-image: var(--gradient-img_6321_459); border:1px solid var(--border-img_6321_459); color:var(--text-img_6321_459); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_459 { background-image: var(--gradient-img_6321_459); border:1px solid var(--border-img_6321_459); color:var(--text-img_6321_459); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_460: linear-gradient(180deg, #769e6c 0%, #3d3d3d 100%); --border-img_6321_460: #4f5d4b; --text-img_6321_460: #4d7243; }
+.btn-img_6321_460 { background-image: var(--gradient-img_6321_460); border:1px solid var(--border-img_6321_460); color:var(--text-img_6321_460); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_460 { background-image: var(--gradient-img_6321_460); border:1px solid var(--border-img_6321_460); color:var(--text-img_6321_460); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_461: linear-gradient(180deg, #5e7c57 0%, #3d3d3d 100%); --border-img_6321_461: #4c5948; --text-img_6321_461: #4c6e43; }
+.btn-img_6321_461 { background-image: var(--gradient-img_6321_461); border:1px solid var(--border-img_6321_461); color:var(--text-img_6321_461); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_461 { background-image: var(--gradient-img_6321_461); border:1px solid var(--border-img_6321_461); color:var(--text-img_6321_461); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_462: linear-gradient(180deg, #383938 0%, #3e403d 100%); --border-img_6321_462: #383a38; --text-img_6321_462: #3d3d3d; }
+.btn-img_6321_462 { background-image: var(--gradient-img_6321_462); border:1px solid var(--border-img_6321_462); color:var(--text-img_6321_462); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_462 { background-image: var(--gradient-img_6321_462); border:1px solid var(--border-img_6321_462); color:var(--text-img_6321_462); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_463: linear-gradient(180deg, #383b37 0%, #3a3a3a 100%); --border-img_6321_463: #3b4139; --text-img_6321_463: #3d3d3d; }
+.btn-img_6321_463 { background-image: var(--gradient-img_6321_463); border:1px solid var(--border-img_6321_463); color:var(--text-img_6321_463); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_463 { background-image: var(--gradient-img_6321_463); border:1px solid var(--border-img_6321_463); color:var(--text-img_6321_463); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_464: linear-gradient(180deg, #4b6e42 0%, #393939 100%); --border-img_6321_464: #414c3d; --text-img_6321_464: #3e3f3d; }
+.btn-img_6321_464 { background-image: var(--gradient-img_6321_464); border:1px solid var(--border-img_6321_464); color:var(--text-img_6321_464); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_464 { background-image: var(--gradient-img_6321_464); border:1px solid var(--border-img_6321_464); color:var(--text-img_6321_464); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_465: linear-gradient(180deg, #3f463d 0%, #3c3e3b 100%); --border-img_6321_465: #3a3d39; --text-img_6321_465: #3d3d3d; }
+.btn-img_6321_465 { background-image: var(--gradient-img_6321_465); border:1px solid var(--border-img_6321_465); color:var(--text-img_6321_465); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_465 { background-image: var(--gradient-img_6321_465); border:1px solid var(--border-img_6321_465); color:var(--text-img_6321_465); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_466: linear-gradient(180deg, #2f2f2f 0%, #383838 100%); --border-img_6321_466: #363636; --text-img_6321_466: #3c3c3c; }
+.btn-img_6321_466 { background-image: var(--gradient-img_6321_466); border:1px solid var(--border-img_6321_466); color:var(--text-img_6321_466); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_466 { background-image: var(--gradient-img_6321_466); border:1px solid var(--border-img_6321_466); color:var(--text-img_6321_466); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_467: linear-gradient(180deg, #383737 0%, #3a3a3a 100%); --border-img_6321_467: #393a39; --text-img_6321_467: #3d3d3d; }
+.btn-img_6321_467 { background-image: var(--gradient-img_6321_467); border:1px solid var(--border-img_6321_467); color:var(--text-img_6321_467); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_467 { background-image: var(--gradient-img_6321_467); border:1px solid var(--border-img_6321_467); color:var(--text-img_6321_467); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_468: linear-gradient(180deg, #4d7044 0%, #383838 100%); --border-img_6321_468: #404b3c; --text-img_6321_468: #3c3c3c; }
+.btn-img_6321_468 { background-image: var(--gradient-img_6321_468); border:1px solid var(--border-img_6321_468); color:var(--text-img_6321_468); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_468 { background-image: var(--gradient-img_6321_468); border:1px solid var(--border-img_6321_468); color:var(--text-img_6321_468); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_469: linear-gradient(180deg, #43513f 0%, #393939 100%); --border-img_6321_469: #3e433d; --text-img_6321_469: #3d3d3d; }
+.btn-img_6321_469 { background-image: var(--gradient-img_6321_469); border:1px solid var(--border-img_6321_469); color:var(--text-img_6321_469); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_469 { background-image: var(--gradient-img_6321_469); border:1px solid var(--border-img_6321_469); color:var(--text-img_6321_469); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_470: linear-gradient(180deg, #3c3e3c 0%, #3c3d3b 100%); --border-img_6321_470: #404140; --text-img_6321_470: #3d3d3d; }
+.btn-img_6321_470 { background-image: var(--gradient-img_6321_470); border:1px solid var(--border-img_6321_470); color:var(--text-img_6321_470); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_470 { background-image: var(--gradient-img_6321_470); border:1px solid var(--border-img_6321_470); color:var(--text-img_6321_470); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_471: linear-gradient(180deg, #373737 0%, #303030 100%); --border-img_6321_471: #434643; --text-img_6321_471: #e5ffdf; }
+.btn-img_6321_471 { background-image: var(--gradient-img_6321_471); border:1px solid var(--border-img_6321_471); color:var(--text-img_6321_471); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_471 { background-image: var(--gradient-img_6321_471); border:1px solid var(--border-img_6321_471); color:var(--text-img_6321_471); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_472: linear-gradient(180deg, #373737 0%, #323131 100%); --border-img_6321_472: #3b3b3a; --text-img_6321_472: #3c3e3b; }
+.btn-img_6321_472 { background-image: var(--gradient-img_6321_472); border:1px solid var(--border-img_6321_472); color:var(--text-img_6321_472); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_472 { background-image: var(--gradient-img_6321_472); border:1px solid var(--border-img_6321_472); color:var(--text-img_6321_472); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_473: linear-gradient(180deg, #383838 0%, #333333 100%); --border-img_6321_473: #3a3a3a; --text-img_6321_473: #343434; }
+.btn-img_6321_473 { background-image: var(--gradient-img_6321_473); border:1px solid var(--border-img_6321_473); color:var(--text-img_6321_473); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_473 { background-image: var(--gradient-img_6321_473); border:1px solid var(--border-img_6321_473); color:var(--text-img_6321_473); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_474: linear-gradient(180deg, #3b3d3b 0%, #393a38 100%); --border-img_6321_474: #4c4f4b; --text-img_6321_474: #393838; }
+.btn-img_6321_474 { background-image: var(--gradient-img_6321_474); border:1px solid var(--border-img_6321_474); color:var(--text-img_6321_474); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_474 { background-image: var(--gradient-img_6321_474); border:1px solid var(--border-img_6321_474); color:var(--text-img_6321_474); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_475: linear-gradient(180deg, #393839 0%, #363535 100%); --border-img_6321_475: #434543; --text-img_6321_475: #373737; }
+.btn-img_6321_475 { background-image: var(--gradient-img_6321_475); border:1px solid var(--border-img_6321_475); color:var(--text-img_6321_475); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_475 { background-image: var(--gradient-img_6321_475); border:1px solid var(--border-img_6321_475); color:var(--text-img_6321_475); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_476: linear-gradient(180deg, #363636 0%, #313131 100%); --border-img_6321_476: #393a39; --text-img_6321_476: #494f48; }
+.btn-img_6321_476 { background-image: var(--gradient-img_6321_476); border:1px solid var(--border-img_6321_476); color:var(--text-img_6321_476); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_476 { background-image: var(--gradient-img_6321_476); border:1px solid var(--border-img_6321_476); color:var(--text-img_6321_476); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_477: linear-gradient(180deg, #3c3e3b 0%, #3d3f3c 100%); --border-img_6321_477: #424342; --text-img_6321_477: #474f45; }
+.btn-img_6321_477 { background-image: var(--gradient-img_6321_477); border:1px solid var(--border-img_6321_477); color:var(--text-img_6321_477); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_477 { background-image: var(--gradient-img_6321_477); border:1px solid var(--border-img_6321_477); color:var(--text-img_6321_477); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_478: linear-gradient(180deg, #9bab98 0%, #303030 100%); --border-img_6321_478: #494c48; --text-img_6321_478: #a1b29e; }
+.btn-img_6321_478 { background-image: var(--gradient-img_6321_478); border:1px solid var(--border-img_6321_478); color:var(--text-img_6321_478); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_478 { background-image: var(--gradient-img_6321_478); border:1px solid var(--border-img_6321_478); color:var(--text-img_6321_478); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_479: linear-gradient(180deg, #393839 0%, #363636 100%); --border-img_6321_479: #434543; --text-img_6321_479: #373737; }
+.btn-img_6321_479 { background-image: var(--gradient-img_6321_479); border:1px solid var(--border-img_6321_479); color:var(--text-img_6321_479); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_479 { background-image: var(--gradient-img_6321_479); border:1px solid var(--border-img_6321_479); color:var(--text-img_6321_479); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_480: linear-gradient(180deg, #444944 0%, #303030 100%); --border-img_6321_480: #363736; --text-img_6321_480: #464b45; }
+.btn-img_6321_480 { background-image: var(--gradient-img_6321_480); border:1px solid var(--border-img_6321_480); color:var(--text-img_6321_480); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_480 { background-image: var(--gradient-img_6321_480); border:1px solid var(--border-img_6321_480); color:var(--text-img_6321_480); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6321_481: linear-gradient(180deg, #383838 0%, #363636 100%); --border-img_6321_481: #3a3b3a; --text-img_6321_481: #363636; }
+.btn-img_6321_481 { background-image: var(--gradient-img_6321_481); border:1px solid var(--border-img_6321_481); color:var(--text-img_6321_481); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6321_481 { background-image: var(--gradient-img_6321_481); border:1px solid var(--border-img_6321_481); color:var(--text-img_6321_481); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_482: linear-gradient(180deg, #5e6367 0%, #3c3c3c 100%); --border-img_6322_482: #494b4d; --text-img_6322_482: #45494c; }
+.btn-img_6322_482 { background-image: var(--gradient-img_6322_482); border:1px solid var(--border-img_6322_482); color:var(--text-img_6322_482); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_482 { background-image: var(--gradient-img_6322_482); border:1px solid var(--border-img_6322_482); color:var(--text-img_6322_482); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_483: linear-gradient(180deg, #5e6367 0%, #393939 100%); --border-img_6322_483: #494b4d; --text-img_6322_483: #45494c; }
+.btn-img_6322_483 { background-image: var(--gradient-img_6322_483); border:1px solid var(--border-img_6322_483); color:var(--text-img_6322_483); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_483 { background-image: var(--gradient-img_6322_483); border:1px solid var(--border-img_6322_483); color:var(--text-img_6322_483); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_484: linear-gradient(180deg, #5e6367 0%, #3f3f3f 100%); --border-img_6322_484: #4c4e50; --text-img_6322_484: #45494c; }
+.btn-img_6322_484 { background-image: var(--gradient-img_6322_484); border:1px solid var(--border-img_6322_484); color:var(--text-img_6322_484); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_484 { background-image: var(--gradient-img_6322_484); border:1px solid var(--border-img_6322_484); color:var(--text-img_6322_484); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_485: linear-gradient(180deg, #5e6367 0%, #3d3d3d 100%); --border-img_6322_485: #494b4d; --text-img_6322_485: #45494c; }
+.btn-img_6322_485 { background-image: var(--gradient-img_6322_485); border:1px solid var(--border-img_6322_485); color:var(--text-img_6322_485); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_485 { background-image: var(--gradient-img_6322_485); border:1px solid var(--border-img_6322_485); color:var(--text-img_6322_485); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_486: linear-gradient(180deg, #5e6367 0%, #2f2f2f 100%); --border-img_6322_486: #46494a; --text-img_6322_486: #45494c; }
+.btn-img_6322_486 { background-image: var(--gradient-img_6322_486); border:1px solid var(--border-img_6322_486); color:var(--text-img_6322_486); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_486 { background-image: var(--gradient-img_6322_486); border:1px solid var(--border-img_6322_486); color:var(--text-img_6322_486); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_487: linear-gradient(180deg, #5e6367 0%, #3a3a3a 100%); --border-img_6322_487: #4d4f51; --text-img_6322_487: #3a3c3d; }
+.btn-img_6322_487 { background-image: var(--gradient-img_6322_487); border:1px solid var(--border-img_6322_487); color:var(--text-img_6322_487); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_487 { background-image: var(--gradient-img_6322_487); border:1px solid var(--border-img_6322_487); color:var(--text-img_6322_487); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_488: linear-gradient(180deg, #5e6367 0%, #3a3a3a 100%); --border-img_6322_488: #4b4d4f; --text-img_6322_488: #3a3c3d; }
+.btn-img_6322_488 { background-image: var(--gradient-img_6322_488); border:1px solid var(--border-img_6322_488); color:var(--text-img_6322_488); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_488 { background-image: var(--gradient-img_6322_488); border:1px solid var(--border-img_6322_488); color:var(--text-img_6322_488); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_489: linear-gradient(180deg, #5e6367 0%, #373936 100%); --border-img_6322_489: #4a4d4e; --text-img_6322_489: #3a3c3d; }
+.btn-img_6322_489 { background-image: var(--gradient-img_6322_489); border:1px solid var(--border-img_6322_489); color:var(--text-img_6322_489); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_489 { background-image: var(--gradient-img_6322_489); border:1px solid var(--border-img_6322_489); color:var(--text-img_6322_489); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_490: linear-gradient(180deg, #5e6367 0%, #3b3a3a 100%); --border-img_6322_490: #4a4c4e; --text-img_6322_490: #393a3a; }
+.btn-img_6322_490 { background-image: var(--gradient-img_6322_490); border:1px solid var(--border-img_6322_490); color:var(--text-img_6322_490); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_490 { background-image: var(--gradient-img_6322_490); border:1px solid var(--border-img_6322_490); color:var(--text-img_6322_490); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_491: linear-gradient(180deg, #5e6367 0%, #363636 100%); --border-img_6322_491: #4c4e50; --text-img_6322_491: #393a3a; }
+.btn-img_6322_491 { background-image: var(--gradient-img_6322_491); border:1px solid var(--border-img_6322_491); color:var(--text-img_6322_491); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_491 { background-image: var(--gradient-img_6322_491); border:1px solid var(--border-img_6322_491); color:var(--text-img_6322_491); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_492: linear-gradient(180deg, #5e6367 0%, #323232 100%); --border-img_6322_492: #4b4d4f; --text-img_6322_492: #393a3a; }
+.btn-img_6322_492 { background-image: var(--gradient-img_6322_492); border:1px solid var(--border-img_6322_492); color:var(--text-img_6322_492); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_492 { background-image: var(--gradient-img_6322_492); border:1px solid var(--border-img_6322_492); color:var(--text-img_6322_492); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_493: linear-gradient(180deg, #5e6367 0%, #2f2f2f 100%); --border-img_6322_493: #4b4e4f; --text-img_6322_493: #3a3b3b; }
+.btn-img_6322_493 { background-image: var(--gradient-img_6322_493); border:1px solid var(--border-img_6322_493); color:var(--text-img_6322_493); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_493 { background-image: var(--gradient-img_6322_493); border:1px solid var(--border-img_6322_493); color:var(--text-img_6322_493); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_494: linear-gradient(180deg, #3c3b3c 0%, #3c3b3b 100%); --border-img_6322_494: #393939; --text-img_6322_494: #3c3b3b; }
+.btn-img_6322_494 { background-image: var(--gradient-img_6322_494); border:1px solid var(--border-img_6322_494); color:var(--text-img_6322_494); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_494 { background-image: var(--gradient-img_6322_494); border:1px solid var(--border-img_6322_494); color:var(--text-img_6322_494); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_495: linear-gradient(180deg, #363636 0%, #2f2f2f 100%); --border-img_6322_495: #464646; --text-img_6322_495: #9c9c9c; }
+.btn-img_6322_495 { background-image: var(--gradient-img_6322_495); border:1px solid var(--border-img_6322_495); color:var(--text-img_6322_495); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_495 { background-image: var(--gradient-img_6322_495); border:1px solid var(--border-img_6322_495); color:var(--text-img_6322_495); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_496: linear-gradient(180deg, #3a3a3a 0%, #363535 100%); --border-img_6322_496: #494848; --text-img_6322_496: #3c3c3c; }
+.btn-img_6322_496 { background-image: var(--gradient-img_6322_496); border:1px solid var(--border-img_6322_496); color:var(--text-img_6322_496); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_496 { background-image: var(--gradient-img_6322_496); border:1px solid var(--border-img_6322_496); color:var(--text-img_6322_496); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_497: linear-gradient(180deg, #343434 0%, #2b2b2b 100%); --border-img_6322_497: #515050; --text-img_6322_497: #676767; }
+.btn-img_6322_497 { background-image: var(--gradient-img_6322_497); border:1px solid var(--border-img_6322_497); color:var(--text-img_6322_497); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_497 { background-image: var(--gradient-img_6322_497); border:1px solid var(--border-img_6322_497); color:var(--text-img_6322_497); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_498: linear-gradient(180deg, #2f2f2f 0%, #2f2f2f 100%); --border-img_6322_498: #464b44; --text-img_6322_498: #9f9f9f; }
+.btn-img_6322_498 { background-image: var(--gradient-img_6322_498); border:1px solid var(--border-img_6322_498); color:var(--text-img_6322_498); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_498 { background-image: var(--gradient-img_6322_498); border:1px solid var(--border-img_6322_498); color:var(--text-img_6322_498); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_499: linear-gradient(180deg, #4a4a49 0%, #3c3b3b 100%); --border-img_6322_499: #525252; --text-img_6322_499: #363636; }
+.btn-img_6322_499 { background-image: var(--gradient-img_6322_499); border:1px solid var(--border-img_6322_499); color:var(--text-img_6322_499); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_499 { background-image: var(--gradient-img_6322_499); border:1px solid var(--border-img_6322_499); color:var(--text-img_6322_499); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_500: linear-gradient(180deg, #525252 0%, #3c3b3b 100%); --border-img_6322_500: #585757; --text-img_6322_500: #363535; }
+.btn-img_6322_500 { background-image: var(--gradient-img_6322_500); border:1px solid var(--border-img_6322_500); color:var(--text-img_6322_500); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_500 { background-image: var(--gradient-img_6322_500); border:1px solid var(--border-img_6322_500); color:var(--text-img_6322_500); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_501: linear-gradient(180deg, #747673 0%, #3c3b3b 100%); --border-img_6322_501: #585857; --text-img_6322_501: #2f2f2f; }
+.btn-img_6322_501 { background-image: var(--gradient-img_6322_501); border:1px solid var(--border-img_6322_501); color:var(--text-img_6322_501); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_501 { background-image: var(--gradient-img_6322_501); border:1px solid var(--border-img_6322_501); color:var(--text-img_6322_501); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_502: linear-gradient(180deg, #3a3a3a 0%, #414040 100%); --border-img_6322_502: #484848; --text-img_6322_502: #3c3b3b; }
+.btn-img_6322_502 { background-image: var(--gradient-img_6322_502); border:1px solid var(--border-img_6322_502); color:var(--text-img_6322_502); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_502 { background-image: var(--gradient-img_6322_502); border:1px solid var(--border-img_6322_502); color:var(--text-img_6322_502); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_503: linear-gradient(180deg, #989898 0%, #5a5959 100%); --border-img_6322_503: #5e5e5e; --text-img_6322_503: #383737; }
+.btn-img_6322_503 { background-image: var(--gradient-img_6322_503); border:1px solid var(--border-img_6322_503); color:var(--text-img_6322_503); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_503 { background-image: var(--gradient-img_6322_503); border:1px solid var(--border-img_6322_503); color:var(--text-img_6322_503); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_504: linear-gradient(180deg, #d7d7d7 0%, #4f4f4f 100%); --border-img_6322_504: #5d5d5d; --text-img_6322_504: #3e3d3d; }
+.btn-img_6322_504 { background-image: var(--gradient-img_6322_504); border:1px solid var(--border-img_6322_504); color:var(--text-img_6322_504); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_504 { background-image: var(--gradient-img_6322_504); border:1px solid var(--border-img_6322_504); color:var(--text-img_6322_504); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_505: linear-gradient(180deg, #c1c1c1 0%, #424242 100%); --border-img_6322_505: #60605f; --text-img_6322_505: #40463e; }
+.btn-img_6322_505 { background-image: var(--gradient-img_6322_505); border:1px solid var(--border-img_6322_505); color:var(--text-img_6322_505); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_505 { background-image: var(--gradient-img_6322_505); border:1px solid var(--border-img_6322_505); color:var(--text-img_6322_505); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_506: linear-gradient(180deg, #3c3b3b 0%, #3b3b3b 100%); --border-img_6322_506: #444343; --text-img_6322_506: #3b3b3b; }
+.btn-img_6322_506 { background-image: var(--gradient-img_6322_506); border:1px solid var(--border-img_6322_506); color:var(--text-img_6322_506); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_506 { background-image: var(--gradient-img_6322_506); border:1px solid var(--border-img_6322_506); color:var(--text-img_6322_506); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_507: linear-gradient(180deg, #4a4a4a 0%, #e3e3e3 100%); --border-img_6322_507: #5f5e5e; --text-img_6322_507: #6b6a6a; }
+.btn-img_6322_507 { background-image: var(--gradient-img_6322_507); border:1px solid var(--border-img_6322_507); color:var(--text-img_6322_507); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_507 { background-image: var(--gradient-img_6322_507); border:1px solid var(--border-img_6322_507); color:var(--text-img_6322_507); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_508: linear-gradient(180deg, #3c3b3b 0%, #626262 100%); --border-img_6322_508: #5e5d5d; --text-img_6322_508: #5a5a5a; }
+.btn-img_6322_508 { background-image: var(--gradient-img_6322_508); border:1px solid var(--border-img_6322_508); color:var(--text-img_6322_508); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_508 { background-image: var(--gradient-img_6322_508); border:1px solid var(--border-img_6322_508); color:var(--text-img_6322_508); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_509: linear-gradient(180deg, #3c3b3b 0%, #b6b6b6 100%); --border-img_6322_509: #626262; --text-img_6322_509: #4e4e4e; }
+.btn-img_6322_509 { background-image: var(--gradient-img_6322_509); border:1px solid var(--border-img_6322_509); color:var(--text-img_6322_509); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_509 { background-image: var(--gradient-img_6322_509); border:1px solid var(--border-img_6322_509); color:var(--text-img_6322_509); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_510: linear-gradient(180deg, #3c3b3b 0%, #b8b8b8 100%); --border-img_6322_510: #585757; --text-img_6322_510: #434343; }
+.btn-img_6322_510 { background-image: var(--gradient-img_6322_510); border:1px solid var(--border-img_6322_510); color:var(--text-img_6322_510); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_510 { background-image: var(--gradient-img_6322_510); border:1px solid var(--border-img_6322_510); color:var(--text-img_6322_510); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_511: linear-gradient(180deg, #4c4b4b 0%, #464545 100%); --border-img_6322_511: #525252; --text-img_6322_511: #494949; }
+.btn-img_6322_511 { background-image: var(--gradient-img_6322_511); border:1px solid var(--border-img_6322_511); color:var(--text-img_6322_511); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_511 { background-image: var(--gradient-img_6322_511); border:1px solid var(--border-img_6322_511); color:var(--text-img_6322_511); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_512: linear-gradient(180deg, #4b4b4b 0%, #444444 100%); --border-img_6322_512: #656464; --text-img_6322_512: #4e4e4e; }
+.btn-img_6322_512 { background-image: var(--gradient-img_6322_512); border:1px solid var(--border-img_6322_512); color:var(--text-img_6322_512); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_512 { background-image: var(--gradient-img_6322_512); border:1px solid var(--border-img_6322_512); color:var(--text-img_6322_512); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_513: linear-gradient(180deg, #434343 0%, #414141 100%); --border-img_6322_513: #565656; --text-img_6322_513: #5f5f5f; }
+.btn-img_6322_513 { background-image: var(--gradient-img_6322_513); border:1px solid var(--border-img_6322_513); color:var(--text-img_6322_513); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_513 { background-image: var(--gradient-img_6322_513); border:1px solid var(--border-img_6322_513); color:var(--text-img_6322_513); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_514: linear-gradient(180deg, #404040 0%, #424242 100%); --border-img_6322_514: #504f4f; --text-img_6322_514: #3b3a3a; }
+.btn-img_6322_514 { background-image: var(--gradient-img_6322_514); border:1px solid var(--border-img_6322_514); color:var(--text-img_6322_514); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_514 { background-image: var(--gradient-img_6322_514); border:1px solid var(--border-img_6322_514); color:var(--text-img_6322_514); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_515: linear-gradient(180deg, #a4a4a4 0%, #767676 100%); --border-img_6322_515: #686767; --text-img_6322_515: #4c4c4c; }
+.btn-img_6322_515 { background-image: var(--gradient-img_6322_515); border:1px solid var(--border-img_6322_515); color:var(--text-img_6322_515); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_515 { background-image: var(--gradient-img_6322_515); border:1px solid var(--border-img_6322_515); color:var(--text-img_6322_515); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_516: linear-gradient(180deg, #ffffff 0%, #7a7a7a 100%); --border-img_6322_516: #717171; --text-img_6322_516: #4e4e4e; }
+.btn-img_6322_516 { background-image: var(--gradient-img_6322_516); border:1px solid var(--border-img_6322_516); color:var(--text-img_6322_516); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_516 { background-image: var(--gradient-img_6322_516); border:1px solid var(--border-img_6322_516); color:var(--text-img_6322_516); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_517: linear-gradient(180deg, #989898 0%, #7a7a7a 100%); --border-img_6322_517: #646363; --text-img_6322_517: #444444; }
+.btn-img_6322_517 { background-image: var(--gradient-img_6322_517); border:1px solid var(--border-img_6322_517); color:var(--text-img_6322_517); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_517 { background-image: var(--gradient-img_6322_517); border:1px solid var(--border-img_6322_517); color:var(--text-img_6322_517); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_518: linear-gradient(180deg, #3b3a3a 0%, #3b3a3a 100%); --border-img_6322_518: #444343; --text-img_6322_518: #3b3a3a; }
+.btn-img_6322_518 { background-image: var(--gradient-img_6322_518); border:1px solid var(--border-img_6322_518); color:var(--text-img_6322_518); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_518 { background-image: var(--gradient-img_6322_518); border:1px solid var(--border-img_6322_518); color:var(--text-img_6322_518); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_519: linear-gradient(180deg, #525252 0%, #747474 100%); --border-img_6322_519: #5f5f5f; --text-img_6322_519: #4c4b4b; }
+.btn-img_6322_519 { background-image: var(--gradient-img_6322_519); border:1px solid var(--border-img_6322_519); color:var(--text-img_6322_519); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_519 { background-image: var(--gradient-img_6322_519); border:1px solid var(--border-img_6322_519); color:var(--text-img_6322_519); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_520: linear-gradient(180deg, #464646 0%, #626161 100%); --border-img_6322_520: #575757; --text-img_6322_520: #484747; }
+.btn-img_6322_520 { background-image: var(--gradient-img_6322_520); border:1px solid var(--border-img_6322_520); color:var(--text-img_6322_520); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_520 { background-image: var(--gradient-img_6322_520); border:1px solid var(--border-img_6322_520); color:var(--text-img_6322_520); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_521: linear-gradient(180deg, #484848 0%, #767676 100%); --border-img_6322_521: #525151; --text-img_6322_521: #575656; }
+.btn-img_6322_521 { background-image: var(--gradient-img_6322_521); border:1px solid var(--border-img_6322_521); color:var(--text-img_6322_521); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_521 { background-image: var(--gradient-img_6322_521); border:1px solid var(--border-img_6322_521); color:var(--text-img_6322_521); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_522: linear-gradient(180deg, #424242 0%, #747474 100%); --border-img_6322_522: #5a5a5a; --text-img_6322_522: #515151; }
+.btn-img_6322_522 { background-image: var(--gradient-img_6322_522); border:1px solid var(--border-img_6322_522); color:var(--text-img_6322_522); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_522 { background-image: var(--gradient-img_6322_522); border:1px solid var(--border-img_6322_522); color:var(--text-img_6322_522); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_523: linear-gradient(180deg, #464646 0%, #4f4e4e 100%); --border-img_6322_523: #535252; --text-img_6322_523: #515050; }
+.btn-img_6322_523 { background-image: var(--gradient-img_6322_523); border:1px solid var(--border-img_6322_523); color:var(--text-img_6322_523); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_523 { background-image: var(--gradient-img_6322_523); border:1px solid var(--border-img_6322_523); color:var(--text-img_6322_523); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_524: linear-gradient(180deg, #696969 0%, #595959 100%); --border-img_6322_524: #696868; --text-img_6322_524: #686767; }
+.btn-img_6322_524 { background-image: var(--gradient-img_6322_524); border:1px solid var(--border-img_6322_524); color:var(--text-img_6322_524); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_524 { background-image: var(--gradient-img_6322_524); border:1px solid var(--border-img_6322_524); color:var(--text-img_6322_524); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_525: linear-gradient(180deg, #646464 0%, #5d5d5d 100%); --border-img_6322_525: #636363; --text-img_6322_525: #727171; }
+.btn-img_6322_525 { background-image: var(--gradient-img_6322_525); border:1px solid var(--border-img_6322_525); color:var(--text-img_6322_525); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_525 { background-image: var(--gradient-img_6322_525); border:1px solid var(--border-img_6322_525); color:var(--text-img_6322_525); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_526: linear-gradient(180deg, #414040 0%, #414040 100%); --border-img_6322_526: #555555; --text-img_6322_526: #3a3a3a; }
+.btn-img_6322_526 { background-image: var(--gradient-img_6322_526); border:1px solid var(--border-img_6322_526); color:var(--text-img_6322_526); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_526 { background-image: var(--gradient-img_6322_526); border:1px solid var(--border-img_6322_526); color:var(--text-img_6322_526); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_527: linear-gradient(180deg, #898989 0%, #adadad 100%); --border-img_6322_527: #737373; --text-img_6322_527: #605f5f; }
+.btn-img_6322_527 { background-image: var(--gradient-img_6322_527); border:1px solid var(--border-img_6322_527); color:var(--text-img_6322_527); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_527 { background-image: var(--gradient-img_6322_527); border:1px solid var(--border-img_6322_527); color:var(--text-img_6322_527); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_528: linear-gradient(180deg, #e6e6e6 0%, #c1c0c0 100%); --border-img_6322_528: #888787; --text-img_6322_528: #626161; }
+.btn-img_6322_528 { background-image: var(--gradient-img_6322_528); border:1px solid var(--border-img_6322_528); color:var(--text-img_6322_528); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_528 { background-image: var(--gradient-img_6322_528); border:1px solid var(--border-img_6322_528); color:var(--text-img_6322_528); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_529: linear-gradient(180deg, #aaaaaa 0%, #bdbdbd 100%); --border-img_6322_529: #767676; --text-img_6322_529: #616060; }
+.btn-img_6322_529 { background-image: var(--gradient-img_6322_529); border:1px solid var(--border-img_6322_529); color:var(--text-img_6322_529); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_529 { background-image: var(--gradient-img_6322_529); border:1px solid var(--border-img_6322_529); color:var(--text-img_6322_529); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_530: linear-gradient(180deg, #3b3a3a 0%, #3a393a 100%); --border-img_6322_530: #424141; --text-img_6322_530: #3a3a3a; }
+.btn-img_6322_530 { background-image: var(--gradient-img_6322_530); border:1px solid var(--border-img_6322_530); color:var(--text-img_6322_530); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_530 { background-image: var(--gradient-img_6322_530); border:1px solid var(--border-img_6322_530); color:var(--text-img_6322_530); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_531: linear-gradient(180deg, #d5d5d5 0%, #3a393a 100%); --border-img_6322_531: #868686; --text-img_6322_531: #605f5f; }
+.btn-img_6322_531 { background-image: var(--gradient-img_6322_531); border:1px solid var(--border-img_6322_531); color:var(--text-img_6322_531); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_531 { background-image: var(--gradient-img_6322_531); border:1px solid var(--border-img_6322_531); color:var(--text-img_6322_531); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_532: linear-gradient(180deg, #6f6f6f 0%, #3a3939 100%); --border-img_6322_532: #717171; --text-img_6322_532: #676666; }
+.btn-img_6322_532 { background-image: var(--gradient-img_6322_532); border:1px solid var(--border-img_6322_532); color:var(--text-img_6322_532); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_532 { background-image: var(--gradient-img_6322_532); border:1px solid var(--border-img_6322_532); color:var(--text-img_6322_532); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_533: linear-gradient(180deg, #b9b8b8 0%, #3a393a 100%); --border-img_6322_533: #7c7b7b; --text-img_6322_533: #605f5f; }
+.btn-img_6322_533 { background-image: var(--gradient-img_6322_533); border:1px solid var(--border-img_6322_533); color:var(--text-img_6322_533); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_533 { background-image: var(--gradient-img_6322_533); border:1px solid var(--border-img_6322_533); color:var(--text-img_6322_533); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_534: linear-gradient(180deg, #d5d5d5 0%, #3a393a 100%); --border-img_6322_534: #6f6f6f; --text-img_6322_534: #605f5f; }
+.btn-img_6322_534 { background-image: var(--gradient-img_6322_534); border:1px solid var(--border-img_6322_534); color:var(--text-img_6322_534); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_534 { background-image: var(--gradient-img_6322_534); border:1px solid var(--border-img_6322_534); color:var(--text-img_6322_534); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_535: linear-gradient(180deg, #3a3a3a 0%, #636262 100%); --border-img_6322_535: #525252; --text-img_6322_535: #686767; }
+.btn-img_6322_535 { background-image: var(--gradient-img_6322_535); border:1px solid var(--border-img_6322_535); color:var(--text-img_6322_535); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_535 { background-image: var(--gradient-img_6322_535); border:1px solid var(--border-img_6322_535); color:var(--text-img_6322_535); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_536: linear-gradient(180deg, #3a3a3a 0%, #929292 100%); --border-img_6322_536: #8b8b8b; --text-img_6322_536: #8d8c8c; }
+.btn-img_6322_536 { background-image: var(--gradient-img_6322_536); border:1px solid var(--border-img_6322_536); color:var(--text-img_6322_536); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_536 { background-image: var(--gradient-img_6322_536); border:1px solid var(--border-img_6322_536); color:var(--text-img_6322_536); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_537: linear-gradient(180deg, #3a3a3a 0%, #656464 100%); --border-img_6322_537: #757474; --text-img_6322_537: #bdbdbd; }
+.btn-img_6322_537 { background-image: var(--gradient-img_6322_537); border:1px solid var(--border-img_6322_537); color:var(--text-img_6322_537); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_537 { background-image: var(--gradient-img_6322_537); border:1px solid var(--border-img_6322_537); color:var(--text-img_6322_537); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_538: linear-gradient(180deg, #3a3939 0%, #3a3939 100%); --border-img_6322_538: #5c5b5b; --text-img_6322_538: #3a3939; }
+.btn-img_6322_538 { background-image: var(--gradient-img_6322_538); border:1px solid var(--border-img_6322_538); color:var(--text-img_6322_538); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_538 { background-image: var(--gradient-img_6322_538); border:1px solid var(--border-img_6322_538); color:var(--text-img_6322_538); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_539: linear-gradient(180deg, #bbbaba 0%, #a4a2a2 100%); --border-img_6322_539: #a9a8a8; --text-img_6322_539: #4f4f4f; }
+.btn-img_6322_539 { background-image: var(--gradient-img_6322_539); border:1px solid var(--border-img_6322_539); color:var(--text-img_6322_539); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_539 { background-image: var(--gradient-img_6322_539); border:1px solid var(--border-img_6322_539); color:var(--text-img_6322_539); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_540: linear-gradient(180deg, #858484 0%, #797878 100%); --border-img_6322_540: #9f9f9f; --text-img_6322_540: #959494; }
+.btn-img_6322_540 { background-image: var(--gradient-img_6322_540); border:1px solid var(--border-img_6322_540); color:var(--text-img_6322_540); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_540 { background-image: var(--gradient-img_6322_540); border:1px solid var(--border-img_6322_540); color:var(--text-img_6322_540); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_541: linear-gradient(180deg, #b8b8b8 0%, #a3a2a2 100%); --border-img_6322_541: #8b8b8a; --text-img_6322_541: #d1d0d0; }
+.btn-img_6322_541 { background-image: var(--gradient-img_6322_541); border:1px solid var(--border-img_6322_541); color:var(--text-img_6322_541); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_541 { background-image: var(--gradient-img_6322_541); border:1px solid var(--border-img_6322_541); color:var(--text-img_6322_541); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_542: linear-gradient(180deg, #bbbbbb 0%, #a4a3a3 100%); --border-img_6322_542: #a9a8a8; --text-img_6322_542: #333333; }
+.btn-img_6322_542 { background-image: var(--gradient-img_6322_542); border:1px solid var(--border-img_6322_542); color:var(--text-img_6322_542); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_542 { background-image: var(--gradient-img_6322_542); border:1px solid var(--border-img_6322_542); color:var(--text-img_6322_542); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_543: linear-gradient(180deg, #474646 0%, #3a3939 100%); --border-img_6322_543: #5e5d5d; --text-img_6322_543: #3a3939; }
+.btn-img_6322_543 { background-image: var(--gradient-img_6322_543); border:1px solid var(--border-img_6322_543); color:var(--text-img_6322_543); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_543 { background-image: var(--gradient-img_6322_543); border:1px solid var(--border-img_6322_543); color:var(--text-img_6322_543); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_544: linear-gradient(180deg, #aaa9a9 0%, #3a3939 100%); --border-img_6322_544: #797878; --text-img_6322_544: #a6a4a4; }
+.btn-img_6322_544 { background-image: var(--gradient-img_6322_544); border:1px solid var(--border-img_6322_544); color:var(--text-img_6322_544); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_544 { background-image: var(--gradient-img_6322_544); border:1px solid var(--border-img_6322_544); color:var(--text-img_6322_544); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_545: linear-gradient(180deg, #c9c8c8 0%, #3a3939 100%); --border-img_6322_545: #b0b0b0; --text-img_6322_545: #a6a4a4; }
+.btn-img_6322_545 { background-image: var(--gradient-img_6322_545); border:1px solid var(--border-img_6322_545); color:var(--text-img_6322_545); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_545 { background-image: var(--gradient-img_6322_545); border:1px solid var(--border-img_6322_545); color:var(--text-img_6322_545); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_546: linear-gradient(180deg, #b5b5b5 0%, #3a3939 100%); --border-img_6322_546: #858484; --text-img_6322_546: #a7a5a5; }
+.btn-img_6322_546 { background-image: var(--gradient-img_6322_546); border:1px solid var(--border-img_6322_546); color:var(--text-img_6322_546); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_546 { background-image: var(--gradient-img_6322_546); border:1px solid var(--border-img_6322_546); color:var(--text-img_6322_546); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_547: linear-gradient(180deg, #6c6b6b 0%, #8f8e8e 100%); --border-img_6322_547: #787878; --text-img_6322_547: #3a3939; }
+.btn-img_6322_547 { background-image: var(--gradient-img_6322_547); border:1px solid var(--border-img_6322_547); color:var(--text-img_6322_547); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_547 { background-image: var(--gradient-img_6322_547); border:1px solid var(--border-img_6322_547); color:var(--text-img_6322_547); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_548: linear-gradient(180deg, #7d7c7c 0%, #aeaeae 100%); --border-img_6322_548: #a9a8a8; --text-img_6322_548: #414040; }
+.btn-img_6322_548 { background-image: var(--gradient-img_6322_548); border:1px solid var(--border-img_6322_548); color:var(--text-img_6322_548); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_548 { background-image: var(--gradient-img_6322_548); border:1px solid var(--border-img_6322_548); color:var(--text-img_6322_548); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_549: linear-gradient(180deg, #868585 0%, #b3b3b3 100%); --border-img_6322_549: #acacac; --text-img_6322_549: #3e3d3d; }
+.btn-img_6322_549 { background-image: var(--gradient-img_6322_549); border:1px solid var(--border-img_6322_549); color:var(--text-img_6322_549); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_549 { background-image: var(--gradient-img_6322_549); border:1px solid var(--border-img_6322_549); color:var(--text-img_6322_549); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_550: linear-gradient(180deg, #3a3939 0%, #393838 100%); --border-img_6322_550: #5f5e5e; --text-img_6322_550: #393939; }
+.btn-img_6322_550 { background-image: var(--gradient-img_6322_550); border:1px solid var(--border-img_6322_550); color:var(--text-img_6322_550); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_550 { background-image: var(--gradient-img_6322_550); border:1px solid var(--border-img_6322_550); color:var(--text-img_6322_550); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_551: linear-gradient(180deg, #3a3939 0%, #4f4f4f 100%); --border-img_6322_551: #818080; --text-img_6322_551: #eaeaea; }
+.btn-img_6322_551 { background-image: var(--gradient-img_6322_551); border:1px solid var(--border-img_6322_551); color:var(--text-img_6322_551); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_551 { background-image: var(--gradient-img_6322_551); border:1px solid var(--border-img_6322_551); color:var(--text-img_6322_551); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_552: linear-gradient(180deg, #3a3939 0%, #959595 100%); --border-img_6322_552: #888888; --text-img_6322_552: #cccccc; }
+.btn-img_6322_552 { background-image: var(--gradient-img_6322_552); border:1px solid var(--border-img_6322_552); color:var(--text-img_6322_552); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_552 { background-image: var(--gradient-img_6322_552); border:1px solid var(--border-img_6322_552); color:var(--text-img_6322_552); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_553: linear-gradient(180deg, #3a3939 0%, #9a9999 100%); --border-img_6322_553: #616060; --text-img_6322_553: #eaeaea; }
+.btn-img_6322_553 { background-image: var(--gradient-img_6322_553); border:1px solid var(--border-img_6322_553); color:var(--text-img_6322_553); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_553 { background-image: var(--gradient-img_6322_553); border:1px solid var(--border-img_6322_553); color:var(--text-img_6322_553); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_554: linear-gradient(180deg, #3a3939 0%, #4c6746 100%); --border-img_6322_554: #868d85; --text-img_6322_554: #eaeaea; }
+.btn-img_6322_554 { background-image: var(--gradient-img_6322_554); border:1px solid var(--border-img_6322_554); color:var(--text-img_6322_554); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_554 { background-image: var(--gradient-img_6322_554); border:1px solid var(--border-img_6322_554); color:var(--text-img_6322_554); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_555: linear-gradient(180deg, #515151 0%, #393838 100%); --border-img_6322_555: #696969; --text-img_6322_555: #393838; }
+.btn-img_6322_555 { background-image: var(--gradient-img_6322_555); border:1px solid var(--border-img_6322_555); color:var(--text-img_6322_555); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_555 { background-image: var(--gradient-img_6322_555); border:1px solid var(--border-img_6322_555); color:var(--text-img_6322_555); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_556: linear-gradient(180deg, #e3e3e3 0%, #393838 100%); --border-img_6322_556: #7f7e7e; --text-img_6322_556: #eaeaea; }
+.btn-img_6322_556 { background-image: var(--gradient-img_6322_556); border:1px solid var(--border-img_6322_556); color:var(--text-img_6322_556); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_556 { background-image: var(--gradient-img_6322_556); border:1px solid var(--border-img_6322_556); color:var(--text-img_6322_556); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_557: linear-gradient(180deg, #ededed 0%, #393838 100%); --border-img_6322_557: #c4c4c4; --text-img_6322_557: #ececec; }
+.btn-img_6322_557 { background-image: var(--gradient-img_6322_557); border:1px solid var(--border-img_6322_557); color:var(--text-img_6322_557); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_557 { background-image: var(--gradient-img_6322_557); border:1px solid var(--border-img_6322_557); color:var(--text-img_6322_557); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_558: linear-gradient(180deg, #ededed 0%, #393838 100%); --border-img_6322_558: #8d908b; --text-img_6322_558: #eff0ef; }
+.btn-img_6322_558 { background-image: var(--gradient-img_6322_558); border:1px solid var(--border-img_6322_558); color:var(--text-img_6322_558); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_558 { background-image: var(--gradient-img_6322_558); border:1px solid var(--border-img_6322_558); color:var(--text-img_6322_558); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_559: linear-gradient(180deg, #706f6f 0%, #858484 100%); --border-img_6322_559: #747373; --text-img_6322_559: #696868; }
+.btn-img_6322_559 { background-image: var(--gradient-img_6322_559); border:1px solid var(--border-img_6322_559); color:var(--text-img_6322_559); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_559 { background-image: var(--gradient-img_6322_559); border:1px solid var(--border-img_6322_559); color:var(--text-img_6322_559); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_560: linear-gradient(180deg, #858484 0%, #acacac 100%); --border-img_6322_560: #a7a7a7; --text-img_6322_560: #848383; }
+.btn-img_6322_560 { background-image: var(--gradient-img_6322_560); border:1px solid var(--border-img_6322_560); color:var(--text-img_6322_560); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_560 { background-image: var(--gradient-img_6322_560); border:1px solid var(--border-img_6322_560); color:var(--text-img_6322_560); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_561: linear-gradient(180deg, #758072 0%, #afb0af 100%); --border-img_6322_561: #a8aca7; --text-img_6322_561: #a2a1a1; }
+.btn-img_6322_561 { background-image: var(--gradient-img_6322_561); border:1px solid var(--border-img_6322_561); color:var(--text-img_6322_561); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_561 { background-image: var(--gradient-img_6322_561); border:1px solid var(--border-img_6322_561); color:var(--text-img_6322_561); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_562: linear-gradient(180deg, #393838 0%, #393838 100%); --border-img_6322_562: #575656; --text-img_6322_562: #393838; }
+.btn-img_6322_562 { background-image: var(--gradient-img_6322_562); border:1px solid var(--border-img_6322_562); color:var(--text-img_6322_562); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_562 { background-image: var(--gradient-img_6322_562); border:1px solid var(--border-img_6322_562); color:var(--text-img_6322_562); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_563: linear-gradient(180deg, #fafaf9 0%, #ebebeb 100%); --border-img_6322_563: #d7d7d7; --text-img_6322_563: #3a3a3a; }
+.btn-img_6322_563 { background-image: var(--gradient-img_6322_563); border:1px solid var(--border-img_6322_563); color:var(--text-img_6322_563); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_563 { background-image: var(--gradient-img_6322_563); border:1px solid var(--border-img_6322_563); color:var(--text-img_6322_563); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_564: linear-gradient(180deg, #aeaeae 0%, #a1a1a1 100%); --border-img_6322_564: #b4b4b4; --text-img_6322_564: #393838; }
+.btn-img_6322_564 { background-image: var(--gradient-img_6322_564); border:1px solid var(--border-img_6322_564); color:var(--text-img_6322_564); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_564 { background-image: var(--gradient-img_6322_564); border:1px solid var(--border-img_6322_564); color:var(--text-img_6322_564); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_565: linear-gradient(180deg, #f9f9f9 0%, #e8e8e8 100%); --border-img_6322_565: #a1a1a1; --text-img_6322_565: #3b3a3a; }
+.btn-img_6322_565 { background-image: var(--gradient-img_6322_565); border:1px solid var(--border-img_6322_565); color:var(--text-img_6322_565); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_565 { background-image: var(--gradient-img_6322_565); border:1px solid var(--border-img_6322_565); color:var(--text-img_6322_565); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_566: linear-gradient(180deg, #fafafa 0%, #ebebeb 100%); --border-img_6322_566: #d2d3d2; --text-img_6322_566: #3d3d3c; }
+.btn-img_6322_566 { background-image: var(--gradient-img_6322_566); border:1px solid var(--border-img_6322_566); color:var(--text-img_6322_566); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_566 { background-image: var(--gradient-img_6322_566); border:1px solid var(--border-img_6322_566); color:var(--text-img_6322_566); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_567: linear-gradient(180deg, #474646 0%, #343739 100%); --border-img_6322_567: #656566; --text-img_6322_567: #383838; }
+.btn-img_6322_567 { background-image: var(--gradient-img_6322_567); border:1px solid var(--border-img_6322_567); color:var(--text-img_6322_567); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_567 { background-image: var(--gradient-img_6322_567); border:1px solid var(--border-img_6322_567); color:var(--text-img_6322_567); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_568: linear-gradient(180deg, #e8e8e8 0%, #343739 100%); --border-img_6322_568: #727273; --text-img_6322_568: #d5d5d5; }
+.btn-img_6322_568 { background-image: var(--gradient-img_6322_568); border:1px solid var(--border-img_6322_568); color:var(--text-img_6322_568); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_568 { background-image: var(--gradient-img_6322_568); border:1px solid var(--border-img_6322_568); color:var(--text-img_6322_568); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_569: linear-gradient(180deg, #ececec 0%, #343739 100%); --border-img_6322_569: #b2b3b4; --text-img_6322_569: #d5d5d5; }
+.btn-img_6322_569 { background-image: var(--gradient-img_6322_569); border:1px solid var(--border-img_6322_569); color:var(--text-img_6322_569); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_569 { background-image: var(--gradient-img_6322_569); border:1px solid var(--border-img_6322_569); color:var(--text-img_6322_569); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_570: linear-gradient(180deg, #ececec 0%, #343739 100%); --border-img_6322_570: #7a7e7a; --text-img_6322_570: #d7e5d4; }
+.btn-img_6322_570 { background-image: var(--gradient-img_6322_570); border:1px solid var(--border-img_6322_570); color:var(--text-img_6322_570); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_570 { background-image: var(--gradient-img_6322_570); border:1px solid var(--border-img_6322_570); color:var(--text-img_6322_570); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_571: linear-gradient(180deg, #888888 0%, #343739 100%); --border-img_6322_571: #5c5c5d; --text-img_6322_571: #727171; }
+.btn-img_6322_571 { background-image: var(--gradient-img_6322_571); border:1px solid var(--border-img_6322_571); color:var(--text-img_6322_571); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_571 { background-image: var(--gradient-img_6322_571); border:1px solid var(--border-img_6322_571); color:var(--text-img_6322_571); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_572: linear-gradient(180deg, #a7a7a7 0%, #3c4042 100%); --border-img_6322_572: #8c8d8e; --text-img_6322_572: #b4b4b4; }
+.btn-img_6322_572 { background-image: var(--gradient-img_6322_572); border:1px solid var(--border-img_6322_572); color:var(--text-img_6322_572); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_572 { background-image: var(--gradient-img_6322_572); border:1px solid var(--border-img_6322_572); color:var(--text-img_6322_572); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_573: linear-gradient(180deg, #9ba797 0%, #343739 100%); --border-img_6322_573: #949a94; --text-img_6322_573: #f6f8f6; }
+.btn-img_6322_573 { background-image: var(--gradient-img_6322_573); border:1px solid var(--border-img_6322_573); color:var(--text-img_6322_573); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_573 { background-image: var(--gradient-img_6322_573); border:1px solid var(--border-img_6322_573); color:var(--text-img_6322_573); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_574: linear-gradient(180deg, #383838 0%, #343739 100%); --border-img_6322_574: #4f5050; --text-img_6322_574: #383838; }
+.btn-img_6322_574 { background-image: var(--gradient-img_6322_574); border:1px solid var(--border-img_6322_574); color:var(--text-img_6322_574); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_574 { background-image: var(--gradient-img_6322_574); border:1px solid var(--border-img_6322_574); color:var(--text-img_6322_574); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_575: linear-gradient(180deg, #333333 0%, #343739 100%); --border-img_6322_575: #818182; --text-img_6322_575: #fbfbfb; }
+.btn-img_6322_575 { background-image: var(--gradient-img_6322_575); border:1px solid var(--border-img_6322_575); color:var(--text-img_6322_575); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_575 { background-image: var(--gradient-img_6322_575); border:1px solid var(--border-img_6322_575); color:var(--text-img_6322_575); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_576: linear-gradient(180deg, #9a9a9a 0%, #494d50 100%); --border-img_6322_576: #8f9091; --text-img_6322_576: #cac9c9; }
+.btn-img_6322_576 { background-image: var(--gradient-img_6322_576); border:1px solid var(--border-img_6322_576); color:var(--text-img_6322_576); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_576 { background-image: var(--gradient-img_6322_576); border:1px solid var(--border-img_6322_576); color:var(--text-img_6322_576); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_577: linear-gradient(180deg, #aeadad 0%, #343739 100%); --border-img_6322_577: #727374; --text-img_6322_577: #fbfbfb; }
+.btn-img_6322_577 { background-image: var(--gradient-img_6322_577); border:1px solid var(--border-img_6322_577); color:var(--text-img_6322_577); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_577 { background-image: var(--gradient-img_6322_577); border:1px solid var(--border-img_6322_577); color:var(--text-img_6322_577); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6322_578: linear-gradient(180deg, #70ab62 0%, #343739 100%); --border-img_6322_578: #8a9988; --text-img_6322_578: #fbfbfb; }
+.btn-img_6322_578 { background-image: var(--gradient-img_6322_578); border:1px solid var(--border-img_6322_578); color:var(--text-img_6322_578); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6322_578 { background-image: var(--gradient-img_6322_578); border:1px solid var(--border-img_6322_578); color:var(--text-img_6322_578); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_579: linear-gradient(180deg, #5e6367 0%, #383838 100%); --border-img_6323_579: #494b4d; --text-img_6323_579: #45494c; }
+.btn-img_6323_579 { background-image: var(--gradient-img_6323_579); border:1px solid var(--border-img_6323_579); color:var(--text-img_6323_579); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_579 { background-image: var(--gradient-img_6323_579); border:1px solid var(--border-img_6323_579); color:var(--text-img_6323_579); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_580: linear-gradient(180deg, #5e6367 0%, #2f2f2f 100%); --border-img_6323_580: #484b4c; --text-img_6323_580: #45494c; }
+.btn-img_6323_580 { background-image: var(--gradient-img_6323_580); border:1px solid var(--border-img_6323_580); color:var(--text-img_6323_580); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_580 { background-image: var(--gradient-img_6323_580); border:1px solid var(--border-img_6323_580); color:var(--text-img_6323_580); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_581: linear-gradient(180deg, #5e6367 0%, #393b38 100%); --border-img_6323_581: #4b4d4e; --text-img_6323_581: #45494c; }
+.btn-img_6323_581 { background-image: var(--gradient-img_6323_581); border:1px solid var(--border-img_6323_581); color:var(--text-img_6323_581); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_581 { background-image: var(--gradient-img_6323_581); border:1px solid var(--border-img_6323_581); color:var(--text-img_6323_581); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_582: linear-gradient(180deg, #5e6367 0%, #373738 100%); --border-img_6323_582: #47494b; --text-img_6323_582: #45494c; }
+.btn-img_6323_582 { background-image: var(--gradient-img_6323_582); border:1px solid var(--border-img_6323_582); color:var(--text-img_6323_582); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_582 { background-image: var(--gradient-img_6323_582); border:1px solid var(--border-img_6323_582); color:var(--text-img_6323_582); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_583: linear-gradient(180deg, #5e6367 0%, #3b3b3b 100%); --border-img_6323_583: #494b4d; --text-img_6323_583: #45494c; }
+.btn-img_6323_583 { background-image: var(--gradient-img_6323_583); border:1px solid var(--border-img_6323_583); color:var(--text-img_6323_583); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_583 { background-image: var(--gradient-img_6323_583); border:1px solid var(--border-img_6323_583); color:var(--text-img_6323_583); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_584: linear-gradient(180deg, #5e6367 0%, #3b3d3b 100%); --border-img_6323_584: #4c4f50; --text-img_6323_584: #3a3c3d; }
+.btn-img_6323_584 { background-image: var(--gradient-img_6323_584); border:1px solid var(--border-img_6323_584); color:var(--text-img_6323_584); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_584 { background-image: var(--gradient-img_6323_584); border:1px solid var(--border-img_6323_584); color:var(--text-img_6323_584); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_585: linear-gradient(180deg, #5e6367 0%, #353635 100%); --border-img_6323_585: #494c4d; --text-img_6323_585: #3a3c3d; }
+.btn-img_6323_585 { background-image: var(--gradient-img_6323_585); border:1px solid var(--border-img_6323_585); color:var(--text-img_6323_585); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_585 { background-image: var(--gradient-img_6323_585); border:1px solid var(--border-img_6323_585); color:var(--text-img_6323_585); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_586: linear-gradient(180deg, #5e6367 0%, #383838 100%); --border-img_6323_586: #4a4d4f; --text-img_6323_586: #3a3c3d; }
+.btn-img_6323_586 { background-image: var(--gradient-img_6323_586); border:1px solid var(--border-img_6323_586); color:var(--text-img_6323_586); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_586 { background-image: var(--gradient-img_6323_586); border:1px solid var(--border-img_6323_586); color:var(--text-img_6323_586); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_587: linear-gradient(180deg, #5e6367 0%, #323232 100%); --border-img_6323_587: #4a4c4e; --text-img_6323_587: #393a3a; }
+.btn-img_6323_587 { background-image: var(--gradient-img_6323_587); border:1px solid var(--border-img_6323_587); color:var(--text-img_6323_587); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_587 { background-image: var(--gradient-img_6323_587); border:1px solid var(--border-img_6323_587); color:var(--text-img_6323_587); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_588: linear-gradient(180deg, #5e6367 0%, #2f2f2f 100%); --border-img_6323_588: #494c4d; --text-img_6323_588: #3a3b3b; }
+.btn-img_6323_588 { background-image: var(--gradient-img_6323_588); border:1px solid var(--border-img_6323_588); color:var(--text-img_6323_588); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_588 { background-image: var(--gradient-img_6323_588); border:1px solid var(--border-img_6323_588); color:var(--text-img_6323_588); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_589: linear-gradient(180deg, #5e6367 0%, #323232 100%); --border-img_6323_589: #4c4e50; --text-img_6323_589: #393a3a; }
+.btn-img_6323_589 { background-image: var(--gradient-img_6323_589); border:1px solid var(--border-img_6323_589); color:var(--text-img_6323_589); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_589 { background-image: var(--gradient-img_6323_589); border:1px solid var(--border-img_6323_589); color:var(--text-img_6323_589); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_590: linear-gradient(180deg, #5e6367 0%, #383838 100%); --border-img_6323_590: #494b4d; --text-img_6323_590: #393a3a; }
+.btn-img_6323_590 { background-image: var(--gradient-img_6323_590); border:1px solid var(--border-img_6323_590); color:var(--text-img_6323_590); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_590 { background-image: var(--gradient-img_6323_590); border:1px solid var(--border-img_6323_590); color:var(--text-img_6323_590); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_591: linear-gradient(180deg, #313131 0%, #212121 100%); --border-img_6323_591: #4c4b4b; --text-img_6323_591: #919191; }
+.btn-img_6323_591 { background-image: var(--gradient-img_6323_591); border:1px solid var(--border-img_6323_591); color:var(--text-img_6323_591); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_591 { background-image: var(--gradient-img_6323_591); border:1px solid var(--border-img_6323_591); color:var(--text-img_6323_591); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_592: linear-gradient(180deg, #2f2f2f 0%, #303030 100%); --border-img_6323_592: #4f534e; --text-img_6323_592: #8c8c8c; }
+.btn-img_6323_592 { background-image: var(--gradient-img_6323_592); border:1px solid var(--border-img_6323_592); color:var(--text-img_6323_592); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_592 { background-image: var(--gradient-img_6323_592); border:1px solid var(--border-img_6323_592); color:var(--text-img_6323_592); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_593: linear-gradient(180deg, #373836 0%, #3d423b 100%); --border-img_6323_593: #434542; --text-img_6323_593: #3a3e38; }
+.btn-img_6323_593 { background-image: var(--gradient-img_6323_593); border:1px solid var(--border-img_6323_593); color:var(--text-img_6323_593); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_593 { background-image: var(--gradient-img_6323_593); border:1px solid var(--border-img_6323_593); color:var(--text-img_6323_593); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_594: linear-gradient(180deg, #313131 0%, #222222 100%); --border-img_6323_594: #3a3939; --text-img_6323_594: #777575; }
+.btn-img_6323_594 { background-image: var(--gradient-img_6323_594); border:1px solid var(--border-img_6323_594); color:var(--text-img_6323_594); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_594 { background-image: var(--gradient-img_6323_594); border:1px solid var(--border-img_6323_594); color:var(--text-img_6323_594); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_595: linear-gradient(180deg, #363635 0%, #2f2f2f 100%); --border-img_6323_595: #3d3d3d; --text-img_6323_595: #2a2a2a; }
+.btn-img_6323_595 { background-image: var(--gradient-img_6323_595); border:1px solid var(--border-img_6323_595); color:var(--text-img_6323_595); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_595 { background-image: var(--gradient-img_6323_595); border:1px solid var(--border-img_6323_595); color:var(--text-img_6323_595); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_596: linear-gradient(180deg, #505250 0%, #3c3b3b 100%); --border-img_6323_596: #565655; --text-img_6323_596: #303030; }
+.btn-img_6323_596 { background-image: var(--gradient-img_6323_596); border:1px solid var(--border-img_6323_596); color:var(--text-img_6323_596); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_596 { background-image: var(--gradient-img_6323_596); border:1px solid var(--border-img_6323_596); color:var(--text-img_6323_596); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_597: linear-gradient(180deg, #3d3d3c 0%, #3c3b3b 100%); --border-img_6323_597: #545453; --text-img_6323_597: #383b37; }
+.btn-img_6323_597 { background-image: var(--gradient-img_6323_597); border:1px solid var(--border-img_6323_597); color:var(--text-img_6323_597); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_597 { background-image: var(--gradient-img_6323_597); border:1px solid var(--border-img_6323_597); color:var(--text-img_6323_597); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_598: linear-gradient(180deg, #343434 0%, #3c3b3b 100%); --border-img_6323_598: #444444; --text-img_6323_598: #363636; }
+.btn-img_6323_598 { background-image: var(--gradient-img_6323_598); border:1px solid var(--border-img_6323_598); color:var(--text-img_6323_598); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_598 { background-image: var(--gradient-img_6323_598); border:1px solid var(--border-img_6323_598); color:var(--text-img_6323_598); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_599: linear-gradient(180deg, #9a9a9a 0%, #505050 100%); --border-img_6323_599: #5b5a5a; --text-img_6323_599: #3e3d3d; }
+.btn-img_6323_599 { background-image: var(--gradient-img_6323_599); border:1px solid var(--border-img_6323_599); color:var(--text-img_6323_599); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_599 { background-image: var(--gradient-img_6323_599); border:1px solid var(--border-img_6323_599); color:var(--text-img_6323_599); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_600: linear-gradient(180deg, #ffffff 0%, #424242 100%); --border-img_6323_600: #616261; --text-img_6323_600: #40463e; }
+.btn-img_6323_600 { background-image: var(--gradient-img_6323_600); border:1px solid var(--border-img_6323_600); color:var(--text-img_6323_600); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_600 { background-image: var(--gradient-img_6323_600); border:1px solid var(--border-img_6323_600); color:var(--text-img_6323_600); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_601: linear-gradient(180deg, #858383 0%, #454945 100%); --border-img_6323_601: #515150; --text-img_6323_601: #363636; }
+.btn-img_6323_601 { background-image: var(--gradient-img_6323_601); border:1px solid var(--border-img_6323_601); color:var(--text-img_6323_601); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_601 { background-image: var(--gradient-img_6323_601); border:1px solid var(--border-img_6323_601); color:var(--text-img_6323_601); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_602: linear-gradient(180deg, #373737 0%, #424442 100%); --border-img_6323_602: #3f403f; --text-img_6323_602: #3d3c3c; }
+.btn-img_6323_602 { background-image: var(--gradient-img_6323_602); border:1px solid var(--border-img_6323_602); color:var(--text-img_6323_602); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_602 { background-image: var(--gradient-img_6323_602); border:1px solid var(--border-img_6323_602); color:var(--text-img_6323_602); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_603: linear-gradient(180deg, #3c3b3b 0%, #fefefe 100%); --border-img_6323_603: #696969; --text-img_6323_603: #4e4e4e; }
+.btn-img_6323_603 { background-image: var(--gradient-img_6323_603); border:1px solid var(--border-img_6323_603); color:var(--text-img_6323_603); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_603 { background-image: var(--gradient-img_6323_603); border:1px solid var(--border-img_6323_603); color:var(--text-img_6323_603); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_604: linear-gradient(180deg, #3c3b3b 0%, #8e8e8e 100%); --border-img_6323_604: #555555; --text-img_6323_604: #424242; }
+.btn-img_6323_604 { background-image: var(--gradient-img_6323_604); border:1px solid var(--border-img_6323_604); color:var(--text-img_6323_604); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_604 { background-image: var(--gradient-img_6323_604); border:1px solid var(--border-img_6323_604); color:var(--text-img_6323_604); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_605: linear-gradient(180deg, #3c3b3b 0%, #494949 100%); --border-img_6323_605: #4d4e4d; --text-img_6323_605: #424242; }
+.btn-img_6323_605 { background-image: var(--gradient-img_6323_605); border:1px solid var(--border-img_6323_605); color:var(--text-img_6323_605); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_605 { background-image: var(--gradient-img_6323_605); border:1px solid var(--border-img_6323_605); color:var(--text-img_6323_605); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_606: linear-gradient(180deg, #3c3b3b 0%, #e3e1e1 100%); --border-img_6323_606: #656664; --text-img_6323_606: #464646; }
+.btn-img_6323_606 { background-image: var(--gradient-img_6323_606); border:1px solid var(--border-img_6323_606); color:var(--text-img_6323_606); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_606 { background-image: var(--gradient-img_6323_606); border:1px solid var(--border-img_6323_606); color:var(--text-img_6323_606); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_607: linear-gradient(180deg, #3c3b3b 0%, #474d46 100%); --border-img_6323_607: #4a5248; --text-img_6323_607: #434343; }
+.btn-img_6323_607 { background-image: var(--gradient-img_6323_607); border:1px solid var(--border-img_6323_607); color:var(--text-img_6323_607); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_607 { background-image: var(--gradient-img_6323_607); border:1px solid var(--border-img_6323_607); color:var(--text-img_6323_607); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_608: linear-gradient(180deg, #4d4d4d 0%, #464646 100%); --border-img_6323_608: #5f5e5e; --text-img_6323_608: #6e6e6e; }
+.btn-img_6323_608 { background-image: var(--gradient-img_6323_608); border:1px solid var(--border-img_6323_608); color:var(--text-img_6323_608); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_608 { background-image: var(--gradient-img_6323_608); border:1px solid var(--border-img_6323_608); color:var(--text-img_6323_608); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_609: linear-gradient(180deg, #434542 0%, #434642 100%); --border-img_6323_609: #555754; --text-img_6323_609: #414141; }
+.btn-img_6323_609 { background-image: var(--gradient-img_6323_609); border:1px solid var(--border-img_6323_609); color:var(--text-img_6323_609); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_609 { background-image: var(--gradient-img_6323_609); border:1px solid var(--border-img_6323_609); color:var(--text-img_6323_609); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_610: linear-gradient(180deg, #424442 0%, #444643 100%); --border-img_6323_610: #575e55; --text-img_6323_610: #454944; }
+.btn-img_6323_610 { background-image: var(--gradient-img_6323_610); border:1px solid var(--border-img_6323_610); color:var(--text-img_6323_610); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_610 { background-image: var(--gradient-img_6323_610); border:1px solid var(--border-img_6323_610); color:var(--text-img_6323_610); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_611: linear-gradient(180deg, #c9c9c9 0%, #7a7a7a 100%); --border-img_6323_611: #6f6e6e; --text-img_6323_611: #4e4e4e; }
+.btn-img_6323_611 { background-image: var(--gradient-img_6323_611); border:1px solid var(--border-img_6323_611); color:var(--text-img_6323_611); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_611 { background-image: var(--gradient-img_6323_611); border:1px solid var(--border-img_6323_611); color:var(--text-img_6323_611); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_612: linear-gradient(180deg, #b8b8b8 0%, #7a7a7a 100%); --border-img_6323_612: #636363; --text-img_6323_612: #444444; }
+.btn-img_6323_612 { background-image: var(--gradient-img_6323_612); border:1px solid var(--border-img_6323_612); color:var(--text-img_6323_612); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_612 { background-image: var(--gradient-img_6323_612); border:1px solid var(--border-img_6323_612); color:var(--text-img_6323_612); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_613: linear-gradient(180deg, #989a96 0%, #696a68 100%); --border-img_6323_613: #646563; --text-img_6323_613: #4b5449; }
+.btn-img_6323_613 { background-image: var(--gradient-img_6323_613); border:1px solid var(--border-img_6323_613); color:var(--text-img_6323_613); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_613 { background-image: var(--gradient-img_6323_613); border:1px solid var(--border-img_6323_613); color:var(--text-img_6323_613); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_614: linear-gradient(180deg, #424442 0%, #676967 100%); --border-img_6323_614: #61675f; --text-img_6323_614: #3d3c3c; }
+.btn-img_6323_614 { background-image: var(--gradient-img_6323_614); border:1px solid var(--border-img_6323_614); color:var(--text-img_6323_614); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_614 { background-image: var(--gradient-img_6323_614); border:1px solid var(--border-img_6323_614); color:var(--text-img_6323_614); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_615: linear-gradient(180deg, #444444 0%, #747474 100%); --border-img_6323_615: #5d5c5c; --text-img_6323_615: #575656; }
+.btn-img_6323_615 { background-image: var(--gradient-img_6323_615); border:1px solid var(--border-img_6323_615); color:var(--text-img_6323_615); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_615 { background-image: var(--gradient-img_6323_615); border:1px solid var(--border-img_6323_615); color:var(--text-img_6323_615); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_616: linear-gradient(180deg, #424242 0%, #747474 100%); --border-img_6323_616: #515151; --text-img_6323_616: #515151; }
+.btn-img_6323_616 { background-image: var(--gradient-img_6323_616); border:1px solid var(--border-img_6323_616); color:var(--text-img_6323_616); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_616 { background-image: var(--gradient-img_6323_616); border:1px solid var(--border-img_6323_616); color:var(--text-img_6323_616); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_617: linear-gradient(180deg, #403f3f 0%, #565555 100%); --border-img_6323_617: #4d4e4c; --text-img_6323_617: #3c3b3b; }
+.btn-img_6323_617 { background-image: var(--gradient-img_6323_617); border:1px solid var(--border-img_6323_617); color:var(--text-img_6323_617); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_617 { background-image: var(--gradient-img_6323_617); border:1px solid var(--border-img_6323_617); color:var(--text-img_6323_617); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_618: linear-gradient(180deg, #424242 0%, #757474 100%); --border-img_6323_618: #5b5d5a; --text-img_6323_618: #4f554d; }
+.btn-img_6323_618 { background-image: var(--gradient-img_6323_618); border:1px solid var(--border-img_6323_618); color:var(--text-img_6323_618); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_618 { background-image: var(--gradient-img_6323_618); border:1px solid var(--border-img_6323_618); color:var(--text-img_6323_618); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_619: linear-gradient(180deg, #404040 0%, #60615f 100%); --border-img_6323_619: #585957; --text-img_6323_619: #3c3b3b; }
+.btn-img_6323_619 { background-image: var(--gradient-img_6323_619); border:1px solid var(--border-img_6323_619); color:var(--text-img_6323_619); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_619 { background-image: var(--gradient-img_6323_619); border:1px solid var(--border-img_6323_619); color:var(--text-img_6323_619); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_620: linear-gradient(180deg, #717171 0%, #5e5e5e 100%); --border-img_6323_620: #6b6a6a; --text-img_6323_620: #757575; }
+.btn-img_6323_620 { background-image: var(--gradient-img_6323_620); border:1px solid var(--border-img_6323_620); color:var(--text-img_6323_620); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_620 { background-image: var(--gradient-img_6323_620); border:1px solid var(--border-img_6323_620); color:var(--text-img_6323_620); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_621: linear-gradient(180deg, #535252 0%, #504f4f 100%); --border-img_6323_621: #606060; --text-img_6323_621: #545353; }
+.btn-img_6323_621 { background-image: var(--gradient-img_6323_621); border:1px solid var(--border-img_6323_621); color:var(--text-img_6323_621); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_621 { background-image: var(--gradient-img_6323_621); border:1px solid var(--border-img_6323_621); color:var(--text-img_6323_621); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_622: linear-gradient(180deg, #63775f 0%, #5e5e5d 100%); --border-img_6323_622: #676965; --text-img_6323_622: #737673; }
+.btn-img_6323_622 { background-image: var(--gradient-img_6323_622); border:1px solid var(--border-img_6323_622); color:var(--text-img_6323_622); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_622 { background-image: var(--gradient-img_6323_622); border:1px solid var(--border-img_6323_622); color:var(--text-img_6323_622); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_623: linear-gradient(180deg, #a2a2a2 0%, #bdbcbc 100%); --border-img_6323_623: #7d7c7c; --text-img_6323_623: #626161; }
+.btn-img_6323_623 { background-image: var(--gradient-img_6323_623); border:1px solid var(--border-img_6323_623); color:var(--text-img_6323_623); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_623 { background-image: var(--gradient-img_6323_623); border:1px solid var(--border-img_6323_623); color:var(--text-img_6323_623); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_624: linear-gradient(180deg, #bfbfbf 0%, #c2c1c1 100%); --border-img_6323_624: #818080; --text-img_6323_624: #616060; }
+.btn-img_6323_624 { background-image: var(--gradient-img_6323_624); border:1px solid var(--border-img_6323_624); color:var(--text-img_6323_624); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_624 { background-image: var(--gradient-img_6323_624); border:1px solid var(--border-img_6323_624); color:var(--text-img_6323_624); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_625: linear-gradient(180deg, #737572 0%, #c1c1c1 100%); --border-img_6323_625: #7b7b7a; --text-img_6323_625: #636561; }
+.btn-img_6323_625 { background-image: var(--gradient-img_6323_625); border:1px solid var(--border-img_6323_625); color:var(--text-img_6323_625); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_625 { background-image: var(--gradient-img_6323_625); border:1px solid var(--border-img_6323_625); color:var(--text-img_6323_625); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_626: linear-gradient(180deg, #60625f 0%, #807f7f 100%); --border-img_6323_626: #7b7f7a; --text-img_6323_626: #464a44; }
+.btn-img_6323_626 { background-image: var(--gradient-img_6323_626); border:1px solid var(--border-img_6323_626); color:var(--text-img_6323_626); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_626 { background-image: var(--gradient-img_6323_626); border:1px solid var(--border-img_6323_626); color:var(--text-img_6323_626); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_627: linear-gradient(180deg, #f4f4f4 0%, #3a3939 100%); --border-img_6323_627: #969595; --text-img_6323_627: #605f5f; }
+.btn-img_6323_627 { background-image: var(--gradient-img_6323_627); border:1px solid var(--border-img_6323_627); color:var(--text-img_6323_627); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_627 { background-image: var(--gradient-img_6323_627); border:1px solid var(--border-img_6323_627); color:var(--text-img_6323_627); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_628: linear-gradient(180deg, #b3b2b2 0%, #3a393a 100%); --border-img_6323_628: #616060; --text-img_6323_628: #605f5f; }
+.btn-img_6323_628 { background-image: var(--gradient-img_6323_628); border:1px solid var(--border-img_6323_628); color:var(--text-img_6323_628); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_628 { background-image: var(--gradient-img_6323_628); border:1px solid var(--border-img_6323_628); color:var(--text-img_6323_628); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_629: linear-gradient(180deg, #525151 0%, #3a3939 100%); --border-img_6323_629: #555455; --text-img_6323_629: #4c4b4b; }
+.btn-img_6323_629 { background-image: var(--gradient-img_6323_629); border:1px solid var(--border-img_6323_629); color:var(--text-img_6323_629); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_629 { background-image: var(--gradient-img_6323_629); border:1px solid var(--border-img_6323_629); color:var(--text-img_6323_629); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_630: linear-gradient(180deg, #ffffff 0%, #3a3939 100%); --border-img_6323_630: #8f8f8e; --text-img_6323_630: #605f5f; }
+.btn-img_6323_630 { background-image: var(--gradient-img_6323_630); border:1px solid var(--border-img_6323_630); color:var(--text-img_6323_630); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_630 { background-image: var(--gradient-img_6323_630); border:1px solid var(--border-img_6323_630); color:var(--text-img_6323_630); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_631: linear-gradient(180deg, #5b5d5a 0%, #3a393a 100%); --border-img_6323_631: #656c63; --text-img_6323_631: #504f4f; }
+.btn-img_6323_631 { background-image: var(--gradient-img_6323_631); border:1px solid var(--border-img_6323_631); color:var(--text-img_6323_631); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_631 { background-image: var(--gradient-img_6323_631); border:1px solid var(--border-img_6323_631); color:var(--text-img_6323_631); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_632: linear-gradient(180deg, #3a3a3a 0%, #a3a3a3 100%); --border-img_6323_632: #8e8e8e; --text-img_6323_632: #b0b0b0; }
+.btn-img_6323_632 { background-image: var(--gradient-img_6323_632); border:1px solid var(--border-img_6323_632); color:var(--text-img_6323_632); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_632 { background-image: var(--gradient-img_6323_632); border:1px solid var(--border-img_6323_632); color:var(--text-img_6323_632); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_633: linear-gradient(180deg, #3a3a3a 0%, #8b8a8a 100%); --border-img_6323_633: #656665; --text-img_6323_633: #5b5a5a; }
+.btn-img_6323_633 { background-image: var(--gradient-img_6323_633); border:1px solid var(--border-img_6323_633); color:var(--text-img_6323_633); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_633 { background-image: var(--gradient-img_6323_633); border:1px solid var(--border-img_6323_633); color:var(--text-img_6323_633); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_634: linear-gradient(180deg, #3a3a3a 0%, #7f7e7e 100%); --border-img_6323_634: #70766e; --text-img_6323_634: #3a3939; }
+.btn-img_6323_634 { background-image: var(--gradient-img_6323_634); border:1px solid var(--border-img_6323_634); color:var(--text-img_6323_634); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_634 { background-image: var(--gradient-img_6323_634); border:1px solid var(--border-img_6323_634); color:var(--text-img_6323_634); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_635: linear-gradient(180deg, #bababa 0%, #a3a2a2 100%); --border-img_6323_635: #b8b7b7; --text-img_6323_635: #f4f4f4; }
+.btn-img_6323_635 { background-image: var(--gradient-img_6323_635); border:1px solid var(--border-img_6323_635); color:var(--text-img_6323_635); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_635 { background-image: var(--gradient-img_6323_635); border:1px solid var(--border-img_6323_635); color:var(--text-img_6323_635); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_636: linear-gradient(180deg, #bbbbbb 0%, #a4a3a3 100%); --border-img_6323_636: #7d7c7c; --text-img_6323_636: #565656; }
+.btn-img_6323_636 { background-image: var(--gradient-img_6323_636); border:1px solid var(--border-img_6323_636); color:var(--text-img_6323_636); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_636 { background-image: var(--gradient-img_6323_636); border:1px solid var(--border-img_6323_636); color:var(--text-img_6323_636); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_637: linear-gradient(180deg, #757474 0%, #6b6a6a 100%); --border-img_6323_637: #979696; --text-img_6323_637: #4a4949; }
+.btn-img_6323_637 { background-image: var(--gradient-img_6323_637); border:1px solid var(--border-img_6323_637); color:var(--text-img_6323_637); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_637 { background-image: var(--gradient-img_6323_637); border:1px solid var(--border-img_6323_637); color:var(--text-img_6323_637); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_638: linear-gradient(180deg, #bbbaba 0%, #a4a2a2 100%); --border-img_6323_638: #a4a3a3; --text-img_6323_638: #343434; }
+.btn-img_6323_638 { background-image: var(--gradient-img_6323_638); border:1px solid var(--border-img_6323_638); color:var(--text-img_6323_638); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_638 { background-image: var(--gradient-img_6323_638); border:1px solid var(--border-img_6323_638); color:var(--text-img_6323_638); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_639: linear-gradient(180deg, #a6a6a6 0%, #949292 100%); --border-img_6323_639: #767774; --text-img_6323_639: #a2a5a1; }
+.btn-img_6323_639 { background-image: var(--gradient-img_6323_639); border:1px solid var(--border-img_6323_639); color:var(--text-img_6323_639); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_639 { background-image: var(--gradient-img_6323_639); border:1px solid var(--border-img_6323_639); color:var(--text-img_6323_639); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_640: linear-gradient(180deg, #bbbbbb 0%, #3a3939 100%); --border-img_6323_640: #8e8d8d; --text-img_6323_640: #a6a4a4; }
+.btn-img_6323_640 { background-image: var(--gradient-img_6323_640); border:1px solid var(--border-img_6323_640); color:var(--text-img_6323_640); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_640 { background-image: var(--gradient-img_6323_640); border:1px solid var(--border-img_6323_640); color:var(--text-img_6323_640); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_641: linear-gradient(180deg, #b5b5b5 0%, #3a3939 100%); --border-img_6323_641: #afafaf; --text-img_6323_641: #a7a5a5; }
+.btn-img_6323_641 { background-image: var(--gradient-img_6323_641); border:1px solid var(--border-img_6323_641); color:var(--text-img_6323_641); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_641 { background-image: var(--gradient-img_6323_641); border:1px solid var(--border-img_6323_641); color:var(--text-img_6323_641); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_642: linear-gradient(180deg, #908f8f 0%, #3a3939 100%); --border-img_6323_642: #808080; --text-img_6323_642: #a6a4a4; }
+.btn-img_6323_642 { background-image: var(--gradient-img_6323_642); border:1px solid var(--border-img_6323_642); color:var(--text-img_6323_642); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_642 { background-image: var(--gradient-img_6323_642); border:1px solid var(--border-img_6323_642); color:var(--text-img_6323_642); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_643: linear-gradient(180deg, #807f7f 0%, #474646 100%); --border-img_6323_643: #90928f; --text-img_6323_643: #898787; }
+.btn-img_6323_643 { background-image: var(--gradient-img_6323_643); border:1px solid var(--border-img_6323_643); color:var(--text-img_6323_643); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_643 { background-image: var(--gradient-img_6323_643); border:1px solid var(--border-img_6323_643); color:var(--text-img_6323_643); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_644: linear-gradient(180deg, #868585 0%, #b3b3b3 100%); --border-img_6323_644: #acabab; --text-img_6323_644: #474646; }
+.btn-img_6323_644 { background-image: var(--gradient-img_6323_644); border:1px solid var(--border-img_6323_644); color:var(--text-img_6323_644); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_644 { background-image: var(--gradient-img_6323_644); border:1px solid var(--border-img_6323_644); color:var(--text-img_6323_644); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_645: linear-gradient(180deg, #838282 0%, #9d9d9c 100%); --border-img_6323_645: #a7a7a6; --text-img_6323_645: #3b3a3a; }
+.btn-img_6323_645 { background-image: var(--gradient-img_6323_645); border:1px solid var(--border-img_6323_645); color:var(--text-img_6323_645); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_645 { background-image: var(--gradient-img_6323_645); border:1px solid var(--border-img_6323_645); color:var(--text-img_6323_645); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_646: linear-gradient(180deg, #797878 0%, #a8a8a8 100%); --border-img_6323_646: #aaa9a9; --text-img_6323_646: #3a3a39; }
+.btn-img_6323_646 { background-image: var(--gradient-img_6323_646); border:1px solid var(--border-img_6323_646); color:var(--text-img_6323_646); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_646 { background-image: var(--gradient-img_6323_646); border:1px solid var(--border-img_6323_646); color:var(--text-img_6323_646); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_647: linear-gradient(180deg, #3a3939 0%, #565555 100%); --border-img_6323_647: #878787; --text-img_6323_647: #eaeaea; }
+.btn-img_6323_647 { background-image: var(--gradient-img_6323_647); border:1px solid var(--border-img_6323_647); color:var(--text-img_6323_647); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_647 { background-image: var(--gradient-img_6323_647); border:1px solid var(--border-img_6323_647); color:var(--text-img_6323_647); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_648: linear-gradient(180deg, #3a3939 0%, #91a18e 100%); --border-img_6323_648: #5f645d; --text-img_6323_648: #eaeaea; }
+.btn-img_6323_648 { background-image: var(--gradient-img_6323_648); border:1px solid var(--border-img_6323_648); color:var(--text-img_6323_648); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_648 { background-image: var(--gradient-img_6323_648); border:1px solid var(--border-img_6323_648); color:var(--text-img_6323_648); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_649: linear-gradient(180deg, #3a3939 0%, #8e908d 100%); --border-img_6323_649: #7e837d; --text-img_6323_649: #a0a0a0; }
+.btn-img_6323_649 { background-image: var(--gradient-img_6323_649); border:1px solid var(--border-img_6323_649); color:var(--text-img_6323_649); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_649 { background-image: var(--gradient-img_6323_649); border:1px solid var(--border-img_6323_649); color:var(--text-img_6323_649); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_650: linear-gradient(180deg, #3a3939 0%, #518a43 100%); --border-img_6323_650: #859482; --text-img_6323_650: #eaeaea; }
+.btn-img_6323_650 { background-image: var(--gradient-img_6323_650); border:1px solid var(--border-img_6323_650); color:var(--text-img_6323_650); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_650 { background-image: var(--gradient-img_6323_650); border:1px solid var(--border-img_6323_650); color:var(--text-img_6323_650); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_651: linear-gradient(180deg, #3a3939 0%, #919191 100%); --border-img_6323_651: #989797; --text-img_6323_651: #a3a2a2; }
+.btn-img_6323_651 { background-image: var(--gradient-img_6323_651); border:1px solid var(--border-img_6323_651); color:var(--text-img_6323_651); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_651 { background-image: var(--gradient-img_6323_651); border:1px solid var(--border-img_6323_651); color:var(--text-img_6323_651); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_652: linear-gradient(180deg, #ededed 0%, #393838 100%); --border-img_6323_652: #858484; --text-img_6323_652: #f0f0f0; }
+.btn-img_6323_652 { background-image: var(--gradient-img_6323_652); border:1px solid var(--border-img_6323_652); color:var(--text-img_6323_652); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_652 { background-image: var(--gradient-img_6323_652); border:1px solid var(--border-img_6323_652); color:var(--text-img_6323_652); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_653: linear-gradient(180deg, #ededed 0%, #393838 100%); --border-img_6323_653: #cacec9; --text-img_6323_653: #eceeec; }
+.btn-img_6323_653 { background-image: var(--gradient-img_6323_653); border:1px solid var(--border-img_6323_653); color:var(--text-img_6323_653); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_653 { background-image: var(--gradient-img_6323_653); border:1px solid var(--border-img_6323_653); color:var(--text-img_6323_653); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_654: linear-gradient(180deg, #d7d8d6 0%, #393838 100%); --border-img_6323_654: #7d817c; --text-img_6323_654: #f2f4f1; }
+.btn-img_6323_654 { background-image: var(--gradient-img_6323_654); border:1px solid var(--border-img_6323_654); color:var(--text-img_6323_654); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_654 { background-image: var(--gradient-img_6323_654); border:1px solid var(--border-img_6323_654); color:var(--text-img_6323_654); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_655: linear-gradient(180deg, #929291 0%, #393838 100%); --border-img_6323_655: #9ea19d; --text-img_6323_655: #393838; }
+.btn-img_6323_655 { background-image: var(--gradient-img_6323_655); border:1px solid var(--border-img_6323_655); color:var(--text-img_6323_655); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_655 { background-image: var(--gradient-img_6323_655); border:1px solid var(--border-img_6323_655); color:var(--text-img_6323_655); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_656: linear-gradient(180deg, #7c7b7b 0%, #aeafae 100%); --border-img_6323_656: #a7a9a7; --text-img_6323_656: #a9a9a9; }
+.btn-img_6323_656 { background-image: var(--gradient-img_6323_656); border:1px solid var(--border-img_6323_656); color:var(--text-img_6323_656); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_656 { background-image: var(--gradient-img_6323_656); border:1px solid var(--border-img_6323_656); color:var(--text-img_6323_656); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_657: linear-gradient(180deg, #777f75 0%, #9a9a99 100%); --border-img_6323_657: #a3a9a1; --text-img_6323_657: #6b6a6a; }
+.btn-img_6323_657 { background-image: var(--gradient-img_6323_657); border:1px solid var(--border-img_6323_657); color:var(--text-img_6323_657); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_657 { background-image: var(--gradient-img_6323_657); border:1px solid var(--border-img_6323_657); color:var(--text-img_6323_657); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_658: linear-gradient(180deg, #7f8e7a 0%, #9d9d9d 100%); --border-img_6323_658: #979e94; --text-img_6323_658: #636562; }
+.btn-img_6323_658 { background-image: var(--gradient-img_6323_658); border:1px solid var(--border-img_6323_658); color:var(--text-img_6323_658); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_658 { background-image: var(--gradient-img_6323_658); border:1px solid var(--border-img_6323_658); color:var(--text-img_6323_658); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_659: linear-gradient(180deg, #fafafa 0%, #ebebeb 100%); --border-img_6323_659: #d1d1d1; --text-img_6323_659: #3b3a3a; }
+.btn-img_6323_659 { background-image: var(--gradient-img_6323_659); border:1px solid var(--border-img_6323_659); color:var(--text-img_6323_659); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_659 { background-image: var(--gradient-img_6323_659); border:1px solid var(--border-img_6323_659); color:var(--text-img_6323_659); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_660: linear-gradient(180deg, #fafafa 0%, #ebebeb 100%); --border-img_6323_660: #a3a3a2; --text-img_6323_660: #3d3d3c; }
+.btn-img_6323_660 { background-image: var(--gradient-img_6323_660); border:1px solid var(--border-img_6323_660); color:var(--text-img_6323_660); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_660 { background-image: var(--gradient-img_6323_660); border:1px solid var(--border-img_6323_660); color:var(--text-img_6323_660); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_661: linear-gradient(180deg, #9f9e9e 0%, #9e9e9d 100%); --border-img_6323_661: #989897; --text-img_6323_661: #393838; }
+.btn-img_6323_661 { background-image: var(--gradient-img_6323_661); border:1px solid var(--border-img_6323_661); color:var(--text-img_6323_661); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_661 { background-image: var(--gradient-img_6323_661); border:1px solid var(--border-img_6323_661); color:var(--text-img_6323_661); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_662: linear-gradient(180deg, #fafafa 0%, #ebebeb 100%); --border-img_6323_662: #d3d4d3; --text-img_6323_662: #3b3a3a; }
+.btn-img_6323_662 { background-image: var(--gradient-img_6323_662); border:1px solid var(--border-img_6323_662); color:var(--text-img_6323_662); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_662 { background-image: var(--gradient-img_6323_662); border:1px solid var(--border-img_6323_662); color:var(--text-img_6323_662); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_663: linear-gradient(180deg, #939191 0%, #464545 100%); --border-img_6323_663: #8b8b8b; --text-img_6323_663: #424141; }
+.btn-img_6323_663 { background-image: var(--gradient-img_6323_663); border:1px solid var(--border-img_6323_663); color:var(--text-img_6323_663); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_663 { background-image: var(--gradient-img_6323_663); border:1px solid var(--border-img_6323_663); color:var(--text-img_6323_663); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_664: linear-gradient(180deg, #ececec 0%, #343739 100%); --border-img_6323_664: #777878; --text-img_6323_664: #dbdbdb; }
+.btn-img_6323_664 { background-image: var(--gradient-img_6323_664); border:1px solid var(--border-img_6323_664); color:var(--text-img_6323_664); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_664 { background-image: var(--gradient-img_6323_664); border:1px solid var(--border-img_6323_664); color:var(--text-img_6323_664); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_665: linear-gradient(180deg, #ececec 0%, #343739 100%); --border-img_6323_665: #b1b2b3; --text-img_6323_665: #d3e3cf; }
+.btn-img_6323_665 { background-image: var(--gradient-img_6323_665); border:1px solid var(--border-img_6323_665); color:var(--text-img_6323_665); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_665 { background-image: var(--gradient-img_6323_665); border:1px solid var(--border-img_6323_665); color:var(--text-img_6323_665); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_666: linear-gradient(180deg, #d0d0d0 0%, #343739 100%); --border-img_6323_666: #737374; --text-img_6323_666: #eaeaea; }
+.btn-img_6323_666 { background-image: var(--gradient-img_6323_666); border:1px solid var(--border-img_6323_666); color:var(--text-img_6323_666); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_666 { background-image: var(--gradient-img_6323_666); border:1px solid var(--border-img_6323_666); color:var(--text-img_6323_666); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_667: linear-gradient(180deg, #6a6a6a 0%, #343739 100%); --border-img_6323_667: #767777; --text-img_6323_667: #464646; }
+.btn-img_6323_667 { background-image: var(--gradient-img_6323_667); border:1px solid var(--border-img_6323_667); color:var(--text-img_6323_667); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_667 { background-image: var(--gradient-img_6323_667); border:1px solid var(--border-img_6323_667); color:var(--text-img_6323_667); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_668: linear-gradient(180deg, #b4b4b3 0%, #343739 100%); --border-img_6323_668: #8d908e; --text-img_6323_668: #edecec; }
+.btn-img_6323_668 { background-image: var(--gradient-img_6323_668); border:1px solid var(--border-img_6323_668); color:var(--text-img_6323_668); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_668 { background-image: var(--gradient-img_6323_668); border:1px solid var(--border-img_6323_668); color:var(--text-img_6323_668); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_669: linear-gradient(180deg, #9e9f9e 0%, #3c4042 100%); --border-img_6323_669: #8a918b; --text-img_6323_669: #b1b2b0; }
+.btn-img_6323_669 { background-image: var(--gradient-img_6323_669); border:1px solid var(--border-img_6323_669); color:var(--text-img_6323_669); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_669 { background-image: var(--gradient-img_6323_669); border:1px solid var(--border-img_6323_669); color:var(--text-img_6323_669); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_670: linear-gradient(180deg, #a2a2a2 0%, #343739 100%); --border-img_6323_670: #737475; --text-img_6323_670: #b1b1b1; }
+.btn-img_6323_670 { background-image: var(--gradient-img_6323_670); border:1px solid var(--border-img_6323_670); color:var(--text-img_6323_670); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_670 { background-image: var(--gradient-img_6323_670); border:1px solid var(--border-img_6323_670); color:var(--text-img_6323_670); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_671: linear-gradient(180deg, #7c7b7b 0%, #343739 100%); --border-img_6323_671: #8d8d8e; --text-img_6323_671: #fbfbfb; }
+.btn-img_6323_671 { background-image: var(--gradient-img_6323_671); border:1px solid var(--border-img_6323_671); color:var(--text-img_6323_671); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_671 { background-image: var(--gradient-img_6323_671); border:1px solid var(--border-img_6323_671); color:var(--text-img_6323_671); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_672: linear-gradient(180deg, #aacba2 0%, #343739 100%); --border-img_6323_672: #677366; --text-img_6323_672: #fbfbfb; }
+.btn-img_6323_672 { background-image: var(--gradient-img_6323_672); border:1px solid var(--border-img_6323_672); color:var(--text-img_6323_672); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_672 { background-image: var(--gradient-img_6323_672); border:1px solid var(--border-img_6323_672); color:var(--text-img_6323_672); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_673: linear-gradient(180deg, #999d97 0%, #494d50 100%); --border-img_6323_673: #747a74; --text-img_6323_673: #bcbfbc; }
+.btn-img_6323_673 { background-image: var(--gradient-img_6323_673); border:1px solid var(--border-img_6323_673); color:var(--text-img_6323_673); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_673 { background-image: var(--gradient-img_6323_673); border:1px solid var(--border-img_6323_673); color:var(--text-img_6323_673); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_674: linear-gradient(180deg, #4a4a4a 0%, #343739 100%); --border-img_6323_674: #8e8f90; --text-img_6323_674: #fbfbfb; }
+.btn-img_6323_674 { background-image: var(--gradient-img_6323_674); border:1px solid var(--border-img_6323_674); color:var(--text-img_6323_674); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_674 { background-image: var(--gradient-img_6323_674); border:1px solid var(--border-img_6323_674); color:var(--text-img_6323_674); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6323_675: linear-gradient(180deg, #525252 0%, #343739 100%); --border-img_6323_675: #78797a; --text-img_6323_675: #575757; }
+.btn-img_6323_675 { background-image: var(--gradient-img_6323_675); border:1px solid var(--border-img_6323_675); color:var(--text-img_6323_675); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6323_675 { background-image: var(--gradient-img_6323_675); border:1px solid var(--border-img_6323_675); color:var(--text-img_6323_675); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_676: linear-gradient(180deg, #5e6367 0%, #2f2f2f 100%); --border-img_6324_676: #474a4b; --text-img_6324_676: #45494c; }
+.btn-img_6324_676 { background-image: var(--gradient-img_6324_676); border:1px solid var(--border-img_6324_676); color:var(--text-img_6324_676); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_676 { background-image: var(--gradient-img_6324_676); border:1px solid var(--border-img_6324_676); color:var(--text-img_6324_676); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_677: linear-gradient(180deg, #5e6367 0%, #383b37 100%); --border-img_6324_677: #494b4c; --text-img_6324_677: #45494c; }
+.btn-img_6324_677 { background-image: var(--gradient-img_6324_677); border:1px solid var(--border-img_6324_677); color:var(--text-img_6324_677); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_677 { background-image: var(--gradient-img_6324_677); border:1px solid var(--border-img_6324_677); color:var(--text-img_6324_677); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_678: linear-gradient(180deg, #5e6367 0%, #373738 100%); --border-img_6324_678: #4b4d4f; --text-img_6324_678: #45494c; }
+.btn-img_6324_678 { background-image: var(--gradient-img_6324_678); border:1px solid var(--border-img_6324_678); color:var(--text-img_6324_678); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_678 { background-image: var(--gradient-img_6324_678); border:1px solid var(--border-img_6324_678); color:var(--text-img_6324_678); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_679: linear-gradient(180deg, #5e6367 0%, #3b3b3b 100%); --border-img_6324_679: #484a4c; --text-img_6324_679: #45494c; }
+.btn-img_6324_679 { background-image: var(--gradient-img_6324_679); border:1px solid var(--border-img_6324_679); color:var(--text-img_6324_679); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_679 { background-image: var(--gradient-img_6324_679); border:1px solid var(--border-img_6324_679); color:var(--text-img_6324_679); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_680: linear-gradient(180deg, #5e6367 0%, #393939 100%); --border-img_6324_680: #494b4d; --text-img_6324_680: #45494c; }
+.btn-img_6324_680 { background-image: var(--gradient-img_6324_680); border:1px solid var(--border-img_6324_680); color:var(--text-img_6324_680); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_680 { background-image: var(--gradient-img_6324_680); border:1px solid var(--border-img_6324_680); color:var(--text-img_6324_680); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_681: linear-gradient(180deg, #5e6367 0%, #2f2f2f 100%); --border-img_6324_681: #4c504f; --text-img_6324_681: #3a3c3d; }
+.btn-img_6324_681 { background-image: var(--gradient-img_6324_681); border:1px solid var(--border-img_6324_681); color:var(--text-img_6324_681); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_681 { background-image: var(--gradient-img_6324_681); border:1px solid var(--border-img_6324_681); color:var(--text-img_6324_681); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_682: linear-gradient(180deg, #5e6367 0%, #353535 100%); --border-img_6324_682: #4a4c4e; --text-img_6324_682: #3a3c3d; }
+.btn-img_6324_682 { background-image: var(--gradient-img_6324_682); border:1px solid var(--border-img_6324_682); color:var(--text-img_6324_682); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_682 { background-image: var(--gradient-img_6324_682); border:1px solid var(--border-img_6324_682); color:var(--text-img_6324_682); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_683: linear-gradient(180deg, #5e6367 0%, #363636 100%); --border-img_6324_683: #4b4d4f; --text-img_6324_683: #3a3c3d; }
+.btn-img_6324_683 { background-image: var(--gradient-img_6324_683); border:1px solid var(--border-img_6324_683); color:var(--text-img_6324_683); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_683 { background-image: var(--gradient-img_6324_683); border:1px solid var(--border-img_6324_683); color:var(--text-img_6324_683); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_684: linear-gradient(180deg, #5e6367 0%, #2f2f2f 100%); --border-img_6324_684: #4a4d4e; --text-img_6324_684: #3a3b3b; }
+.btn-img_6324_684 { background-image: var(--gradient-img_6324_684); border:1px solid var(--border-img_6324_684); color:var(--text-img_6324_684); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_684 { background-image: var(--gradient-img_6324_684); border:1px solid var(--border-img_6324_684); color:var(--text-img_6324_684); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_685: linear-gradient(180deg, #5e6367 0%, #363636 100%); --border-img_6324_685: #494c4d; --text-img_6324_685: #393a3a; }
+.btn-img_6324_685 { background-image: var(--gradient-img_6324_685); border:1px solid var(--border-img_6324_685); color:var(--text-img_6324_685); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_685 { background-image: var(--gradient-img_6324_685); border:1px solid var(--border-img_6324_685); color:var(--text-img_6324_685); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_686: linear-gradient(180deg, #5e6367 0%, #383737 100%); --border-img_6324_686: #4b4d4e; --text-img_6324_686: #393a3a; }
+.btn-img_6324_686 { background-image: var(--gradient-img_6324_686); border:1px solid var(--border-img_6324_686); color:var(--text-img_6324_686); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_686 { background-image: var(--gradient-img_6324_686); border:1px solid var(--border-img_6324_686); color:var(--text-img_6324_686); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_687: linear-gradient(180deg, #5e6367 0%, #323232 100%); --border-img_6324_687: #494b4d; --text-img_6324_687: #393a3a; }
+.btn-img_6324_687 { background-image: var(--gradient-img_6324_687); border:1px solid var(--border-img_6324_687); color:var(--text-img_6324_687); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_687 { background-image: var(--gradient-img_6324_687); border:1px solid var(--border-img_6324_687); color:var(--text-img_6324_687); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_688: linear-gradient(180deg, #2f2f2f 0%, #343833 100%); --border-img_6324_688: #50544f; --text-img_6324_688: #7a7a7a; }
+.btn-img_6324_688 { background-image: var(--gradient-img_6324_688); border:1px solid var(--border-img_6324_688); color:var(--text-img_6324_688); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_688 { background-image: var(--gradient-img_6324_688); border:1px solid var(--border-img_6324_688); color:var(--text-img_6324_688); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_689: linear-gradient(180deg, #363836 0%, #3c413a 100%); --border-img_6324_689: #444643; --text-img_6324_689: #383c36; }
+.btn-img_6324_689 { background-image: var(--gradient-img_6324_689); border:1px solid var(--border-img_6324_689); color:var(--text-img_6324_689); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_689 { background-image: var(--gradient-img_6324_689); border:1px solid var(--border-img_6324_689); color:var(--text-img_6324_689); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_690: linear-gradient(180deg, #313131 0%, #222222 100%); --border-img_6324_690: #3d3c3c; --text-img_6324_690: #777575; }
+.btn-img_6324_690 { background-image: var(--gradient-img_6324_690); border:1px solid var(--border-img_6324_690); color:var(--text-img_6324_690); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_690 { background-image: var(--gradient-img_6324_690); border:1px solid var(--border-img_6324_690); color:var(--text-img_6324_690); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_691: linear-gradient(180deg, #363636 0%, #313030 100%); --border-img_6324_691: #393939; --text-img_6324_691: #2f2f2f; }
+.btn-img_6324_691 { background-image: var(--gradient-img_6324_691); border:1px solid var(--border-img_6324_691); color:var(--text-img_6324_691); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_691 { background-image: var(--gradient-img_6324_691); border:1px solid var(--border-img_6324_691); color:var(--text-img_6324_691); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_692: linear-gradient(180deg, #313131 0%, #272727 100%); --border-img_6324_692: #3f3f3f; --text-img_6324_692: #404040; }
+.btn-img_6324_692 { background-image: var(--gradient-img_6324_692); border:1px solid var(--border-img_6324_692); color:var(--text-img_6324_692); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_692 { background-image: var(--gradient-img_6324_692); border:1px solid var(--border-img_6324_692); color:var(--text-img_6324_692); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_693: linear-gradient(180deg, #bcbcbc 0%, #3c3b3b 100%); --border-img_6324_693: #4b4e4a; --text-img_6324_693: #2f2f2f; }
+.btn-img_6324_693 { background-image: var(--gradient-img_6324_693); border:1px solid var(--border-img_6324_693); color:var(--text-img_6324_693); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_693 { background-image: var(--gradient-img_6324_693); border:1px solid var(--border-img_6324_693); color:var(--text-img_6324_693); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_694: linear-gradient(180deg, #8d8b8b 0%, #3c3b3b 100%); --border-img_6324_694: #424341; --text-img_6324_694: #252525; }
+.btn-img_6324_694 { background-image: var(--gradient-img_6324_694); border:1px solid var(--border-img_6324_694); color:var(--text-img_6324_694); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_694 { background-image: var(--gradient-img_6324_694); border:1px solid var(--border-img_6324_694); color:var(--text-img_6324_694); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_695: linear-gradient(180deg, #525252 0%, #3c3b3b 100%); --border-img_6324_695: #3a3a3a; --text-img_6324_695: #262626; }
+.btn-img_6324_695 { background-image: var(--gradient-img_6324_695); border:1px solid var(--border-img_6324_695); color:var(--text-img_6324_695); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_695 { background-image: var(--gradient-img_6324_695); border:1px solid var(--border-img_6324_695); color:var(--text-img_6324_695); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_696: linear-gradient(180deg, #c7c7c7 0%, #424242 100%); --border-img_6324_696: #616160; --text-img_6324_696: #40463e; }
+.btn-img_6324_696 { background-image: var(--gradient-img_6324_696); border:1px solid var(--border-img_6324_696); color:var(--text-img_6324_696); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_696 { background-image: var(--gradient-img_6324_696); border:1px solid var(--border-img_6324_696); color:var(--text-img_6324_696); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_697: linear-gradient(180deg, #4d4c4c 0%, #434642 100%); --border-img_6324_697: #494a48; --text-img_6324_697: #393939; }
+.btn-img_6324_697 { background-image: var(--gradient-img_6324_697); border:1px solid var(--border-img_6324_697); color:var(--text-img_6324_697); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_697 { background-image: var(--gradient-img_6324_697); border:1px solid var(--border-img_6324_697); color:var(--text-img_6324_697); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_698: linear-gradient(180deg, #434242 0%, #424442 100%); --border-img_6324_698: #454545; --text-img_6324_698: #3b3a3a; }
+.btn-img_6324_698 { background-image: var(--gradient-img_6324_698); border:1px solid var(--border-img_6324_698); color:var(--text-img_6324_698); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_698 { background-image: var(--gradient-img_6324_698); border:1px solid var(--border-img_6324_698); color:var(--text-img_6324_698); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_699: linear-gradient(180deg, #565656 0%, #424242 100%); --border-img_6324_699: #434343; --text-img_6324_699: #383737; }
+.btn-img_6324_699 { background-image: var(--gradient-img_6324_699); border:1px solid var(--border-img_6324_699); color:var(--text-img_6324_699); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_699 { background-image: var(--gradient-img_6324_699); border:1px solid var(--border-img_6324_699); color:var(--text-img_6324_699); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_700: linear-gradient(180deg, #3c3b3b 0%, #888888 100%); --border-img_6324_700: #555454; --text-img_6324_700: #424242; }
+.btn-img_6324_700 { background-image: var(--gradient-img_6324_700); border:1px solid var(--border-img_6324_700); color:var(--text-img_6324_700); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_700 { background-image: var(--gradient-img_6324_700); border:1px solid var(--border-img_6324_700); color:var(--text-img_6324_700); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_701: linear-gradient(180deg, #3c3b3b 0%, #4f4f4f 100%); --border-img_6324_701: #535952; --text-img_6324_701: #434343; }
+.btn-img_6324_701 { background-image: var(--gradient-img_6324_701); border:1px solid var(--border-img_6324_701); color:var(--text-img_6324_701); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_701 { background-image: var(--gradient-img_6324_701); border:1px solid var(--border-img_6324_701); color:var(--text-img_6324_701); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_702: linear-gradient(180deg, #3c3b3b 0%, #e3e1e1 100%); --border-img_6324_702: #636462; --text-img_6324_702: #464646; }
+.btn-img_6324_702 { background-image: var(--gradient-img_6324_702); border:1px solid var(--border-img_6324_702); color:var(--text-img_6324_702); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_702 { background-image: var(--gradient-img_6324_702); border:1px solid var(--border-img_6324_702); color:var(--text-img_6324_702); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_703: linear-gradient(180deg, #3c3b3b 0%, #434542 100%); --border-img_6324_703: #4a5147; --text-img_6324_703: #424242; }
+.btn-img_6324_703 { background-image: var(--gradient-img_6324_703); border:1px solid var(--border-img_6324_703); color:var(--text-img_6324_703); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_703 { background-image: var(--gradient-img_6324_703); border:1px solid var(--border-img_6324_703); color:var(--text-img_6324_703); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_704: linear-gradient(180deg, #3c3b3b 0%, #76a26b 100%); --border-img_6324_704: #4c5749; --text-img_6324_704: #424242; }
+.btn-img_6324_704 { background-image: var(--gradient-img_6324_704); border:1px solid var(--border-img_6324_704); color:var(--text-img_6324_704); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_704 { background-image: var(--gradient-img_6324_704); border:1px solid var(--border-img_6324_704); color:var(--text-img_6324_704); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_705: linear-gradient(180deg, #424242 0%, #424242 100%); --border-img_6324_705: #454444; --text-img_6324_705: #b8b8b8; }
+.btn-img_6324_705 { background-image: var(--gradient-img_6324_705); border:1px solid var(--border-img_6324_705); color:var(--text-img_6324_705); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_705 { background-image: var(--gradient-img_6324_705); border:1px solid var(--border-img_6324_705); color:var(--text-img_6324_705); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_706: linear-gradient(180deg, #424242 0%, #424242 100%); --border-img_6324_706: #484f46; --text-img_6324_706: #e3e1e1; }
+.btn-img_6324_706 { background-image: var(--gradient-img_6324_706); border:1px solid var(--border-img_6324_706); color:var(--text-img_6324_706); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_706 { background-image: var(--gradient-img_6324_706); border:1px solid var(--border-img_6324_706); color:var(--text-img_6324_706); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_707: linear-gradient(180deg, #424242 0%, #424242 100%); --border-img_6324_707: #434343; --text-img_6324_707: #8fd07f; }
+.btn-img_6324_707 { background-image: var(--gradient-img_6324_707); border:1px solid var(--border-img_6324_707); color:var(--text-img_6324_707); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_707 { background-image: var(--gradient-img_6324_707); border:1px solid var(--border-img_6324_707); color:var(--text-img_6324_707); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_708: linear-gradient(180deg, #9c9c9c 0%, #7a7a7a 100%); --border-img_6324_708: #646363; --text-img_6324_708: #444444; }
+.btn-img_6324_708 { background-image: var(--gradient-img_6324_708); border:1px solid var(--border-img_6324_708); color:var(--text-img_6324_708); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_708 { background-image: var(--gradient-img_6324_708); border:1px solid var(--border-img_6324_708); color:var(--text-img_6324_708); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_709: linear-gradient(180deg, #4f524e 0%, #4d4e4c 100%); --border-img_6324_709: #5d5e5d; --text-img_6324_709: #495246; }
+.btn-img_6324_709 { background-image: var(--gradient-img_6324_709); border:1px solid var(--border-img_6324_709); color:var(--text-img_6324_709); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_709 { background-image: var(--gradient-img_6324_709); border:1px solid var(--border-img_6324_709); color:var(--text-img_6324_709); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_710: linear-gradient(180deg, #70716f 0%, #717370 100%); --border-img_6324_710: #636462; --text-img_6324_710: #4f5b4c; }
+.btn-img_6324_710 { background-image: var(--gradient-img_6324_710); border:1px solid var(--border-img_6324_710); color:var(--text-img_6324_710); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_710 { background-image: var(--gradient-img_6324_710); border:1px solid var(--border-img_6324_710); color:var(--text-img_6324_710); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_711: linear-gradient(180deg, #83ba75 0%, #7b7a7a 100%); --border-img_6324_711: #5d695a; --text-img_6324_711: #434343; }
+.btn-img_6324_711 { background-image: var(--gradient-img_6324_711); border:1px solid var(--border-img_6324_711); color:var(--text-img_6324_711); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_711 { background-image: var(--gradient-img_6324_711); border:1px solid var(--border-img_6324_711); color:var(--text-img_6324_711); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_712: linear-gradient(180deg, #424242 0%, #747474 100%); --border-img_6324_712: #505050; --text-img_6324_712: #515151; }
+.btn-img_6324_712 { background-image: var(--gradient-img_6324_712); border:1px solid var(--border-img_6324_712); color:var(--text-img_6324_712); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_712 { background-image: var(--gradient-img_6324_712); border:1px solid var(--border-img_6324_712); color:var(--text-img_6324_712); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_713: linear-gradient(180deg, #404040 0%, #595858 100%); --border-img_6324_713: #4e504d; --text-img_6324_713: #3e3d3d; }
+.btn-img_6324_713 { background-image: var(--gradient-img_6324_713); border:1px solid var(--border-img_6324_713); color:var(--text-img_6324_713); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_713 { background-image: var(--gradient-img_6324_713); border:1px solid var(--border-img_6324_713); color:var(--text-img_6324_713); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_714: linear-gradient(180deg, #424242 0%, #757474 100%); --border-img_6324_714: #5b5d5a; --text-img_6324_714: #4f554d; }
+.btn-img_6324_714 { background-image: var(--gradient-img_6324_714); border:1px solid var(--border-img_6324_714); color:var(--text-img_6324_714); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_714 { background-image: var(--gradient-img_6324_714); border:1px solid var(--border-img_6324_714); color:var(--text-img_6324_714); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_715: linear-gradient(180deg, #403f3f 0%, #60625f 100%); --border-img_6324_715: #585957; --text-img_6324_715: #3b3a3a; }
+.btn-img_6324_715 { background-image: var(--gradient-img_6324_715); border:1px solid var(--border-img_6324_715); color:var(--text-img_6324_715); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_715 { background-image: var(--gradient-img_6324_715); border:1px solid var(--border-img_6324_715); color:var(--text-img_6324_715); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_716: linear-gradient(180deg, #424242 0%, #757474 100%); --border-img_6324_716: #515050; --text-img_6324_716: #4d4c4c; }
+.btn-img_6324_716 { background-image: var(--gradient-img_6324_716); border:1px solid var(--border-img_6324_716); color:var(--text-img_6324_716); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_716 { background-image: var(--gradient-img_6324_716); border:1px solid var(--border-img_6324_716); color:var(--text-img_6324_716); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_717: linear-gradient(180deg, #7a7a7a 0%, #656565 100%); --border-img_6324_717: #4c4b4b; --text-img_6324_717: #9d9d9d; }
+.btn-img_6324_717 { background-image: var(--gradient-img_6324_717); border:1px solid var(--border-img_6324_717); color:var(--text-img_6324_717); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_717 { background-image: var(--gradient-img_6324_717); border:1px solid var(--border-img_6324_717); color:var(--text-img_6324_717); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_718: linear-gradient(180deg, #81a479 0%, #666565 100%); --border-img_6324_718: #50504f; --text-img_6324_718: #989797; }
+.btn-img_6324_718 { background-image: var(--gradient-img_6324_718); border:1px solid var(--border-img_6324_718); color:var(--text-img_6324_718); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_718 { background-image: var(--gradient-img_6324_718); border:1px solid var(--border-img_6324_718); color:var(--text-img_6324_718); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_719: linear-gradient(180deg, #7a7a7a 0%, #666565 100%); --border-img_6324_719: #4f4e4e; --text-img_6324_719: #7e9878; }
+.btn-img_6324_719 { background-image: var(--gradient-img_6324_719); border:1px solid var(--border-img_6324_719); color:var(--text-img_6324_719); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_719 { background-image: var(--gradient-img_6324_719); border:1px solid var(--border-img_6324_719); color:var(--text-img_6324_719); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_720: linear-gradient(180deg, #aeaeae 0%, #c0c0c0 100%); --border-img_6324_720: #777777; --text-img_6324_720: #616060; }
+.btn-img_6324_720 { background-image: var(--gradient-img_6324_720); border:1px solid var(--border-img_6324_720); color:var(--text-img_6324_720); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_720 { background-image: var(--gradient-img_6324_720); border:1px solid var(--border-img_6324_720); color:var(--text-img_6324_720); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_721: linear-gradient(180deg, #4a4b49 0%, #939393 100%); --border-img_6324_721: #767675; --text-img_6324_721: #3a3a3a; }
+.btn-img_6324_721 { background-image: var(--gradient-img_6324_721); border:1px solid var(--border-img_6324_721); color:var(--text-img_6324_721); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_721 { background-image: var(--gradient-img_6324_721); border:1px solid var(--border-img_6324_721); color:var(--text-img_6324_721); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_722: linear-gradient(180deg, #797b78 0%, #666666 100%); --border-img_6324_722: #828281; --text-img_6324_722: #606060; }
+.btn-img_6324_722 { background-image: var(--gradient-img_6324_722); border:1px solid var(--border-img_6324_722); color:var(--text-img_6324_722); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_722 { background-image: var(--gradient-img_6324_722); border:1px solid var(--border-img_6324_722); color:var(--text-img_6324_722); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_723: linear-gradient(180deg, #80a477 0%, #aaaaaa 100%); --border-img_6324_723: #6d746b; --text-img_6324_723: #605f5f; }
+.btn-img_6324_723 { background-image: var(--gradient-img_6324_723); border:1px solid var(--border-img_6324_723); color:var(--text-img_6324_723); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_723 { background-image: var(--gradient-img_6324_723); border:1px solid var(--border-img_6324_723); color:var(--text-img_6324_723); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_724: linear-gradient(180deg, #adadad 0%, #3a393a 100%); --border-img_6324_724: #605f5f; --text-img_6324_724: #605f5f; }
+.btn-img_6324_724 { background-image: var(--gradient-img_6324_724); border:1px solid var(--border-img_6324_724); color:var(--text-img_6324_724); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_724 { background-image: var(--gradient-img_6324_724); border:1px solid var(--border-img_6324_724); color:var(--text-img_6324_724); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_725: linear-gradient(180deg, #555555 0%, #3a3939 100%); --border-img_6324_725: #565555; --text-img_6324_725: #525252; }
+.btn-img_6324_725 { background-image: var(--gradient-img_6324_725); border:1px solid var(--border-img_6324_725); color:var(--text-img_6324_725); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_725 { background-image: var(--gradient-img_6324_725); border:1px solid var(--border-img_6324_725); color:var(--text-img_6324_725); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_726: linear-gradient(180deg, #f9f9f9 0%, #3a393a 100%); --border-img_6324_726: #8f8f8f; --text-img_6324_726: #605f5f; }
+.btn-img_6324_726 { background-image: var(--gradient-img_6324_726); border:1px solid var(--border-img_6324_726); color:var(--text-img_6324_726); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_726 { background-image: var(--gradient-img_6324_726); border:1px solid var(--border-img_6324_726); color:var(--text-img_6324_726); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_727: linear-gradient(180deg, #5b5d5a 0%, #3a393a 100%); --border-img_6324_727: #646a62; --text-img_6324_727: #494949; }
+.btn-img_6324_727 { background-image: var(--gradient-img_6324_727); border:1px solid var(--border-img_6324_727); color:var(--text-img_6324_727); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_727 { background-image: var(--gradient-img_6324_727); border:1px solid var(--border-img_6324_727); color:var(--text-img_6324_727); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_728: linear-gradient(180deg, #84b279 0%, #3a3939 100%); --border-img_6324_728: #606d5d; --text-img_6324_728: #605f5f; }
+.btn-img_6324_728 { background-image: var(--gradient-img_6324_728); border:1px solid var(--border-img_6324_728); color:var(--text-img_6324_728); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_728 { background-image: var(--gradient-img_6324_728); border:1px solid var(--border-img_6324_728); color:var(--text-img_6324_728); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_729: linear-gradient(180deg, #3a393a 0%, #606060 100%); --border-img_6324_729: #4e4e4e; --text-img_6324_729: #bebebe; }
+.btn-img_6324_729 { background-image: var(--gradient-img_6324_729); border:1px solid var(--border-img_6324_729); color:var(--text-img_6324_729); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_729 { background-image: var(--gradient-img_6324_729); border:1px solid var(--border-img_6324_729); color:var(--text-img_6324_729); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_730: linear-gradient(180deg, #3a3a3a 0%, #4f4f4f 100%); --border-img_6324_730: #616660; --text-img_6324_730: #bdbdbd; }
+.btn-img_6324_730 { background-image: var(--gradient-img_6324_730); border:1px solid var(--border-img_6324_730); color:var(--text-img_6324_730); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_730 { background-image: var(--gradient-img_6324_730); border:1px solid var(--border-img_6324_730); color:var(--text-img_6324_730); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_731: linear-gradient(180deg, #3a3a3a 0%, #6f806a 100%); --border-img_6324_731: #646762; --text-img_6324_731: #bdbdbd; }
+.btn-img_6324_731 { background-image: var(--gradient-img_6324_731); border:1px solid var(--border-img_6324_731); color:var(--text-img_6324_731); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_731 { background-image: var(--gradient-img_6324_731); border:1px solid var(--border-img_6324_731); color:var(--text-img_6324_731); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_732: linear-gradient(180deg, #bbbbbb 0%, #a4a3a3 100%); --border-img_6324_732: #7b7a7a; --text-img_6324_732: #686767; }
+.btn-img_6324_732 { background-image: var(--gradient-img_6324_732); border:1px solid var(--border-img_6324_732); color:var(--text-img_6324_732); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_732 { background-image: var(--gradient-img_6324_732); border:1px solid var(--border-img_6324_732); color:var(--text-img_6324_732); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_733: linear-gradient(180deg, #757474 0%, #6b6a6a 100%); --border-img_6324_733: #969696; --text-img_6324_733: #5d5c5c; }
+.btn-img_6324_733 { background-image: var(--gradient-img_6324_733); border:1px solid var(--border-img_6324_733); color:var(--text-img_6324_733); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_733 { background-image: var(--gradient-img_6324_733); border:1px solid var(--border-img_6324_733); color:var(--text-img_6324_733); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_734: linear-gradient(180deg, #bbbaba 0%, #a4a2a2 100%); --border-img_6324_734: #a5a4a4; --text-img_6324_734: #343434; }
+.btn-img_6324_734 { background-image: var(--gradient-img_6324_734); border:1px solid var(--border-img_6324_734); color:var(--text-img_6324_734); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_734 { background-image: var(--gradient-img_6324_734); border:1px solid var(--border-img_6324_734); color:var(--text-img_6324_734); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_735: linear-gradient(180deg, #9f9f9f 0%, #8e8d8d 100%); --border-img_6324_735: #747672; --text-img_6324_735: #ababaa; }
+.btn-img_6324_735 { background-image: var(--gradient-img_6324_735); border:1px solid var(--border-img_6324_735); color:var(--text-img_6324_735); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_735 { background-image: var(--gradient-img_6324_735); border:1px solid var(--border-img_6324_735); color:var(--text-img_6324_735); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_736: linear-gradient(180deg, #999898 0%, #898787 100%); --border-img_6324_736: #747573; --text-img_6324_736: #afaeae; }
+.btn-img_6324_736 { background-image: var(--gradient-img_6324_736); border:1px solid var(--border-img_6324_736); color:var(--text-img_6324_736); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_736 { background-image: var(--gradient-img_6324_736); border:1px solid var(--border-img_6324_736); color:var(--text-img_6324_736); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_737: linear-gradient(180deg, #b5b5b5 0%, #3a3939 100%); --border-img_6324_737: #868585; --text-img_6324_737: #a7a5a5; }
+.btn-img_6324_737 { background-image: var(--gradient-img_6324_737); border:1px solid var(--border-img_6324_737); color:var(--text-img_6324_737); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_737 { background-image: var(--gradient-img_6324_737); border:1px solid var(--border-img_6324_737); color:var(--text-img_6324_737); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_738: linear-gradient(180deg, #929191 0%, #3a3939 100%); --border-img_6324_738: #8b8a8a; --text-img_6324_738: #a6a4a4; }
+.btn-img_6324_738 { background-image: var(--gradient-img_6324_738); border:1px solid var(--border-img_6324_738); color:var(--text-img_6324_738); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_738 { background-image: var(--gradient-img_6324_738); border:1px solid var(--border-img_6324_738); color:var(--text-img_6324_738); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_739: linear-gradient(180deg, #707070 0%, #3a3939 100%); --border-img_6324_739: #8d8e8c; --text-img_6324_739: #3a3939; }
+.btn-img_6324_739 { background-image: var(--gradient-img_6324_739); border:1px solid var(--border-img_6324_739); color:var(--text-img_6324_739); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_739 { background-image: var(--gradient-img_6324_739); border:1px solid var(--border-img_6324_739); color:var(--text-img_6324_739); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_740: linear-gradient(180deg, #a7a7a7 0%, #b3b3b3 100%); --border-img_6324_740: #878885; --text-img_6324_740: #a6a4a4; }
+.btn-img_6324_740 { background-image: var(--gradient-img_6324_740); border:1px solid var(--border-img_6324_740); color:var(--text-img_6324_740); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_740 { background-image: var(--gradient-img_6324_740); border:1px solid var(--border-img_6324_740); color:var(--text-img_6324_740); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_741: linear-gradient(180deg, #a6a5a5 0%, #ececec 100%); --border-img_6324_741: #8f8e8e; --text-img_6324_741: #414040; }
+.btn-img_6324_741 { background-image: var(--gradient-img_6324_741); border:1px solid var(--border-img_6324_741); color:var(--text-img_6324_741); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_741 { background-image: var(--gradient-img_6324_741); border:1px solid var(--border-img_6324_741); color:var(--text-img_6324_741); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_742: linear-gradient(180deg, #a5a4a4 0%, #ececec 100%); --border-img_6324_742: #939392; --text-img_6324_742: #3e413d; }
+.btn-img_6324_742 { background-image: var(--gradient-img_6324_742); border:1px solid var(--border-img_6324_742); color:var(--text-img_6324_742); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_742 { background-image: var(--gradient-img_6324_742); border:1px solid var(--border-img_6324_742); color:var(--text-img_6324_742); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_743: linear-gradient(180deg, #a5a4a4 0%, #f3f3f3 100%); --border-img_6324_743: #8b8a8a; --text-img_6324_743: #616060; }
+.btn-img_6324_743 { background-image: var(--gradient-img_6324_743); border:1px solid var(--border-img_6324_743); color:var(--text-img_6324_743); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_743 { background-image: var(--gradient-img_6324_743); border:1px solid var(--border-img_6324_743); color:var(--text-img_6324_743); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_744: linear-gradient(180deg, #3a3939 0%, #96a492 100%); --border-img_6324_744: #5e635c; --text-img_6324_744: #eaebea; }
+.btn-img_6324_744 { background-image: var(--gradient-img_6324_744); border:1px solid var(--border-img_6324_744); color:var(--text-img_6324_744); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_744 { background-image: var(--gradient-img_6324_744); border:1px solid var(--border-img_6324_744); color:var(--text-img_6324_744); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_745: linear-gradient(180deg, #3a3939 0%, #8f938e 100%); --border-img_6324_745: #6a7068; --text-img_6324_745: #bebdbd; }
+.btn-img_6324_745 { background-image: var(--gradient-img_6324_745); border:1px solid var(--border-img_6324_745); color:var(--text-img_6324_745); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_745 { background-image: var(--gradient-img_6324_745); border:1px solid var(--border-img_6324_745); color:var(--text-img_6324_745); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_746: linear-gradient(180deg, #3a3939 0%, #518a43 100%); --border-img_6324_746: #869583; --text-img_6324_746: #eaeaea; }
+.btn-img_6324_746 { background-image: var(--gradient-img_6324_746); border:1px solid var(--border-img_6324_746); color:var(--text-img_6324_746); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_746 { background-image: var(--gradient-img_6324_746); border:1px solid var(--border-img_6324_746); color:var(--text-img_6324_746); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_747: linear-gradient(180deg, #3a3939 0%, #8b8a8a 100%); --border-img_6324_747: #999998; --text-img_6324_747: #858484; }
+.btn-img_6324_747 { background-image: var(--gradient-img_6324_747); border:1px solid var(--border-img_6324_747); color:var(--text-img_6324_747); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_747 { background-image: var(--gradient-img_6324_747); border:1px solid var(--border-img_6324_747); color:var(--text-img_6324_747); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_748: linear-gradient(180deg, #3a3939 0%, #cac9c9 100%); --border-img_6324_748: #777777; --text-img_6324_748: #f6f5f5; }
+.btn-img_6324_748 { background-image: var(--gradient-img_6324_748); border:1px solid var(--border-img_6324_748); color:var(--text-img_6324_748); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_748 { background-image: var(--gradient-img_6324_748); border:1px solid var(--border-img_6324_748); color:var(--text-img_6324_748); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_749: linear-gradient(180deg, #ededed 0%, #393838 100%); --border-img_6324_749: #8e928d; --text-img_6324_749: #eeefee; }
+.btn-img_6324_749 { background-image: var(--gradient-img_6324_749); border:1px solid var(--border-img_6324_749); color:var(--text-img_6324_749); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_749 { background-image: var(--gradient-img_6324_749); border:1px solid var(--border-img_6324_749); color:var(--text-img_6324_749); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_750: linear-gradient(180deg, #888887 0%, #393838 100%); --border-img_6324_750: #a0a49f; --text-img_6324_750: #757874; }
+.btn-img_6324_750 { background-image: var(--gradient-img_6324_750); border:1px solid var(--border-img_6324_750); color:var(--text-img_6324_750); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_750 { background-image: var(--gradient-img_6324_750); border:1px solid var(--border-img_6324_750); color:var(--text-img_6324_750); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_751: linear-gradient(180deg, #a6a6a6 0%, #393838 100%); --border-img_6324_751: #a1a59f; --text-img_6324_751: #d3d5d3; }
+.btn-img_6324_751 { background-image: var(--gradient-img_6324_751); border:1px solid var(--border-img_6324_751); color:var(--text-img_6324_751); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_751 { background-image: var(--gradient-img_6324_751); border:1px solid var(--border-img_6324_751); color:var(--text-img_6324_751); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_752: linear-gradient(180deg, #f2f2f2 0%, #393838 100%); --border-img_6324_752: #858484; --text-img_6324_752: #e2e1e1; }
+.btn-img_6324_752 { background-image: var(--gradient-img_6324_752); border:1px solid var(--border-img_6324_752); color:var(--text-img_6324_752); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_752 { background-image: var(--gradient-img_6324_752); border:1px solid var(--border-img_6324_752); color:var(--text-img_6324_752); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_753: linear-gradient(180deg, #587153 0%, #e8e8e8 100%); --border-img_6324_753: #919690; --text-img_6324_753: #b3b3b3; }
+.btn-img_6324_753 { background-image: var(--gradient-img_6324_753); border:1px solid var(--border-img_6324_753); color:var(--text-img_6324_753); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_753 { background-image: var(--gradient-img_6324_753); border:1px solid var(--border-img_6324_753); color:var(--text-img_6324_753); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_754: linear-gradient(180deg, #5f9353 0%, #e8e8e8 100%); --border-img_6324_754: #8e998b; --text-img_6324_754: #b0b3af; }
+.btn-img_6324_754 { background-image: var(--gradient-img_6324_754); border:1px solid var(--border-img_6324_754); color:var(--text-img_6324_754); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_754 { background-image: var(--gradient-img_6324_754); border:1px solid var(--border-img_6324_754); color:var(--text-img_6324_754); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_755: linear-gradient(180deg, #b7b6b6 0%, #424242 100%); --border-img_6324_755: #686767; --text-img_6324_755: #c0bfbf; }
+.btn-img_6324_755 { background-image: var(--gradient-img_6324_755); border:1px solid var(--border-img_6324_755); color:var(--text-img_6324_755); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_755 { background-image: var(--gradient-img_6324_755); border:1px solid var(--border-img_6324_755); color:var(--text-img_6324_755); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_756: linear-gradient(180deg, #f5f5f5 0%, #e8e9e8 100%); --border-img_6324_756: #a0a09f; --text-img_6324_756: #3d3d3c; }
+.btn-img_6324_756 { background-image: var(--gradient-img_6324_756); border:1px solid var(--border-img_6324_756); color:var(--text-img_6324_756); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_756 { background-image: var(--gradient-img_6324_756); border:1px solid var(--border-img_6324_756); color:var(--text-img_6324_756); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_757: linear-gradient(180deg, #a9a9a9 0%, #a7a8a7 100%); --border-img_6324_757: #8f908e; --text-img_6324_757: #393838; }
+.btn-img_6324_757 { background-image: var(--gradient-img_6324_757); border:1px solid var(--border-img_6324_757); color:var(--text-img_6324_757); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_757 { background-image: var(--gradient-img_6324_757); border:1px solid var(--border-img_6324_757); color:var(--text-img_6324_757); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_758: linear-gradient(180deg, #fafafa 0%, #ebebeb 100%); --border-img_6324_758: #d3d4d3; --text-img_6324_758: #3b3a3a; }
+.btn-img_6324_758 { background-image: var(--gradient-img_6324_758); border:1px solid var(--border-img_6324_758); color:var(--text-img_6324_758); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_758 { background-image: var(--gradient-img_6324_758); border:1px solid var(--border-img_6324_758); color:var(--text-img_6324_758); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_759: linear-gradient(180deg, #898888 0%, #454545 100%); --border-img_6324_759: #8e8e8d; --text-img_6324_759: #3e3e3e; }
+.btn-img_6324_759 { background-image: var(--gradient-img_6324_759); border:1px solid var(--border-img_6324_759); color:var(--text-img_6324_759); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_759 { background-image: var(--gradient-img_6324_759); border:1px solid var(--border-img_6324_759); color:var(--text-img_6324_759); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_760: linear-gradient(180deg, #e4e2e2 0%, #424242 100%); --border-img_6324_760: #6e6d6d; --text-img_6324_760: #505050; }
+.btn-img_6324_760 { background-image: var(--gradient-img_6324_760); border:1px solid var(--border-img_6324_760); color:var(--text-img_6324_760); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_760 { background-image: var(--gradient-img_6324_760); border:1px solid var(--border-img_6324_760); color:var(--text-img_6324_760); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_761: linear-gradient(180deg, #ecedec 0%, #343739 100%); --border-img_6324_761: #7a7f7b; --text-img_6324_761: #d5e4d1; }
+.btn-img_6324_761 { background-image: var(--gradient-img_6324_761); border:1px solid var(--border-img_6324_761); color:var(--text-img_6324_761); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_761 { background-image: var(--gradient-img_6324_761); border:1px solid var(--border-img_6324_761); color:var(--text-img_6324_761); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_762: linear-gradient(180deg, #838282 0%, #343739 100%); --border-img_6324_762: #979899; --text-img_6324_762: #626262; }
+.btn-img_6324_762 { background-image: var(--gradient-img_6324_762); border:1px solid var(--border-img_6324_762); color:var(--text-img_6324_762); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_762 { background-image: var(--gradient-img_6324_762); border:1px solid var(--border-img_6324_762); color:var(--text-img_6324_762); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_763: linear-gradient(180deg, #afafae 0%, #343739 100%); --border-img_6324_763: #717273; --text-img_6324_763: #eeeeee; }
+.btn-img_6324_763 { background-image: var(--gradient-img_6324_763); border:1px solid var(--border-img_6324_763); color:var(--text-img_6324_763); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_763 { background-image: var(--gradient-img_6324_763); border:1px solid var(--border-img_6324_763); color:var(--text-img_6324_763); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_764: linear-gradient(180deg, #424242 0%, #343739 100%); --border-img_6324_764: #49494a; --text-img_6324_764: #656565; }
+.btn-img_6324_764 { background-image: var(--gradient-img_6324_764); border:1px solid var(--border-img_6324_764); color:var(--text-img_6324_764); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_764 { background-image: var(--gradient-img_6324_764); border:1px solid var(--border-img_6324_764); color:var(--text-img_6324_764); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_765: linear-gradient(180deg, #b5d0af 0%, #343739 100%); --border-img_6324_765: #808281; --text-img_6324_765: #f9f9f9; }
+.btn-img_6324_765 { background-image: var(--gradient-img_6324_765); border:1px solid var(--border-img_6324_765); color:var(--text-img_6324_765); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_765 { background-image: var(--gradient-img_6324_765); border:1px solid var(--border-img_6324_765); color:var(--text-img_6324_765); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_766: linear-gradient(180deg, #a9a9a9 0%, #3c4042 100%); --border-img_6324_766: #818283; --text-img_6324_766: #f9f9f9; }
+.btn-img_6324_766 { background-image: var(--gradient-img_6324_766); border:1px solid var(--border-img_6324_766); color:var(--text-img_6324_766); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_766 { background-image: var(--gradient-img_6324_766); border:1px solid var(--border-img_6324_766); color:var(--text-img_6324_766); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_767: linear-gradient(180deg, #a5a5a5 0%, #343739 100%); --border-img_6324_767: #595a5a; --text-img_6324_767: #424242; }
+.btn-img_6324_767 { background-image: var(--gradient-img_6324_767); border:1px solid var(--border-img_6324_767); color:var(--text-img_6324_767); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_767 { background-image: var(--gradient-img_6324_767); border:1px solid var(--border-img_6324_767); color:var(--text-img_6324_767); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_768: linear-gradient(180deg, #aecda7 0%, #343739 100%); --border-img_6324_768: #677266; --text-img_6324_768: #fbfbfb; }
+.btn-img_6324_768 { background-image: var(--gradient-img_6324_768); border:1px solid var(--border-img_6324_768); color:var(--text-img_6324_768); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_768 { background-image: var(--gradient-img_6324_768); border:1px solid var(--border-img_6324_768); color:var(--text-img_6324_768); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_769: linear-gradient(180deg, #9ba399 0%, #343739 100%); --border-img_6324_769: #686f68; --text-img_6324_769: #dcdfdb; }
+.btn-img_6324_769 { background-image: var(--gradient-img_6324_769); border:1px solid var(--border-img_6324_769); color:var(--text-img_6324_769); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_769 { background-image: var(--gradient-img_6324_769); border:1px solid var(--border-img_6324_769); color:var(--text-img_6324_769); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_770: linear-gradient(180deg, #4a4a4a 0%, #494d50 100%); --border-img_6324_770: #8a8b8c; --text-img_6324_770: #fbfbfb; }
+.btn-img_6324_770 { background-image: var(--gradient-img_6324_770); border:1px solid var(--border-img_6324_770); color:var(--text-img_6324_770); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_770 { background-image: var(--gradient-img_6324_770); border:1px solid var(--border-img_6324_770); color:var(--text-img_6324_770); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_771: linear-gradient(180deg, #474747 0%, #343739 100%); --border-img_6324_771: #818283; --text-img_6324_771: #555555; }
+.btn-img_6324_771 { background-image: var(--gradient-img_6324_771); border:1px solid var(--border-img_6324_771); color:var(--text-img_6324_771); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_771 { background-image: var(--gradient-img_6324_771); border:1px solid var(--border-img_6324_771); color:var(--text-img_6324_771); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6324_772: linear-gradient(180deg, #c8c8c8 0%, #343739 100%); --border-img_6324_772: #606161; --text-img_6324_772: #424242; }
+.btn-img_6324_772 { background-image: var(--gradient-img_6324_772); border:1px solid var(--border-img_6324_772); color:var(--text-img_6324_772); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6324_772 { background-image: var(--gradient-img_6324_772); border:1px solid var(--border-img_6324_772); color:var(--text-img_6324_772); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_773: linear-gradient(180deg, #5e6367 0%, #cacaca 100%); --border-img_6325_773: #787a7c; --text-img_6325_773: #45494c; }
+.btn-img_6325_773 { background-image: var(--gradient-img_6325_773); border:1px solid var(--border-img_6325_773); color:var(--text-img_6325_773); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_773 { background-image: var(--gradient-img_6325_773); border:1px solid var(--border-img_6325_773); color:var(--text-img_6325_773); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_774: linear-gradient(180deg, #5e6367 0%, #dddddd 100%); --border-img_6325_774: #818385; --text-img_6325_774: #45494c; }
+.btn-img_6325_774 { background-image: var(--gradient-img_6325_774); border:1px solid var(--border-img_6325_774); color:var(--text-img_6325_774); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_774 { background-image: var(--gradient-img_6325_774); border:1px solid var(--border-img_6325_774); color:var(--text-img_6325_774); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_775: linear-gradient(180deg, #5e6367 0%, #dddddd 100%); --border-img_6325_775: #828586; --text-img_6325_775: #45494c; }
+.btn-img_6325_775 { background-image: var(--gradient-img_6325_775); border:1px solid var(--border-img_6325_775); color:var(--text-img_6325_775); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_775 { background-image: var(--gradient-img_6325_775); border:1px solid var(--border-img_6325_775); color:var(--text-img_6325_775); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_776: linear-gradient(180deg, #5e6367 0%, #dddddd 100%); --border-img_6325_776: #7f8183; --text-img_6325_776: #45494c; }
+.btn-img_6325_776 { background-image: var(--gradient-img_6325_776); border:1px solid var(--border-img_6325_776); color:var(--text-img_6325_776); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_776 { background-image: var(--gradient-img_6325_776); border:1px solid var(--border-img_6325_776); color:var(--text-img_6325_776); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_777: linear-gradient(180deg, #5e6367 0%, #cdcdcd 100%); --border-img_6325_777: #787b7d; --text-img_6325_777: #45494c; }
+.btn-img_6325_777 { background-image: var(--gradient-img_6325_777); border:1px solid var(--border-img_6325_777); color:var(--text-img_6325_777); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_777 { background-image: var(--gradient-img_6325_777); border:1px solid var(--border-img_6325_777); color:var(--text-img_6325_777); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_778: linear-gradient(180deg, #5e6367 0%, #e3e3e3 100%); --border-img_6325_778: #898b8d; --text-img_6325_778: #36383a; }
+.btn-img_6325_778 { background-image: var(--gradient-img_6325_778); border:1px solid var(--border-img_6325_778); color:var(--text-img_6325_778); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_778 { background-image: var(--gradient-img_6325_778); border:1px solid var(--border-img_6325_778); color:var(--text-img_6325_778); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_779: linear-gradient(180deg, #5e6367 0%, #e3e3e3 100%); --border-img_6325_779: #8e9092; --text-img_6325_779: #36383a; }
+.btn-img_6325_779 { background-image: var(--gradient-img_6325_779); border:1px solid var(--border-img_6325_779); color:var(--text-img_6325_779); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_779 { background-image: var(--gradient-img_6325_779); border:1px solid var(--border-img_6325_779); color:var(--text-img_6325_779); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_780: linear-gradient(180deg, #5e6367 0%, #e3e3e3 100%); --border-img_6325_780: #878a8c; --text-img_6325_780: #36383a; }
+.btn-img_6325_780 { background-image: var(--gradient-img_6325_780); border:1px solid var(--border-img_6325_780); color:var(--text-img_6325_780); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_780 { background-image: var(--gradient-img_6325_780); border:1px solid var(--border-img_6325_780); color:var(--text-img_6325_780); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_781: linear-gradient(180deg, #5e6367 0%, #9a9a9a 100%); --border-img_6325_781: #76787a; --text-img_6325_781: #4f4f50; }
+.btn-img_6325_781 { background-image: var(--gradient-img_6325_781); border:1px solid var(--border-img_6325_781); color:var(--text-img_6325_781); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_781 { background-image: var(--gradient-img_6325_781); border:1px solid var(--border-img_6325_781); color:var(--text-img_6325_781); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_782: linear-gradient(180deg, #5e6367 0%, #dbdbdb 100%); --border-img_6325_782: #909294; --text-img_6325_782: #4e4f50; }
+.btn-img_6325_782 { background-image: var(--gradient-img_6325_782); border:1px solid var(--border-img_6325_782); color:var(--text-img_6325_782); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_782 { background-image: var(--gradient-img_6325_782); border:1px solid var(--border-img_6325_782); color:var(--text-img_6325_782); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_783: linear-gradient(180deg, #5e6367 0%, #dbdbdb 100%); --border-img_6325_783: #929496; --text-img_6325_783: #4e4f50; }
+.btn-img_6325_783 { background-image: var(--gradient-img_6325_783); border:1px solid var(--border-img_6325_783); color:var(--text-img_6325_783); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_783 { background-image: var(--gradient-img_6325_783); border:1px solid var(--border-img_6325_783); color:var(--text-img_6325_783); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_784: linear-gradient(180deg, #5e6367 0%, #b0b8ae 100%); --border-img_6325_784: #797d7c; --text-img_6325_784: #4f4f50; }
+.btn-img_6325_784 { background-image: var(--gradient-img_6325_784); border:1px solid var(--border-img_6325_784); color:var(--text-img_6325_784); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_784 { background-image: var(--gradient-img_6325_784); border:1px solid var(--border-img_6325_784); color:var(--text-img_6325_784); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_785: linear-gradient(180deg, #525252 0%, #d3d3d3 100%); --border-img_6325_785: #a5a5a5; --text-img_6325_785: #dddddd; }
+.btn-img_6325_785 { background-image: var(--gradient-img_6325_785); border:1px solid var(--border-img_6325_785); color:var(--text-img_6325_785); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_785 { background-image: var(--gradient-img_6325_785); border:1px solid var(--border-img_6325_785); color:var(--text-img_6325_785); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_786: linear-gradient(180deg, #d8d8d8 0%, #dfdfe0 100%); --border-img_6325_786: #d4d4d4; --text-img_6325_786: #dedede; }
+.btn-img_6325_786 { background-image: var(--gradient-img_6325_786); border:1px solid var(--border-img_6325_786); color:var(--text-img_6325_786); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_786 { background-image: var(--gradient-img_6325_786); border:1px solid var(--border-img_6325_786); color:var(--text-img_6325_786); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_787: linear-gradient(180deg, #d8d8d8 0%, #e0e0e0 100%); --border-img_6325_787: #d9d9d9; --text-img_6325_787: #dedede; }
+.btn-img_6325_787 { background-image: var(--gradient-img_6325_787); border:1px solid var(--border-img_6325_787); color:var(--text-img_6325_787); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_787 { background-image: var(--gradient-img_6325_787); border:1px solid var(--border-img_6325_787); color:var(--text-img_6325_787); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_788: linear-gradient(180deg, #d8d8d8 0%, #dfdfe0 100%); --border-img_6325_788: #dcdcdc; --text-img_6325_788: #dedede; }
+.btn-img_6325_788 { background-image: var(--gradient-img_6325_788); border:1px solid var(--border-img_6325_788); color:var(--text-img_6325_788); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_788 { background-image: var(--gradient-img_6325_788); border:1px solid var(--border-img_6325_788); color:var(--text-img_6325_788); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_789: linear-gradient(180deg, #a2aba0 0%, #d7d7d7 100%); --border-img_6325_789: #a9aca9; --text-img_6325_789: #dddddd; }
+.btn-img_6325_789 { background-image: var(--gradient-img_6325_789); border:1px solid var(--border-img_6325_789); color:var(--text-img_6325_789); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_789 { background-image: var(--gradient-img_6325_789); border:1px solid var(--border-img_6325_789); color:var(--text-img_6325_789); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_790: linear-gradient(180deg, #cfcfcf 0%, #e0e0e0 100%); --border-img_6325_790: #bbbbbb; --text-img_6325_790: #b8b8b8; }
+.btn-img_6325_790 { background-image: var(--gradient-img_6325_790); border:1px solid var(--border-img_6325_790); color:var(--text-img_6325_790); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_790 { background-image: var(--gradient-img_6325_790); border:1px solid var(--border-img_6325_790); color:var(--text-img_6325_790); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_791: linear-gradient(180deg, #cfcfcf 0%, #b6b6b6 100%); --border-img_6325_791: #cbcbcb; --text-img_6325_791: #bababa; }
+.btn-img_6325_791 { background-image: var(--gradient-img_6325_791); border:1px solid var(--border-img_6325_791); color:var(--text-img_6325_791); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_791 { background-image: var(--gradient-img_6325_791); border:1px solid var(--border-img_6325_791); color:var(--text-img_6325_791); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_792: linear-gradient(180deg, #cfcfcf 0%, #cfd6cd 100%); --border-img_6325_792: #b6bab5; --text-img_6325_792: #dedede; }
+.btn-img_6325_792 { background-image: var(--gradient-img_6325_792); border:1px solid var(--border-img_6325_792); color:var(--text-img_6325_792); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_792 { background-image: var(--gradient-img_6325_792); border:1px solid var(--border-img_6325_792); color:var(--text-img_6325_792); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_793: linear-gradient(180deg, #dddddd 0%, #9f9f9f 100%); --border-img_6325_793: #a1a1a1; --text-img_6325_793: #d9d9d9; }
+.btn-img_6325_793 { background-image: var(--gradient-img_6325_793); border:1px solid var(--border-img_6325_793); color:var(--text-img_6325_793); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_793 { background-image: var(--gradient-img_6325_793); border:1px solid var(--border-img_6325_793); color:var(--text-img_6325_793); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_794: linear-gradient(180deg, #dedede 0%, #505050 100%); --border-img_6325_794: #b6b7b5; --text-img_6325_794: #e0e0e0; }
+.btn-img_6325_794 { background-image: var(--gradient-img_6325_794); border:1px solid var(--border-img_6325_794); color:var(--text-img_6325_794); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_794 { background-image: var(--gradient-img_6325_794); border:1px solid var(--border-img_6325_794); color:var(--text-img_6325_794); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_795: linear-gradient(180deg, #dedede 0%, #8cbe7f 100%); --border-img_6325_795: #bbceb6; --text-img_6325_795: #dedede; }
+.btn-img_6325_795 { background-image: var(--gradient-img_6325_795); border:1px solid var(--border-img_6325_795); color:var(--text-img_6325_795); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_795 { background-image: var(--gradient-img_6325_795); border:1px solid var(--border-img_6325_795); color:var(--text-img_6325_795); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_796: linear-gradient(180deg, #dddddd 0%, #afc8a9 100%); --border-img_6325_796: #a5afa3; --text-img_6325_796: #dfdfdf; }
+.btn-img_6325_796 { background-image: var(--gradient-img_6325_796); border:1px solid var(--border-img_6325_796); color:var(--text-img_6325_796); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_796 { background-image: var(--gradient-img_6325_796); border:1px solid var(--border-img_6325_796); color:var(--text-img_6325_796); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_797: linear-gradient(180deg, #d4d4d4 0%, #bbbbbb 100%); --border-img_6325_797: #a3a3a3; --text-img_6325_797: #e1e1e1; }
+.btn-img_6325_797 { background-image: var(--gradient-img_6325_797); border:1px solid var(--border-img_6325_797); color:var(--text-img_6325_797); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_797 { background-image: var(--gradient-img_6325_797); border:1px solid var(--border-img_6325_797); color:var(--text-img_6325_797); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_798: linear-gradient(180deg, #e1e1e1 0%, #434343 100%); --border-img_6325_798: #a9a9a9; --text-img_6325_798: #4d4d4d; }
+.btn-img_6325_798 { background-image: var(--gradient-img_6325_798); border:1px solid var(--border-img_6325_798); color:var(--text-img_6325_798); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_798 { background-image: var(--gradient-img_6325_798); border:1px solid var(--border-img_6325_798); color:var(--text-img_6325_798); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_799: linear-gradient(180deg, #9e9e9e 0%, #84b579 100%); --border-img_6325_799: #98aa94; --text-img_6325_799: #79bc68; }
+.btn-img_6325_799 { background-image: var(--gradient-img_6325_799); border:1px solid var(--border-img_6325_799); color:var(--text-img_6325_799); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_799 { background-image: var(--gradient-img_6325_799); border:1px solid var(--border-img_6325_799); color:var(--text-img_6325_799); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_800: linear-gradient(180deg, #85ad7a 0%, #40543a 100%); --border-img_6325_800: #99ae94; --text-img_6325_800: #619455; }
+.btn-img_6325_800 { background-image: var(--gradient-img_6325_800); border:1px solid var(--border-img_6325_800); color:var(--text-img_6325_800); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_800 { background-image: var(--gradient-img_6325_800); border:1px solid var(--border-img_6325_800); color:var(--text-img_6325_800); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_801: linear-gradient(180deg, #d9d9d8 0%, #c3c6c2 100%); --border-img_6325_801: #959f93; --text-img_6325_801: #e1e1e1; }
+.btn-img_6325_801 { background-image: var(--gradient-img_6325_801); border:1px solid var(--border-img_6325_801); color:var(--text-img_6325_801); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_801 { background-image: var(--gradient-img_6325_801); border:1px solid var(--border-img_6325_801); color:var(--text-img_6325_801); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_802: linear-gradient(180deg, #787878 0%, #cecdcd 100%); --border-img_6325_802: #949494; --text-img_6325_802: #545454; }
+.btn-img_6325_802 { background-image: var(--gradient-img_6325_802); border:1px solid var(--border-img_6325_802); color:var(--text-img_6325_802); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_802 { background-image: var(--gradient-img_6325_802); border:1px solid var(--border-img_6325_802); color:var(--text-img_6325_802); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_803: linear-gradient(180deg, #85b27a 0%, #d4d1d2 100%); --border-img_6325_803: #b0b9ac; --text-img_6325_803: #6eab60; }
+.btn-img_6325_803 { background-image: var(--gradient-img_6325_803); border:1px solid var(--border-img_6325_803); color:var(--text-img_6325_803); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_803 { background-image: var(--gradient-img_6325_803); border:1px solid var(--border-img_6325_803); color:var(--text-img_6325_803); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_804: linear-gradient(180deg, #8db484 0%, #bebdbd 100%); --border-img_6325_804: #99a995; --text-img_6325_804: #445d3e; }
+.btn-img_6325_804 { background-image: var(--gradient-img_6325_804); border:1px solid var(--border-img_6325_804); color:var(--text-img_6325_804); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_804 { background-image: var(--gradient-img_6325_804); border:1px solid var(--border-img_6325_804); color:var(--text-img_6325_804); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_805: linear-gradient(180deg, #9b9b9b 0%, #d6d5d5 100%); --border-img_6325_805: #a1a1a1; --text-img_6325_805: #d8d8d8; }
+.btn-img_6325_805 { background-image: var(--gradient-img_6325_805); border:1px solid var(--border-img_6325_805); color:var(--text-img_6325_805); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_805 { background-image: var(--gradient-img_6325_805); border:1px solid var(--border-img_6325_805); color:var(--text-img_6325_805); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_806: linear-gradient(180deg, #454545 0%, #cbccca 100%); --border-img_6325_806: #afb4ad; --text-img_6325_806: #d2d0d0; }
+.btn-img_6325_806 { background-image: var(--gradient-img_6325_806); border:1px solid var(--border-img_6325_806); color:var(--text-img_6325_806); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_806 { background-image: var(--gradient-img_6325_806); border:1px solid var(--border-img_6325_806); color:var(--text-img_6325_806); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_807: linear-gradient(180deg, #7ba171 0%, #bab9b9 100%); --border-img_6325_807: #b8c5b4; --text-img_6325_807: #c8c6c6; }
+.btn-img_6325_807 { background-image: var(--gradient-img_6325_807); border:1px solid var(--border-img_6325_807); color:var(--text-img_6325_807); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_807 { background-image: var(--gradient-img_6325_807); border:1px solid var(--border-img_6325_807); color:var(--text-img_6325_807); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_808: linear-gradient(180deg, #a1ad9e 0%, #d3d2d1 100%); --border-img_6325_808: #a6aaa4; --text-img_6325_808: #d4d4d4; }
+.btn-img_6325_808 { background-image: var(--gradient-img_6325_808); border:1px solid var(--border-img_6325_808); color:var(--text-img_6325_808); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_808 { background-image: var(--gradient-img_6325_808); border:1px solid var(--border-img_6325_808); color:var(--text-img_6325_808); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_809: linear-gradient(180deg, #d2d2d2 0%, #d4d4d4 100%); --border-img_6325_809: #adacac; --text-img_6325_809: #e5e5e5; }
+.btn-img_6325_809 { background-image: var(--gradient-img_6325_809); border:1px solid var(--border-img_6325_809); color:var(--text-img_6325_809); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_809 { background-image: var(--gradient-img_6325_809); border:1px solid var(--border-img_6325_809); color:var(--text-img_6325_809); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_810: linear-gradient(180deg, #cccbcb 0%, #fcfcfc 100%); --border-img_6325_810: #dfdede; --text-img_6325_810: #c5c5c5; }
+.btn-img_6325_810 { background-image: var(--gradient-img_6325_810); border:1px solid var(--border-img_6325_810); color:var(--text-img_6325_810); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_810 { background-image: var(--gradient-img_6325_810); border:1px solid var(--border-img_6325_810); color:var(--text-img_6325_810); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_811: linear-gradient(180deg, #d6d3d3 0%, #fcfcfc 100%); --border-img_6325_811: #e2e2e0; --text-img_6325_811: #b3cfad; }
+.btn-img_6325_811 { background-image: var(--gradient-img_6325_811); border:1px solid var(--border-img_6325_811); color:var(--text-img_6325_811); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_811 { background-image: var(--gradient-img_6325_811); border:1px solid var(--border-img_6325_811); color:var(--text-img_6325_811); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_812: linear-gradient(180deg, #bbb8b8 0%, #fcfcfc 100%); --border-img_6325_812: #d8d7d7; --text-img_6325_812: #979797; }
+.btn-img_6325_812 { background-image: var(--gradient-img_6325_812); border:1px solid var(--border-img_6325_812); color:var(--text-img_6325_812); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_812 { background-image: var(--gradient-img_6325_812); border:1px solid var(--border-img_6325_812); color:var(--text-img_6325_812); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_813: linear-gradient(180deg, #d3d3d3 0%, #d9d9d9 100%); --border-img_6325_813: #a8a7a7; --text-img_6325_813: #e5e5e5; }
+.btn-img_6325_813 { background-image: var(--gradient-img_6325_813); border:1px solid var(--border-img_6325_813); color:var(--text-img_6325_813); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_813 { background-image: var(--gradient-img_6325_813); border:1px solid var(--border-img_6325_813); color:var(--text-img_6325_813); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_814: linear-gradient(180deg, #d3d3d3 0%, #eaeaea 100%); --border-img_6325_814: #b4bbb2; --text-img_6325_814: #c0c0c0; }
+.btn-img_6325_814 { background-image: var(--gradient-img_6325_814); border:1px solid var(--border-img_6325_814); color:var(--text-img_6325_814); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_814 { background-image: var(--gradient-img_6325_814); border:1px solid var(--border-img_6325_814); color:var(--text-img_6325_814); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_815: linear-gradient(180deg, #bfd5ba 0%, #ececec 100%); --border-img_6325_815: #e2e3e1; --text-img_6325_815: #e9e9e7; }
+.btn-img_6325_815 { background-image: var(--gradient-img_6325_815); border:1px solid var(--border-img_6325_815); color:var(--text-img_6325_815); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_815 { background-image: var(--gradient-img_6325_815); border:1px solid var(--border-img_6325_815); color:var(--text-img_6325_815); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_816: linear-gradient(180deg, #d4d3d3 0%, #eaeaea 100%); --border-img_6325_816: #bbbbbb; --text-img_6325_816: #c1bebe; }
+.btn-img_6325_816 { background-image: var(--gradient-img_6325_816); border:1px solid var(--border-img_6325_816); color:var(--text-img_6325_816); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_816 { background-image: var(--gradient-img_6325_816); border:1px solid var(--border-img_6325_816); color:var(--text-img_6325_816); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_817: linear-gradient(180deg, #d6d5d5 0%, #959595 100%); --border-img_6325_817: #949c92; --text-img_6325_817: #b5d2ad; }
+.btn-img_6325_817 { background-image: var(--gradient-img_6325_817); border:1px solid var(--border-img_6325_817); color:var(--text-img_6325_817); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_817 { background-image: var(--gradient-img_6325_817); border:1px solid var(--border-img_6325_817); color:var(--text-img_6325_817); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_818: linear-gradient(180deg, #cecccc 0%, #d1d9ce 100%); --border-img_6325_818: #ccd5c9; --text-img_6325_818: #cecece; }
+.btn-img_6325_818 { background-image: var(--gradient-img_6325_818); border:1px solid var(--border-img_6325_818); color:var(--text-img_6325_818); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_818 { background-image: var(--gradient-img_6325_818); border:1px solid var(--border-img_6325_818); color:var(--text-img_6325_818); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_819: linear-gradient(180deg, #d2d0d0 0%, #e0e1df 100%); --border-img_6325_819: #d1d7ce; --text-img_6325_819: #cfcfcf; }
+.btn-img_6325_819 { background-image: var(--gradient-img_6325_819); border:1px solid var(--border-img_6325_819); color:var(--text-img_6325_819); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_819 { background-image: var(--gradient-img_6325_819); border:1px solid var(--border-img_6325_819); color:var(--text-img_6325_819); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_820: linear-gradient(180deg, #d8d7d7 0%, #ebebeb 100%); --border-img_6325_820: #bcbbbb; --text-img_6325_820: #eaeaea; }
+.btn-img_6325_820 { background-image: var(--gradient-img_6325_820); border:1px solid var(--border-img_6325_820); color:var(--text-img_6325_820); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_820 { background-image: var(--gradient-img_6325_820); border:1px solid var(--border-img_6325_820); color:var(--text-img_6325_820); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_821: linear-gradient(180deg, #dcdcdc 0%, #dedede 100%); --border-img_6325_821: #a8afa7; --text-img_6325_821: #e9e9e9; }
+.btn-img_6325_821 { background-image: var(--gradient-img_6325_821); border:1px solid var(--border-img_6325_821); color:var(--text-img_6325_821); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_821 { background-image: var(--gradient-img_6325_821); border:1px solid var(--border-img_6325_821); color:var(--text-img_6325_821); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_822: linear-gradient(180deg, #ebebeb 0%, #e7e6e6 100%); --border-img_6325_822: #cad3c7; --text-img_6325_822: #e8e8e8; }
+.btn-img_6325_822 { background-image: var(--gradient-img_6325_822); border:1px solid var(--border-img_6325_822); color:var(--text-img_6325_822); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_822 { background-image: var(--gradient-img_6325_822); border:1px solid var(--border-img_6325_822); color:var(--text-img_6325_822); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_823: linear-gradient(180deg, #ebecec 0%, #97be8d 100%); --border-img_6325_823: #ccd4c9; --text-img_6325_823: #cccccc; }
+.btn-img_6325_823 { background-image: var(--gradient-img_6325_823); border:1px solid var(--border-img_6325_823); color:var(--text-img_6325_823); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_823 { background-image: var(--gradient-img_6325_823); border:1px solid var(--border-img_6325_823); color:var(--text-img_6325_823); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_824: linear-gradient(180deg, #ebebeb 0%, #e4e4e4 100%); --border-img_6325_824: #dedddd; --text-img_6325_824: #dad9d9; }
+.btn-img_6325_824 { background-image: var(--gradient-img_6325_824); border:1px solid var(--border-img_6325_824); color:var(--text-img_6325_824); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_824 { background-image: var(--gradient-img_6325_824); border:1px solid var(--border-img_6325_824); color:var(--text-img_6325_824); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_825: linear-gradient(180deg, #e0e1e0 0%, #e3e3e3 100%); --border-img_6325_825: #bcbcbc; --text-img_6325_825: #e9e9e9; }
+.btn-img_6325_825 { background-image: var(--gradient-img_6325_825); border:1px solid var(--border-img_6325_825); color:var(--text-img_6325_825); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_825 { background-image: var(--gradient-img_6325_825); border:1px solid var(--border-img_6325_825); color:var(--text-img_6325_825); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_826: linear-gradient(180deg, #99c38f 0%, #ededed 100%); --border-img_6325_826: #bfc7bd; --text-img_6325_826: #4e6249; }
+.btn-img_6325_826 { background-image: var(--gradient-img_6325_826); border:1px solid var(--border-img_6325_826); color:var(--text-img_6325_826); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_826 { background-image: var(--gradient-img_6325_826); border:1px solid var(--border-img_6325_826); color:var(--text-img_6325_826); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_827: linear-gradient(180deg, #e6e6e6 0%, #67a658 100%); --border-img_6325_827: #abc3a5; --text-img_6325_827: #67a658; }
+.btn-img_6325_827 { background-image: var(--gradient-img_6325_827); border:1px solid var(--border-img_6325_827); color:var(--text-img_6325_827); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_827 { background-image: var(--gradient-img_6325_827); border:1px solid var(--border-img_6325_827); color:var(--text-img_6325_827); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_828: linear-gradient(180deg, #e9e9e9 0%, #e8e7e7 100%); --border-img_6325_828: #c1c4c0; --text-img_6325_828: #ececec; }
+.btn-img_6325_828 { background-image: var(--gradient-img_6325_828); border:1px solid var(--border-img_6325_828); color:var(--text-img_6325_828); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_828 { background-image: var(--gradient-img_6325_828); border:1px solid var(--border-img_6325_828); color:var(--text-img_6325_828); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_829: linear-gradient(180deg, #b9bbb8 0%, #cdd9ca 100%); --border-img_6325_829: #90a08c; --text-img_6325_829: #ececec; }
+.btn-img_6325_829 { background-image: var(--gradient-img_6325_829); border:1px solid var(--border-img_6325_829); color:var(--text-img_6325_829); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_829 { background-image: var(--gradient-img_6325_829); border:1px solid var(--border-img_6325_829); color:var(--text-img_6325_829); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_830: linear-gradient(180deg, #e5e4e4 0%, #e1dfdf 100%); --border-img_6325_830: #b1c2ac; --text-img_6325_830: #dedcdc; }
+.btn-img_6325_830 { background-image: var(--gradient-img_6325_830); border:1px solid var(--border-img_6325_830); color:var(--text-img_6325_830); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_830 { background-image: var(--gradient-img_6325_830); border:1px solid var(--border-img_6325_830); color:var(--text-img_6325_830); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_831: linear-gradient(180deg, #67a658 0%, #dbd8d8 100%); --border-img_6325_831: #9dbc94; --text-img_6325_831: #8fb884; }
+.btn-img_6325_831 { background-image: var(--gradient-img_6325_831); border:1px solid var(--border-img_6325_831); color:var(--text-img_6325_831); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_831 { background-image: var(--gradient-img_6325_831); border:1px solid var(--border-img_6325_831); color:var(--text-img_6325_831); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_832: linear-gradient(180deg, #b7ccb1 0%, #dbd8d8 100%); --border-img_6325_832: #cad3c6; --text-img_6325_832: #ced5ca; }
+.btn-img_6325_832 { background-image: var(--gradient-img_6325_832); border:1px solid var(--border-img_6325_832); color:var(--text-img_6325_832); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_832 { background-image: var(--gradient-img_6325_832); border:1px solid var(--border-img_6325_832); color:var(--text-img_6325_832); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_833: linear-gradient(180deg, #e3e3e3 0%, #e4e4e4 100%); --border-img_6325_833: #c1c1c1; --text-img_6325_833: #ececec; }
+.btn-img_6325_833 { background-image: var(--gradient-img_6325_833); border:1px solid var(--border-img_6325_833); color:var(--text-img_6325_833); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_833 { background-image: var(--gradient-img_6325_833); border:1px solid var(--border-img_6325_833); color:var(--text-img_6325_833); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_834: linear-gradient(180deg, #949494 0%, #ececec 100%); --border-img_6325_834: #a0a89f; --text-img_6325_834: #c9e2c4; }
+.btn-img_6325_834 { background-image: var(--gradient-img_6325_834); border:1px solid var(--border-img_6325_834); color:var(--text-img_6325_834); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_834 { background-image: var(--gradient-img_6325_834); border:1px solid var(--border-img_6325_834); color:var(--text-img_6325_834); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_835: linear-gradient(180deg, #7fb172 0%, #f2f2f2 100%); --border-img_6325_835: #cedccb; --text-img_6325_835: #d1cfcf; }
+.btn-img_6325_835 { background-image: var(--gradient-img_6325_835); border:1px solid var(--border-img_6325_835); color:var(--text-img_6325_835); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_835 { background-image: var(--gradient-img_6325_835); border:1px solid var(--border-img_6325_835); color:var(--text-img_6325_835); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_836: linear-gradient(180deg, #67a658 0%, #f2f2f2 100%); --border-img_6325_836: #c5d5c0; --text-img_6325_836: #d6d4d4; }
+.btn-img_6325_836 { background-image: var(--gradient-img_6325_836); border:1px solid var(--border-img_6325_836); color:var(--text-img_6325_836); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_836 { background-image: var(--gradient-img_6325_836); border:1px solid var(--border-img_6325_836); color:var(--text-img_6325_836); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_837: linear-gradient(180deg, #ececec 0%, #ececec 100%); --border-img_6325_837: #c2c1c1; --text-img_6325_837: #ededed; }
+.btn-img_6325_837 { background-image: var(--gradient-img_6325_837); border:1px solid var(--border-img_6325_837); color:var(--text-img_6325_837); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_837 { background-image: var(--gradient-img_6325_837); border:1px solid var(--border-img_6325_837); color:var(--text-img_6325_837); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_838: linear-gradient(180deg, #b5ddab 0%, #ededed 100%); --border-img_6325_838: #bcbebb; --text-img_6325_838: #ededed; }
+.btn-img_6325_838 { background-image: var(--gradient-img_6325_838); border:1px solid var(--border-img_6325_838); color:var(--text-img_6325_838); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_838 { background-image: var(--gradient-img_6325_838); border:1px solid var(--border-img_6325_838); color:var(--text-img_6325_838); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_839: linear-gradient(180deg, #dbd9d9 0%, #f2f2f2 100%); --border-img_6325_839: #e1e0e0; --text-img_6325_839: #f4f4f4; }
+.btn-img_6325_839 { background-image: var(--gradient-img_6325_839); border:1px solid var(--border-img_6325_839); color:var(--text-img_6325_839); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_839 { background-image: var(--gradient-img_6325_839); border:1px solid var(--border-img_6325_839); color:var(--text-img_6325_839); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_840: linear-gradient(180deg, #e7e6e6 0%, #ededed 100%); --border-img_6325_840: #cbcaca; --text-img_6325_840: #ededed; }
+.btn-img_6325_840 { background-image: var(--gradient-img_6325_840); border:1px solid var(--border-img_6325_840); color:var(--text-img_6325_840); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_840 { background-image: var(--gradient-img_6325_840); border:1px solid var(--border-img_6325_840); color:var(--text-img_6325_840); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_841: linear-gradient(180deg, #e0e0e0 0%, #e2e2e2 100%); --border-img_6325_841: #c2c2c2; --text-img_6325_841: #ebebeb; }
+.btn-img_6325_841 { background-image: var(--gradient-img_6325_841); border:1px solid var(--border-img_6325_841); color:var(--text-img_6325_841); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_841 { background-image: var(--gradient-img_6325_841); border:1px solid var(--border-img_6325_841); color:var(--text-img_6325_841); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_842: linear-gradient(180deg, #f0f0f0 0%, #eaeaea 100%); --border-img_6325_842: #e9e9e9; --text-img_6325_842: #f0f0f0; }
+.btn-img_6325_842 { background-image: var(--gradient-img_6325_842); border:1px solid var(--border-img_6325_842); color:var(--text-img_6325_842); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_842 { background-image: var(--gradient-img_6325_842); border:1px solid var(--border-img_6325_842); color:var(--text-img_6325_842); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_843: linear-gradient(180deg, #f4f4f4 0%, #f7f7f7 100%); --border-img_6325_843: #f3f4f3; --text-img_6325_843: #f2f2f2; }
+.btn-img_6325_843 { background-image: var(--gradient-img_6325_843); border:1px solid var(--border-img_6325_843); color:var(--text-img_6325_843); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_843 { background-image: var(--gradient-img_6325_843); border:1px solid var(--border-img_6325_843); color:var(--text-img_6325_843); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_844: linear-gradient(180deg, #f0f0f0 0%, #fcfcfc 100%); --border-img_6325_844: #f4f4f4; --text-img_6325_844: #f0f0f0; }
+.btn-img_6325_844 { background-image: var(--gradient-img_6325_844); border:1px solid var(--border-img_6325_844); color:var(--text-img_6325_844); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_844 { background-image: var(--gradient-img_6325_844); border:1px solid var(--border-img_6325_844); color:var(--text-img_6325_844); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_845: linear-gradient(180deg, #e4e4e4 0%, #e8e8e8 100%); --border-img_6325_845: #c4c4c4; --text-img_6325_845: #ececec; }
+.btn-img_6325_845 { background-image: var(--gradient-img_6325_845); border:1px solid var(--border-img_6325_845); color:var(--text-img_6325_845); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_845 { background-image: var(--gradient-img_6325_845); border:1px solid var(--border-img_6325_845); color:var(--text-img_6325_845); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_846: linear-gradient(180deg, #ececec 0%, #f0f0f0 100%); --border-img_6325_846: #c6c5c5; --text-img_6325_846: #f2f2f2; }
+.btn-img_6325_846 { background-image: var(--gradient-img_6325_846); border:1px solid var(--border-img_6325_846); color:var(--text-img_6325_846); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_846 { background-image: var(--gradient-img_6325_846); border:1px solid var(--border-img_6325_846); color:var(--text-img_6325_846); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_847: linear-gradient(180deg, #f0f0f0 0%, #f7f7f7 100%); --border-img_6325_847: #eeeeee; --text-img_6325_847: #f7f7f7; }
+.btn-img_6325_847 { background-image: var(--gradient-img_6325_847); border:1px solid var(--border-img_6325_847); color:var(--text-img_6325_847); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_847 { background-image: var(--gradient-img_6325_847); border:1px solid var(--border-img_6325_847); color:var(--text-img_6325_847); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_848: linear-gradient(180deg, #f0f0f0 0%, #f1f1f1 100%); --border-img_6325_848: #f2f3f2; --text-img_6325_848: #f5f7f5; }
+.btn-img_6325_848 { background-image: var(--gradient-img_6325_848); border:1px solid var(--border-img_6325_848); color:var(--text-img_6325_848); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_848 { background-image: var(--gradient-img_6325_848); border:1px solid var(--border-img_6325_848); color:var(--text-img_6325_848); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_849: linear-gradient(180deg, #ececec 0%, #eceded 100%); --border-img_6325_849: #c7c7c7; --text-img_6325_849: #f2f4f2; }
+.btn-img_6325_849 { background-image: var(--gradient-img_6325_849); border:1px solid var(--border-img_6325_849); color:var(--text-img_6325_849); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_849 { background-image: var(--gradient-img_6325_849); border:1px solid var(--border-img_6325_849); color:var(--text-img_6325_849); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_850: linear-gradient(180deg, #f4f4f4 0%, #f3f3f3 100%); --border-img_6325_850: #cdcdcd; --text-img_6325_850: #f6f6f6; }
+.btn-img_6325_850 { background-image: var(--gradient-img_6325_850); border:1px solid var(--border-img_6325_850); color:var(--text-img_6325_850); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_850 { background-image: var(--gradient-img_6325_850); border:1px solid var(--border-img_6325_850); color:var(--text-img_6325_850); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_851: linear-gradient(180deg, #e8eee6 0%, #ededed 100%); --border-img_6325_851: #f4f4f4; --text-img_6325_851: #f1f2f1; }
+.btn-img_6325_851 { background-image: var(--gradient-img_6325_851); border:1px solid var(--border-img_6325_851); color:var(--text-img_6325_851); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_851 { background-image: var(--gradient-img_6325_851); border:1px solid var(--border-img_6325_851); color:var(--text-img_6325_851); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_852: linear-gradient(180deg, #f7f8f7 0%, #ececec 100%); --border-img_6325_852: #d1d1d1; --text-img_6325_852: #f4f4f4; }
+.btn-img_6325_852 { background-image: var(--gradient-img_6325_852); border:1px solid var(--border-img_6325_852); color:var(--text-img_6325_852); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_852 { background-image: var(--gradient-img_6325_852); border:1px solid var(--border-img_6325_852); color:var(--text-img_6325_852); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_853: linear-gradient(180deg, #e2e2e2 0%, #e0e0e0 100%); --border-img_6325_853: #c2c2c2; --text-img_6325_853: #e8e8e8; }
+.btn-img_6325_853 { background-image: var(--gradient-img_6325_853); border:1px solid var(--border-img_6325_853); color:var(--text-img_6325_853); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_853 { background-image: var(--gradient-img_6325_853); border:1px solid var(--border-img_6325_853); color:var(--text-img_6325_853); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_854: linear-gradient(180deg, #f3f4f3 0%, #eaebea 100%); --border-img_6325_854: #f2f2f2; --text-img_6325_854: #eef0ee; }
+.btn-img_6325_854 { background-image: var(--gradient-img_6325_854); border:1px solid var(--border-img_6325_854); color:var(--text-img_6325_854); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_854 { background-image: var(--gradient-img_6325_854); border:1px solid var(--border-img_6325_854); color:var(--text-img_6325_854); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_855: linear-gradient(180deg, #f7f7f7 0%, #ebebeb 100%); --border-img_6325_855: #f1f1f1; --text-img_6325_855: #f1f1f1; }
+.btn-img_6325_855 { background-image: var(--gradient-img_6325_855); border:1px solid var(--border-img_6325_855); color:var(--text-img_6325_855); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_855 { background-image: var(--gradient-img_6325_855); border:1px solid var(--border-img_6325_855); color:var(--text-img_6325_855); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_856: linear-gradient(180deg, #e6e6e6 0%, #e0e1e0 100%); --border-img_6325_856: #c3c3c3; --text-img_6325_856: #e6e8e6; }
+.btn-img_6325_856 { background-image: var(--gradient-img_6325_856); border:1px solid var(--border-img_6325_856); color:var(--text-img_6325_856); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_856 { background-image: var(--gradient-img_6325_856); border:1px solid var(--border-img_6325_856); color:var(--text-img_6325_856); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_857: linear-gradient(180deg, #f0f0f0 0%, #343739 100%); --border-img_6325_857: #929992; --text-img_6325_857: #d3e4cf; }
+.btn-img_6325_857 { background-image: var(--gradient-img_6325_857); border:1px solid var(--border-img_6325_857); color:var(--text-img_6325_857); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_857 { background-image: var(--gradient-img_6325_857); border:1px solid var(--border-img_6325_857); color:var(--text-img_6325_857); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_858: linear-gradient(180deg, #f7f7f7 0%, #343739 100%); --border-img_6325_858: #aeb3af; --text-img_6325_858: #c9e6c2; }
+.btn-img_6325_858 { background-image: var(--gradient-img_6325_858); border:1px solid var(--border-img_6325_858); color:var(--text-img_6325_858); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_858 { background-image: var(--gradient-img_6325_858); border:1px solid var(--border-img_6325_858); color:var(--text-img_6325_858); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_859: linear-gradient(180deg, #eaeaea 0%, #343739 100%); --border-img_6325_859: #a0a1a1; --text-img_6325_859: #b1b1b1; }
+.btn-img_6325_859 { background-image: var(--gradient-img_6325_859); border:1px solid var(--border-img_6325_859); color:var(--text-img_6325_859); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_859 { background-image: var(--gradient-img_6325_859); border:1px solid var(--border-img_6325_859); color:var(--text-img_6325_859); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_860: linear-gradient(180deg, #e8e9e8 0%, #343739 100%); --border-img_6325_860: #8a8b8b; --text-img_6325_860: #bfbfbf; }
+.btn-img_6325_860 { background-image: var(--gradient-img_6325_860); border:1px solid var(--border-img_6325_860); color:var(--text-img_6325_860); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_860 { background-image: var(--gradient-img_6325_860); border:1px solid var(--border-img_6325_860); color:var(--text-img_6325_860); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_861: linear-gradient(180deg, #f4f4f4 0%, #343739 100%); --border-img_6325_861: #8d938e; --text-img_6325_861: #afe5a4; }
+.btn-img_6325_861 { background-image: var(--gradient-img_6325_861); border:1px solid var(--border-img_6325_861); color:var(--text-img_6325_861); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_861 { background-image: var(--gradient-img_6325_861); border:1px solid var(--border-img_6325_861); color:var(--text-img_6325_861); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_862: linear-gradient(180deg, #e9eae9 0%, #3c4042 100%); --border-img_6325_862: #9ea59e; --text-img_6325_862: #9a9a9a; }
+.btn-img_6325_862 { background-image: var(--gradient-img_6325_862); border:1px solid var(--border-img_6325_862); color:var(--text-img_6325_862); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_862 { background-image: var(--gradient-img_6325_862); border:1px solid var(--border-img_6325_862); color:var(--text-img_6325_862); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_863: linear-gradient(180deg, #e7e7e7 0%, #343739 100%); --border-img_6325_863: #8c8d8e; --text-img_6325_863: #838383; }
+.btn-img_6325_863 { background-image: var(--gradient-img_6325_863); border:1px solid var(--border-img_6325_863); color:var(--text-img_6325_863); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_863 { background-image: var(--gradient-img_6325_863); border:1px solid var(--border-img_6325_863); color:var(--text-img_6325_863); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_864: linear-gradient(180deg, #e0e0e0 0%, #343739 100%); --border-img_6325_864: #899288; --text-img_6325_864: #e5e5e5; }
+.btn-img_6325_864 { background-image: var(--gradient-img_6325_864); border:1px solid var(--border-img_6325_864); color:var(--text-img_6325_864); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_864 { background-image: var(--gradient-img_6325_864); border:1px solid var(--border-img_6325_864); color:var(--text-img_6325_864); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_865: linear-gradient(180deg, #f7f7f7 0%, #343739 100%); --border-img_6325_865: #a1b29f; --text-img_6325_865: #8fb985; }
+.btn-img_6325_865 { background-image: var(--gradient-img_6325_865); border:1px solid var(--border-img_6325_865); color:var(--text-img_6325_865); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_865 { background-image: var(--gradient-img_6325_865); border:1px solid var(--border-img_6325_865); color:var(--text-img_6325_865); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_866: linear-gradient(180deg, #e6e7e6 0%, #494d50 100%); --border-img_6325_866: #9ba49b; --text-img_6325_866: #7a7a7a; }
+.btn-img_6325_866 { background-image: var(--gradient-img_6325_866); border:1px solid var(--border-img_6325_866); color:var(--text-img_6325_866); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_866 { background-image: var(--gradient-img_6325_866); border:1px solid var(--border-img_6325_866); color:var(--text-img_6325_866); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_867: linear-gradient(180deg, #e6e6e5 0%, #343739 100%); --border-img_6325_867: #979899; --text-img_6325_867: #7b7b7b; }
+.btn-img_6325_867 { background-image: var(--gradient-img_6325_867); border:1px solid var(--border-img_6325_867); color:var(--text-img_6325_867); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_867 { background-image: var(--gradient-img_6325_867); border:1px solid var(--border-img_6325_867); color:var(--text-img_6325_867); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6325_868: linear-gradient(180deg, #dedede 0%, #343739 100%); --border-img_6325_868: #808182; --text-img_6325_868: #dedede; }
+.btn-img_6325_868 { background-image: var(--gradient-img_6325_868); border:1px solid var(--border-img_6325_868); color:var(--text-img_6325_868); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6325_868 { background-image: var(--gradient-img_6325_868); border:1px solid var(--border-img_6325_868); color:var(--text-img_6325_868); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_869: linear-gradient(180deg, #5e6367 0%, #e1e1e1 100%); --border-img_6326_869: #8b8d8f; --text-img_6326_869: #45494c; }
+.btn-img_6326_869 { background-image: var(--gradient-img_6326_869); border:1px solid var(--border-img_6326_869); color:var(--text-img_6326_869); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_869 { background-image: var(--gradient-img_6326_869); border:1px solid var(--border-img_6326_869); color:var(--text-img_6326_869); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_870: linear-gradient(180deg, #5e6367 0%, #e1e1e1 100%); --border-img_6326_870: #8b8e8f; --text-img_6326_870: #45494c; }
+.btn-img_6326_870 { background-image: var(--gradient-img_6326_870); border:1px solid var(--border-img_6326_870); color:var(--text-img_6326_870); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_870 { background-image: var(--gradient-img_6326_870); border:1px solid var(--border-img_6326_870); color:var(--text-img_6326_870); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_871: linear-gradient(180deg, #5e6367 0%, #e2e2e2 100%); --border-img_6326_871: #8d9091; --text-img_6326_871: #45494c; }
+.btn-img_6326_871 { background-image: var(--gradient-img_6326_871); border:1px solid var(--border-img_6326_871); color:var(--text-img_6326_871); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_871 { background-image: var(--gradient-img_6326_871); border:1px solid var(--border-img_6326_871); color:var(--text-img_6326_871); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_872: linear-gradient(180deg, #5e6367 0%, #e2e2e2 100%); --border-img_6326_872: #888d8c; --text-img_6326_872: #45494c; }
+.btn-img_6326_872 { background-image: var(--gradient-img_6326_872); border:1px solid var(--border-img_6326_872); color:var(--text-img_6326_872); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_872 { background-image: var(--gradient-img_6326_872); border:1px solid var(--border-img_6326_872); color:var(--text-img_6326_872); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_873: linear-gradient(180deg, #5e6367 0%, #e2e2e2 100%); --border-img_6326_873: #7d877f; --text-img_6326_873: #45494c; }
+.btn-img_6326_873 { background-image: var(--gradient-img_6326_873); border:1px solid var(--border-img_6326_873); color:var(--text-img_6326_873); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_873 { background-image: var(--gradient-img_6326_873); border:1px solid var(--border-img_6326_873); color:var(--text-img_6326_873); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_874: linear-gradient(180deg, #5e6367 0%, #525252 100%); --border-img_6326_874: #6e7072; --text-img_6326_874: #6f7173; }
+.btn-img_6326_874 { background-image: var(--gradient-img_6326_874); border:1px solid var(--border-img_6326_874); color:var(--text-img_6326_874); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_874 { background-image: var(--gradient-img_6326_874); border:1px solid var(--border-img_6326_874); color:var(--text-img_6326_874); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_875: linear-gradient(180deg, #5e6367 0%, #525252 100%); --border-img_6326_875: #6d6f71; --text-img_6326_875: #6f7173; }
+.btn-img_6326_875 { background-image: var(--gradient-img_6326_875); border:1px solid var(--border-img_6326_875); color:var(--text-img_6326_875); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_875 { background-image: var(--gradient-img_6326_875); border:1px solid var(--border-img_6326_875); color:var(--text-img_6326_875); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_876: linear-gradient(180deg, #5e6367 0%, #7ec46b 100%); --border-img_6326_876: #7d947c; --text-img_6326_876: #484b4c; }
+.btn-img_6326_876 { background-image: var(--gradient-img_6326_876); border:1px solid var(--border-img_6326_876); color:var(--text-img_6326_876); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_876 { background-image: var(--gradient-img_6326_876); border:1px solid var(--border-img_6326_876); color:var(--text-img_6326_876); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_877: linear-gradient(180deg, #5e6367 0%, #505050 100%); --border-img_6326_877: #6e7072; --text-img_6326_877: #aeafaf; }
+.btn-img_6326_877 { background-image: var(--gradient-img_6326_877); border:1px solid var(--border-img_6326_877); color:var(--text-img_6326_877); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_877 { background-image: var(--gradient-img_6326_877); border:1px solid var(--border-img_6326_877); color:var(--text-img_6326_877); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_878: linear-gradient(180deg, #5e6367 0%, #505050 100%); --border-img_6326_878: #6e7072; --text-img_6326_878: #afafb0; }
+.btn-img_6326_878 { background-image: var(--gradient-img_6326_878); border:1px solid var(--border-img_6326_878); color:var(--text-img_6326_878); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_878 { background-image: var(--gradient-img_6326_878); border:1px solid var(--border-img_6326_878); color:var(--text-img_6326_878); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_879: linear-gradient(180deg, #5e6367 0%, #767676 100%); --border-img_6326_879: #7e8480; --text-img_6326_879: #afb0b0; }
+.btn-img_6326_879 { background-image: var(--gradient-img_6326_879); border:1px solid var(--border-img_6326_879); color:var(--text-img_6326_879); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_879 { background-image: var(--gradient-img_6326_879); border:1px solid var(--border-img_6326_879); color:var(--text-img_6326_879); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_880: linear-gradient(180deg, #5e6367 0%, #7bc068 100%); --border-img_6326_880: #789475; --text-img_6326_880: #929393; }
+.btn-img_6326_880 { background-image: var(--gradient-img_6326_880); border:1px solid var(--border-img_6326_880); color:var(--text-img_6326_880); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_880 { background-image: var(--gradient-img_6326_880); border:1px solid var(--border-img_6326_880); color:var(--text-img_6326_880); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_881: linear-gradient(180deg, #4f4f4f 0%, #464646 100%); --border-img_6326_881: #585858; --text-img_6326_881: #ffffff; }
+.btn-img_6326_881 { background-image: var(--gradient-img_6326_881); border:1px solid var(--border-img_6326_881); color:var(--text-img_6326_881); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_881 { background-image: var(--gradient-img_6326_881); border:1px solid var(--border-img_6326_881); color:var(--text-img_6326_881); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_882: linear-gradient(180deg, #4f4f4f 0%, #464646 100%); --border-img_6326_882: #4f4f4f; --text-img_6326_882: #4b4b4b; }
+.btn-img_6326_882 { background-image: var(--gradient-img_6326_882); border:1px solid var(--border-img_6326_882); color:var(--text-img_6326_882); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_882 { background-image: var(--gradient-img_6326_882); border:1px solid var(--border-img_6326_882); color:var(--text-img_6326_882); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_883: linear-gradient(180deg, #4f4f4f 0%, #464646 100%); --border-img_6326_883: #4b4b4b; --text-img_6326_883: #4b4b4b; }
+.btn-img_6326_883 { background-image: var(--gradient-img_6326_883); border:1px solid var(--border-img_6326_883); color:var(--text-img_6326_883); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_883 { background-image: var(--gradient-img_6326_883); border:1px solid var(--border-img_6326_883); color:var(--text-img_6326_883); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_884: linear-gradient(180deg, #b8cdb3 0%, #b5c9b1 100%); --border-img_6326_884: #809a79; --text-img_6326_884: #e4e4e4; }
+.btn-img_6326_884 { background-image: var(--gradient-img_6326_884); border:1px solid var(--border-img_6326_884); color:var(--text-img_6326_884); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_884 { background-image: var(--gradient-img_6326_884); border:1px solid var(--border-img_6326_884); color:var(--text-img_6326_884); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_885: linear-gradient(180deg, #79bf67 0%, #6aac5b 100%); --border-img_6326_885: #80bd71; --text-img_6326_885: #cfe7ca; }
+.btn-img_6326_885 { background-image: var(--gradient-img_6326_885); border:1px solid var(--border-img_6326_885); color:var(--text-img_6326_885); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_885 { background-image: var(--gradient-img_6326_885); border:1px solid var(--border-img_6326_885); color:var(--text-img_6326_885); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_886: linear-gradient(180deg, #4e4e4e 0%, #434343 100%); --border-img_6326_886: #575757; --text-img_6326_886: #7b7b7b; }
+.btn-img_6326_886 { background-image: var(--gradient-img_6326_886); border:1px solid var(--border-img_6326_886); color:var(--text-img_6326_886); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_886 { background-image: var(--gradient-img_6326_886); border:1px solid var(--border-img_6326_886); color:var(--text-img_6326_886); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_887: linear-gradient(180deg, #4e4e4e 0%, #434343 100%); --border-img_6326_887: #585858; --text-img_6326_887: #484848; }
+.btn-img_6326_887 { background-image: var(--gradient-img_6326_887); border:1px solid var(--border-img_6326_887); color:var(--text-img_6326_887); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_887 { background-image: var(--gradient-img_6326_887); border:1px solid var(--border-img_6326_887); color:var(--text-img_6326_887); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_888: linear-gradient(180deg, #76bb65 0%, #65a657 100%); --border-img_6326_888: #90c085; --text-img_6326_888: #f2f8f1; }
+.btn-img_6326_888 { background-image: var(--gradient-img_6326_888); border:1px solid var(--border-img_6326_888); color:var(--text-img_6326_888); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_888 { background-image: var(--gradient-img_6326_888); border:1px solid var(--border-img_6326_888); color:var(--text-img_6326_888); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_889: linear-gradient(180deg, #ffffff 0%, #e4e4e4 100%); --border-img_6326_889: #989898; --text-img_6326_889: #454545; }
+.btn-img_6326_889 { background-image: var(--gradient-img_6326_889); border:1px solid var(--border-img_6326_889); color:var(--text-img_6326_889); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_889 { background-image: var(--gradient-img_6326_889); border:1px solid var(--border-img_6326_889); color:var(--text-img_6326_889); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_890: linear-gradient(180deg, #4b4b4b 0%, #e5e5e5 100%); --border-img_6326_890: #848484; --text-img_6326_890: #454545; }
+.btn-img_6326_890 { background-image: var(--gradient-img_6326_890); border:1px solid var(--border-img_6326_890); color:var(--text-img_6326_890); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_890 { background-image: var(--gradient-img_6326_890); border:1px solid var(--border-img_6326_890); color:var(--text-img_6326_890); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_891: linear-gradient(180deg, #727272 0%, #e6e6e6 100%); --border-img_6326_891: #96a293; --text-img_6326_891: #454545; }
+.btn-img_6326_891 { background-image: var(--gradient-img_6326_891); border:1px solid var(--border-img_6326_891); color:var(--text-img_6326_891); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_891 { background-image: var(--gradient-img_6326_891); border:1px solid var(--border-img_6326_891); color:var(--text-img_6326_891); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_892: linear-gradient(180deg, #d2e8cd 0%, #e6e6e6 100%); --border-img_6326_892: #a5c99d; --text-img_6326_892: #69aa5a; }
+.btn-img_6326_892 { background-image: var(--gradient-img_6326_892); border:1px solid var(--border-img_6326_892); color:var(--text-img_6326_892); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_892 { background-image: var(--gradient-img_6326_892); border:1px solid var(--border-img_6326_892); color:var(--text-img_6326_892); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_893: linear-gradient(180deg, #9c9c9c 0%, #c3c2c2 100%); --border-img_6326_893: #aaaaaa; --text-img_6326_893: #cccbcb; }
+.btn-img_6326_893 { background-image: var(--gradient-img_6326_893); border:1px solid var(--border-img_6326_893); color:var(--text-img_6326_893); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_893 { background-image: var(--gradient-img_6326_893); border:1px solid var(--border-img_6326_893); color:var(--text-img_6326_893); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_894: linear-gradient(180deg, #9c9c9c 0%, #e5e5e5 100%); --border-img_6326_894: #b1b1b1; --text-img_6326_894: #d1d0d0; }
+.btn-img_6326_894 { background-image: var(--gradient-img_6326_894); border:1px solid var(--border-img_6326_894); color:var(--text-img_6326_894); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_894 { background-image: var(--gradient-img_6326_894); border:1px solid var(--border-img_6326_894); color:var(--text-img_6326_894); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_895: linear-gradient(180deg, #9c9c9c 0%, #d2d1d1 100%); --border-img_6326_895: #b0b0af; --text-img_6326_895: #d5d4d4; }
+.btn-img_6326_895 { background-image: var(--gradient-img_6326_895); border:1px solid var(--border-img_6326_895); color:var(--text-img_6326_895); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_895 { background-image: var(--gradient-img_6326_895); border:1px solid var(--border-img_6326_895); color:var(--text-img_6326_895); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_896: linear-gradient(180deg, #c7d5c3 0%, #e5e5e5 100%); --border-img_6326_896: #c6cec4; --text-img_6326_896: #dad8d8; }
+.btn-img_6326_896 { background-image: var(--gradient-img_6326_896); border:1px solid var(--border-img_6326_896); color:var(--text-img_6326_896); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_896 { background-image: var(--gradient-img_6326_896); border:1px solid var(--border-img_6326_896); color:var(--text-img_6326_896); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_897: linear-gradient(180deg, #64a456 0%, #dbddda 100%); --border-img_6326_897: #b5c8af; --text-img_6326_897: #d3d1d1; }
+.btn-img_6326_897 { background-image: var(--gradient-img_6326_897); border:1px solid var(--border-img_6326_897); color:var(--text-img_6326_897); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_897 { background-image: var(--gradient-img_6326_897); border:1px solid var(--border-img_6326_897); color:var(--text-img_6326_897); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_898: linear-gradient(180deg, #e4e4e4 0%, #dadada 100%); --border-img_6326_898: #d8d8d8; --text-img_6326_898: #c6c5c5; }
+.btn-img_6326_898 { background-image: var(--gradient-img_6326_898); border:1px solid var(--border-img_6326_898); color:var(--text-img_6326_898); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_898 { background-image: var(--gradient-img_6326_898); border:1px solid var(--border-img_6326_898); color:var(--text-img_6326_898); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_899: linear-gradient(180deg, #e6e6e6 0%, #dddcdb 100%); --border-img_6326_899: #e1e1e1; --text-img_6326_899: #cecdcd; }
+.btn-img_6326_899 { background-image: var(--gradient-img_6326_899); border:1px solid var(--border-img_6326_899); color:var(--text-img_6326_899); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_899 { background-image: var(--gradient-img_6326_899); border:1px solid var(--border-img_6326_899); color:var(--text-img_6326_899); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_900: linear-gradient(180deg, #e6e6e6 0%, #ececeb 100%); --border-img_6326_900: #e0dfdf; --text-img_6326_900: #d7d9d5; }
+.btn-img_6326_900 { background-image: var(--gradient-img_6326_900); border:1px solid var(--border-img_6326_900); color:var(--text-img_6326_900); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_900 { background-image: var(--gradient-img_6326_900); border:1px solid var(--border-img_6326_900); color:var(--text-img_6326_900); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_901: linear-gradient(180deg, #c4c3c3 0%, #cfcfcf 100%); --border-img_6326_901: #c6c6c6; --text-img_6326_901: #c0bfbf; }
+.btn-img_6326_901 { background-image: var(--gradient-img_6326_901); border:1px solid var(--border-img_6326_901); color:var(--text-img_6326_901); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_901 { background-image: var(--gradient-img_6326_901); border:1px solid var(--border-img_6326_901); color:var(--text-img_6326_901); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_902: linear-gradient(180deg, #cdcbcb 0%, #717070 100%); --border-img_6326_902: #c1c0c0; --text-img_6326_902: #ececec; }
+.btn-img_6326_902 { background-image: var(--gradient-img_6326_902); border:1px solid var(--border-img_6326_902); color:var(--text-img_6326_902); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_902 { background-image: var(--gradient-img_6326_902); border:1px solid var(--border-img_6326_902); color:var(--text-img_6326_902); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_903: linear-gradient(180deg, #d6d4d4 0%, #b5d0af 100%); --border-img_6326_903: #c3cfbf; --text-img_6326_903: #ececec; }
+.btn-img_6326_903 { background-image: var(--gradient-img_6326_903); border:1px solid var(--border-img_6326_903); color:var(--text-img_6326_903); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_903 { background-image: var(--gradient-img_6326_903); border:1px solid var(--border-img_6326_903); color:var(--text-img_6326_903); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_904: linear-gradient(180deg, #d0cdcd 0%, #accca5 100%); --border-img_6326_904: #c0cbbc; --text-img_6326_904: #ececec; }
+.btn-img_6326_904 { background-image: var(--gradient-img_6326_904); border:1px solid var(--border-img_6326_904); color:var(--text-img_6326_904); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_904 { background-image: var(--gradient-img_6326_904); border:1px solid var(--border-img_6326_904); color:var(--text-img_6326_904); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_905: linear-gradient(180deg, #c0bfbf 0%, #bfbfbf 100%); --border-img_6326_905: #d1d1d1; --text-img_6326_905: #c2c2c2; }
+.btn-img_6326_905 { background-image: var(--gradient-img_6326_905); border:1px solid var(--border-img_6326_905); color:var(--text-img_6326_905); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_905 { background-image: var(--gradient-img_6326_905); border:1px solid var(--border-img_6326_905); color:var(--text-img_6326_905); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_906: linear-gradient(180deg, #eaeaea 0%, #f7f7f7 100%); --border-img_6326_906: #dadada; --text-img_6326_906: #717070; }
+.btn-img_6326_906 { background-image: var(--gradient-img_6326_906); border:1px solid var(--border-img_6326_906); color:var(--text-img_6326_906); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_906 { background-image: var(--gradient-img_6326_906); border:1px solid var(--border-img_6326_906); color:var(--text-img_6326_906); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_907: linear-gradient(180deg, #dad9d9 0%, #dfdede 100%); --border-img_6326_907: #d9dcd8; --text-img_6326_907: #d3d2d2; }
+.btn-img_6326_907 { background-image: var(--gradient-img_6326_907); border:1px solid var(--border-img_6326_907); color:var(--text-img_6326_907); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_907 { background-image: var(--gradient-img_6326_907); border:1px solid var(--border-img_6326_907); color:var(--text-img_6326_907); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_908: linear-gradient(180deg, #eaeaea 0%, #f7f7f7 100%); --border-img_6326_908: #e0e7de; --text-img_6326_908: #7ab06d; }
+.btn-img_6326_908 { background-image: var(--gradient-img_6326_908); border:1px solid var(--border-img_6326_908); color:var(--text-img_6326_908); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_908 { background-image: var(--gradient-img_6326_908); border:1px solid var(--border-img_6326_908); color:var(--text-img_6326_908); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_909: linear-gradient(180deg, #e3e4e2 0%, #eeefed 100%); --border-img_6326_909: #d4d9d2; --text-img_6326_909: #f1f1f1; }
+.btn-img_6326_909 { background-image: var(--gradient-img_6326_909); border:1px solid var(--border-img_6326_909); color:var(--text-img_6326_909); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_909 { background-image: var(--gradient-img_6326_909); border:1px solid var(--border-img_6326_909); color:var(--text-img_6326_909); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_910: linear-gradient(180deg, #d4d4d4 0%, #c3c2c2 100%); --border-img_6326_910: #c0bfbf; --text-img_6326_910: #eaeaea; }
+.btn-img_6326_910 { background-image: var(--gradient-img_6326_910); border:1px solid var(--border-img_6326_910); color:var(--text-img_6326_910); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_910 { background-image: var(--gradient-img_6326_910); border:1px solid var(--border-img_6326_910); color:var(--text-img_6326_910); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_911: linear-gradient(180deg, #dfdfde 0%, #cecdcd 100%); --border-img_6326_911: #dadad9; --text-img_6326_911: #dcdbdb; }
+.btn-img_6326_911 { background-image: var(--gradient-img_6326_911); border:1px solid var(--border-img_6326_911); color:var(--text-img_6326_911); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_911 { background-image: var(--gradient-img_6326_911); border:1px solid var(--border-img_6326_911); color:var(--text-img_6326_911); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_912: linear-gradient(180deg, #b3cfac 0%, #d8d5d5 100%); --border-img_6326_912: #c8d2c4; --text-img_6326_912: #f8f8f8; }
+.btn-img_6326_912 { background-image: var(--gradient-img_6326_912); border:1px solid var(--border-img_6326_912); color:var(--text-img_6326_912); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_912 { background-image: var(--gradient-img_6326_912); border:1px solid var(--border-img_6326_912); color:var(--text-img_6326_912); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_913: linear-gradient(180deg, #d1d0d0 0%, #eaeaea 100%); --border-img_6326_913: #dbdbdb; --text-img_6326_913: #c1c1c1; }
+.btn-img_6326_913 { background-image: var(--gradient-img_6326_913); border:1px solid var(--border-img_6326_913); color:var(--text-img_6326_913); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_913 { background-image: var(--gradient-img_6326_913); border:1px solid var(--border-img_6326_913); color:var(--text-img_6326_913); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_914: linear-gradient(180deg, #fafafa 0%, #ebebeb 100%); --border-img_6326_914: #eae9e9; --text-img_6326_914: #cac8c8; }
+.btn-img_6326_914 { background-image: var(--gradient-img_6326_914); border:1px solid var(--border-img_6326_914); color:var(--text-img_6326_914); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_914 { background-image: var(--gradient-img_6326_914); border:1px solid var(--border-img_6326_914); color:var(--text-img_6326_914); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_915: linear-gradient(180deg, #f4f5f3 0%, #ececec 100%); --border-img_6326_915: #e6e5e5; --text-img_6326_915: #d2d0d0; }
+.btn-img_6326_915 { background-image: var(--gradient-img_6326_915); border:1px solid var(--border-img_6326_915); color:var(--text-img_6326_915); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_915 { background-image: var(--gradient-img_6326_915); border:1px solid var(--border-img_6326_915); color:var(--text-img_6326_915); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_916: linear-gradient(180deg, #f7f8f6 0%, #ececec 100%); --border-img_6326_916: #e7e6e6; --text-img_6326_916: #d9d6d6; }
+.btn-img_6326_916 { background-image: var(--gradient-img_6326_916); border:1px solid var(--border-img_6326_916); color:var(--text-img_6326_916); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_916 { background-image: var(--gradient-img_6326_916); border:1px solid var(--border-img_6326_916); color:var(--text-img_6326_916); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_917: linear-gradient(180deg, #bfbebe 0%, #e9e9e9 100%); --border-img_6326_917: #d7d6d6; --text-img_6326_917: #c0c0c0; }
+.btn-img_6326_917 { background-image: var(--gradient-img_6326_917); border:1px solid var(--border-img_6326_917); color:var(--text-img_6326_917); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_917 { background-image: var(--gradient-img_6326_917); border:1px solid var(--border-img_6326_917); color:var(--text-img_6326_917); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_918: linear-gradient(180deg, #fcfcfc 0%, #eaebeb 100%); --border-img_6326_918: #e7e7e7; --text-img_6326_918: #c7c6c6; }
+.btn-img_6326_918 { background-image: var(--gradient-img_6326_918); border:1px solid var(--border-img_6326_918); color:var(--text-img_6326_918); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_918 { background-image: var(--gradient-img_6326_918); border:1px solid var(--border-img_6326_918); color:var(--text-img_6326_918); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_919: linear-gradient(180deg, #e1e0e0 0%, #ebebeb 100%); --border-img_6326_919: #e2e2e1; --text-img_6326_919: #cecccc; }
+.btn-img_6326_919 { background-image: var(--gradient-img_6326_919); border:1px solid var(--border-img_6326_919); color:var(--text-img_6326_919); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_919 { background-image: var(--gradient-img_6326_919); border:1px solid var(--border-img_6326_919); color:var(--text-img_6326_919); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_920: linear-gradient(180deg, #fcfcfc 0%, #ececec 100%); --border-img_6326_920: #ebebeb; --text-img_6326_920: #d4d2d2; }
+.btn-img_6326_920 { background-image: var(--gradient-img_6326_920); border:1px solid var(--border-img_6326_920); color:var(--text-img_6326_920); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_920 { background-image: var(--gradient-img_6326_920); border:1px solid var(--border-img_6326_920); color:var(--text-img_6326_920); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_921: linear-gradient(180deg, #f2f3f2 0%, #ececec 100%); --border-img_6326_921: #e6e5e4; --text-img_6326_921: #d9d6d6; }
+.btn-img_6326_921 { background-image: var(--gradient-img_6326_921); border:1px solid var(--border-img_6326_921); color:var(--text-img_6326_921); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_921 { background-image: var(--gradient-img_6326_921); border:1px solid var(--border-img_6326_921); color:var(--text-img_6326_921); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_922: linear-gradient(180deg, #c2c2c2 0%, #88c17a 100%); --border-img_6326_922: #c1d2bd; --text-img_6326_922: #dae1d8; }
+.btn-img_6326_922 { background-image: var(--gradient-img_6326_922); border:1px solid var(--border-img_6326_922); color:var(--text-img_6326_922); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_922 { background-image: var(--gradient-img_6326_922); border:1px solid var(--border-img_6326_922); color:var(--text-img_6326_922); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_923: linear-gradient(180deg, #cdcccc 0%, #e8e8e8 100%); --border-img_6326_923: #dcdbdb; --text-img_6326_923: #e8e8e8; }
+.btn-img_6326_923 { background-image: var(--gradient-img_6326_923); border:1px solid var(--border-img_6326_923); color:var(--text-img_6326_923); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_923 { background-image: var(--gradient-img_6326_923); border:1px solid var(--border-img_6326_923); color:var(--text-img_6326_923); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_924: linear-gradient(180deg, #d8d5d5 0%, #e8e8e8 100%); --border-img_6326_924: #e3e2e2; --text-img_6326_924: #e9e9e9; }
+.btn-img_6326_924 { background-image: var(--gradient-img_6326_924); border:1px solid var(--border-img_6326_924); color:var(--text-img_6326_924); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_924 { background-image: var(--gradient-img_6326_924); border:1px solid var(--border-img_6326_924); color:var(--text-img_6326_924); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_925: linear-gradient(180deg, #679c59 0%, #6aab5a 100%); --border-img_6326_925: #97c58c; --text-img_6326_925: #c0dfb8; }
+.btn-img_6326_925 { background-image: var(--gradient-img_6326_925); border:1px solid var(--border-img_6326_925); color:var(--text-img_6326_925); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_925 { background-image: var(--gradient-img_6326_925); border:1px solid var(--border-img_6326_925); color:var(--text-img_6326_925); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_926: linear-gradient(180deg, #e7e7e7 0%, #e9e9e9 100%); --border-img_6326_926: #d1dcce; --text-img_6326_926: #ececec; }
+.btn-img_6326_926 { background-image: var(--gradient-img_6326_926); border:1px solid var(--border-img_6326_926); color:var(--text-img_6326_926); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_926 { background-image: var(--gradient-img_6326_926); border:1px solid var(--border-img_6326_926); color:var(--text-img_6326_926); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_927: linear-gradient(180deg, #d5d5d5 0%, #e6e6e6 100%); --border-img_6326_927: #dddddd; --text-img_6326_927: #d5d5d5; }
+.btn-img_6326_927 { background-image: var(--gradient-img_6326_927); border:1px solid var(--border-img_6326_927); color:var(--text-img_6326_927); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_927 { background-image: var(--gradient-img_6326_927); border:1px solid var(--border-img_6326_927); color:var(--text-img_6326_927); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_928: linear-gradient(180deg, #d5d5d5 0%, #e6e6e6 100%); --border-img_6326_928: #e1e0e0; --text-img_6326_928: #d1d0d0; }
+.btn-img_6326_928 { background-image: var(--gradient-img_6326_928); border:1px solid var(--border-img_6326_928); color:var(--text-img_6326_928); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_928 { background-image: var(--gradient-img_6326_928); border:1px solid var(--border-img_6326_928); color:var(--text-img_6326_928); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_929: linear-gradient(180deg, #d5d5d5 0%, #e6e6e6 100%); --border-img_6326_929: #e5e4e4; --text-img_6326_929: #d2d2d2; }
+.btn-img_6326_929 { background-image: var(--gradient-img_6326_929); border:1px solid var(--border-img_6326_929); color:var(--text-img_6326_929); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_929 { background-image: var(--gradient-img_6326_929); border:1px solid var(--border-img_6326_929); color:var(--text-img_6326_929); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_930: linear-gradient(180deg, #79be67 0%, #ececec 100%); --border-img_6326_930: #a2c39a; --text-img_6326_930: #a5cd9c; }
+.btn-img_6326_930 { background-image: var(--gradient-img_6326_930); border:1px solid var(--border-img_6326_930); color:var(--text-img_6326_930); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_930 { background-image: var(--gradient-img_6326_930); border:1px solid var(--border-img_6326_930); color:var(--text-img_6326_930); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_931: linear-gradient(180deg, #e8e8e8 0%, #e4e3e3 100%); --border-img_6326_931: #e4e4e4; --text-img_6326_931: #e6e6e6; }
+.btn-img_6326_931 { background-image: var(--gradient-img_6326_931); border:1px solid var(--border-img_6326_931); color:var(--text-img_6326_931); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_931 { background-image: var(--gradient-img_6326_931); border:1px solid var(--border-img_6326_931); color:var(--text-img_6326_931); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_932: linear-gradient(180deg, #e9e8e9 0%, #e4e3e3 100%); --border-img_6326_932: #d1d6cf; --text-img_6326_932: #e1e1e1; }
+.btn-img_6326_932 { background-image: var(--gradient-img_6326_932); border:1px solid var(--border-img_6326_932); color:var(--text-img_6326_932); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_932 { background-image: var(--gradient-img_6326_932); border:1px solid var(--border-img_6326_932); color:var(--text-img_6326_932); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_933: linear-gradient(180deg, #e9e9e9 0%, #b5ccaf 100%); --border-img_6326_933: #ccd6c9; --text-img_6326_933: #dcdbdb; }
+.btn-img_6326_933 { background-image: var(--gradient-img_6326_933); border:1px solid var(--border-img_6326_933); color:var(--text-img_6326_933); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_933 { background-image: var(--gradient-img_6326_933); border:1px solid var(--border-img_6326_933); color:var(--text-img_6326_933); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_934: linear-gradient(180deg, #81b774 0%, #555555 100%); --border-img_6326_934: #aab3a8; --text-img_6326_934: #ececec; }
+.btn-img_6326_934 { background-image: var(--gradient-img_6326_934); border:1px solid var(--border-img_6326_934); color:var(--text-img_6326_934); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_934 { background-image: var(--gradient-img_6326_934); border:1px solid var(--border-img_6326_934); color:var(--text-img_6326_934); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_935: linear-gradient(180deg, #e6e6e6 0%, #c7d4c3 100%); --border-img_6326_935: #d3dbd0; --text-img_6326_935: #e5e4e4; }
+.btn-img_6326_935 { background-image: var(--gradient-img_6326_935); border:1px solid var(--border-img_6326_935); color:var(--text-img_6326_935); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_935 { background-image: var(--gradient-img_6326_935); border:1px solid var(--border-img_6326_935); color:var(--text-img_6326_935); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_936: linear-gradient(180deg, #e6e6e6 0%, #67a658 100%); --border-img_6326_936: #b2caac; --text-img_6326_936: #aac7a2; }
+.btn-img_6326_936 { background-image: var(--gradient-img_6326_936); border:1px solid var(--border-img_6326_936); color:var(--text-img_6326_936); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_936 { background-image: var(--gradient-img_6326_936); border:1px solid var(--border-img_6326_936); color:var(--text-img_6326_936); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_937: linear-gradient(180deg, #ececec 0%, #8cd579 100%); --border-img_6326_937: #889c83; --text-img_6326_937: #383838; }
+.btn-img_6326_937 { background-image: var(--gradient-img_6326_937); border:1px solid var(--border-img_6326_937); color:var(--text-img_6326_937); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_937 { background-image: var(--gradient-img_6326_937); border:1px solid var(--border-img_6326_937); color:var(--text-img_6326_937); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_938: linear-gradient(180deg, #e9e9e9 0%, #e9e9e9 100%); --border-img_6326_938: #cdcdcd; --text-img_6326_938: #eeeeee; }
+.btn-img_6326_938 { background-image: var(--gradient-img_6326_938); border:1px solid var(--border-img_6326_938); color:var(--text-img_6326_938); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_938 { background-image: var(--gradient-img_6326_938); border:1px solid var(--border-img_6326_938); color:var(--text-img_6326_938); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_939: linear-gradient(180deg, #e5e4e4 0%, #82b376 100%); --border-img_6326_939: #bacfb5; --text-img_6326_939: #e3e2e2; }
+.btn-img_6326_939 { background-image: var(--gradient-img_6326_939); border:1px solid var(--border-img_6326_939); color:var(--text-img_6326_939); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_939 { background-image: var(--gradient-img_6326_939); border:1px solid var(--border-img_6326_939); color:var(--text-img_6326_939); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_940: linear-gradient(180deg, #e5e4e4 0%, #67a658 100%); --border-img_6326_940: #94bc8a; --text-img_6326_940: #67a658; }
+.btn-img_6326_940 { background-image: var(--gradient-img_6326_940); border:1px solid var(--border-img_6326_940); color:var(--text-img_6326_940); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_940 { background-image: var(--gradient-img_6326_940); border:1px solid var(--border-img_6326_940); color:var(--text-img_6326_940); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_941: linear-gradient(180deg, #e5e4e4 0%, #67a658 100%); --border-img_6326_941: #9cc092; --text-img_6326_941: #6ca95e; }
+.btn-img_6326_941 { background-image: var(--gradient-img_6326_941); border:1px solid var(--border-img_6326_941); color:var(--text-img_6326_941); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_941 { background-image: var(--gradient-img_6326_941); border:1px solid var(--border-img_6326_941); color:var(--text-img_6326_941); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_942: linear-gradient(180deg, #363636 0%, #afeaa3 100%); --border-img_6326_942: #889885; --text-img_6326_942: #313131; }
+.btn-img_6326_942 { background-image: var(--gradient-img_6326_942); border:1px solid var(--border-img_6326_942); color:var(--text-img_6326_942); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_942 { background-image: var(--gradient-img_6326_942); border:1px solid var(--border-img_6326_942); color:var(--text-img_6326_942); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_943: linear-gradient(180deg, #e2e1e1 0%, #dedddd 100%); --border-img_6326_943: #d2dbce; --text-img_6326_943: #e0dfdf; }
+.btn-img_6326_943 { background-image: var(--gradient-img_6326_943); border:1px solid var(--border-img_6326_943); color:var(--text-img_6326_943); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_943 { background-image: var(--gradient-img_6326_943); border:1px solid var(--border-img_6326_943); color:var(--text-img_6326_943); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_944: linear-gradient(180deg, #67a658 0%, #67a658 100%); --border-img_6326_944: #83b377; --text-img_6326_944: #67a658; }
+.btn-img_6326_944 { background-image: var(--gradient-img_6326_944); border:1px solid var(--border-img_6326_944); color:var(--text-img_6326_944); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_944 { background-image: var(--gradient-img_6326_944); border:1px solid var(--border-img_6326_944); color:var(--text-img_6326_944); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_945: linear-gradient(180deg, #68a759 0%, #67a658 100%); --border-img_6326_945: #81b275; --text-img_6326_945: #67a658; }
+.btn-img_6326_945 { background-image: var(--gradient-img_6326_945); border:1px solid var(--border-img_6326_945); color:var(--text-img_6326_945); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_945 { background-image: var(--gradient-img_6326_945); border:1px solid var(--border-img_6326_945); color:var(--text-img_6326_945); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_946: linear-gradient(180deg, #85b07a 0%, #afe4a4 100%); --border-img_6326_946: #b1ccaa; --text-img_6326_946: #c3c3c3; }
+.btn-img_6326_946 { background-image: var(--gradient-img_6326_946); border:1px solid var(--border-img_6326_946); color:var(--text-img_6326_946); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_946 { background-image: var(--gradient-img_6326_946); border:1px solid var(--border-img_6326_946); color:var(--text-img_6326_946); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_947: linear-gradient(180deg, #86b57b 0%, #dddbdb 100%); --border-img_6326_947: #b5caaf; --text-img_6326_947: #67a658; }
+.btn-img_6326_947 { background-image: var(--gradient-img_6326_947); border:1px solid var(--border-img_6326_947); color:var(--text-img_6326_947); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_947 { background-image: var(--gradient-img_6326_947); border:1px solid var(--border-img_6326_947); color:var(--text-img_6326_947); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_948: linear-gradient(180deg, #67a658 0%, #dddbdb 100%); --border-img_6326_948: #93ba89; --text-img_6326_948: #67a658; }
+.btn-img_6326_948 { background-image: var(--gradient-img_6326_948); border:1px solid var(--border-img_6326_948); color:var(--text-img_6326_948); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_948 { background-image: var(--gradient-img_6326_948); border:1px solid var(--border-img_6326_948); color:var(--text-img_6326_948); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_949: linear-gradient(180deg, #303030 0%, #8bbb81 100%); --border-img_6326_949: #7e9879; --text-img_6326_949: #bce1b5; }
+.btn-img_6326_949 { background-image: var(--gradient-img_6326_949); border:1px solid var(--border-img_6326_949); color:var(--text-img_6326_949); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_949 { background-image: var(--gradient-img_6326_949); border:1px solid var(--border-img_6326_949); color:var(--text-img_6326_949); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_950: linear-gradient(180deg, #e9e9e9 0%, #e9e8e8 100%); --border-img_6326_950: #d4dcd1; --text-img_6326_950: #efefef; }
+.btn-img_6326_950 { background-image: var(--gradient-img_6326_950); border:1px solid var(--border-img_6326_950); color:var(--text-img_6326_950); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_950 { background-image: var(--gradient-img_6326_950); border:1px solid var(--border-img_6326_950); color:var(--text-img_6326_950); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_951: linear-gradient(180deg, #67a658 0%, #dddada 100%); --border-img_6326_951: #b2c7ab; --text-img_6326_951: #80b174; }
+.btn-img_6326_951 { background-image: var(--gradient-img_6326_951); border:1px solid var(--border-img_6326_951); color:var(--text-img_6326_951); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_951 { background-image: var(--gradient-img_6326_951); border:1px solid var(--border-img_6326_951); color:var(--text-img_6326_951); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_952: linear-gradient(180deg, #67a658 0%, #dddada 100%); --border-img_6326_952: #9bbd92; --text-img_6326_952: #67a658; }
+.btn-img_6326_952 { background-image: var(--gradient-img_6326_952); border:1px solid var(--border-img_6326_952); color:var(--text-img_6326_952); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_952 { background-image: var(--gradient-img_6326_952); border:1px solid var(--border-img_6326_952); color:var(--text-img_6326_952); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_953: linear-gradient(180deg, #67a658 0%, #dddada 100%); --border-img_6326_953: #9abc91; --text-img_6326_953: #67a658; }
+.btn-img_6326_953 { background-image: var(--gradient-img_6326_953); border:1px solid var(--border-img_6326_953); color:var(--text-img_6326_953); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_953 { background-image: var(--gradient-img_6326_953); border:1px solid var(--border-img_6326_953); color:var(--text-img_6326_953); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_954: linear-gradient(180deg, #6d8a65 0%, #343739 100%); --border-img_6326_954: #8caa87; --text-img_6326_954: #9ad18c; }
+.btn-img_6326_954 { background-image: var(--gradient-img_6326_954); border:1px solid var(--border-img_6326_954); color:var(--text-img_6326_954); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_954 { background-image: var(--gradient-img_6326_954); border:1px solid var(--border-img_6326_954); color:var(--text-img_6326_954); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_955: linear-gradient(180deg, #d8d6d6 0%, #343739 100%); --border-img_6326_955: #b3b3b3; --text-img_6326_955: #dcdada; }
+.btn-img_6326_955 { background-image: var(--gradient-img_6326_955); border:1px solid var(--border-img_6326_955); color:var(--text-img_6326_955); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_955 { background-image: var(--gradient-img_6326_955); border:1px solid var(--border-img_6326_955); color:var(--text-img_6326_955); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_956: linear-gradient(180deg, #dcdada 0%, #343739 100%); --border-img_6326_956: #b1b1b1; --text-img_6326_956: #dcdada; }
+.btn-img_6326_956 { background-image: var(--gradient-img_6326_956); border:1px solid var(--border-img_6326_956); color:var(--text-img_6326_956); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_956 { background-image: var(--gradient-img_6326_956); border:1px solid var(--border-img_6326_956); color:var(--text-img_6326_956); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_957: linear-gradient(180deg, #d4d2d2 0%, #343739 100%); --border-img_6326_957: #acacac; --text-img_6326_957: #dcdada; }
+.btn-img_6326_957 { background-image: var(--gradient-img_6326_957); border:1px solid var(--border-img_6326_957); color:var(--text-img_6326_957); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_957 { background-image: var(--gradient-img_6326_957); border:1px solid var(--border-img_6326_957); color:var(--text-img_6326_957); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_958: linear-gradient(180deg, #687464 0%, #343739 100%); --border-img_6326_958: #879386; --text-img_6326_958: #bcdbb4; }
+.btn-img_6326_958 { background-image: var(--gradient-img_6326_958); border:1px solid var(--border-img_6326_958); color:var(--text-img_6326_958); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_958 { background-image: var(--gradient-img_6326_958); border:1px solid var(--border-img_6326_958); color:var(--text-img_6326_958); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_959: linear-gradient(180deg, #b7b6b6 0%, #3c4042 100%); --border-img_6326_959: #9f9fa0; --text-img_6326_959: #e4e3e3; }
+.btn-img_6326_959 { background-image: var(--gradient-img_6326_959); border:1px solid var(--border-img_6326_959); color:var(--text-img_6326_959); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_959 { background-image: var(--gradient-img_6326_959); border:1px solid var(--border-img_6326_959); color:var(--text-img_6326_959); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_960: linear-gradient(180deg, #a9a8a8 0%, #343739 100%); --border-img_6326_960: #9d9d9e; --text-img_6326_960: #e5e4e4; }
+.btn-img_6326_960 { background-image: var(--gradient-img_6326_960); border:1px solid var(--border-img_6326_960); color:var(--text-img_6326_960); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_960 { background-image: var(--gradient-img_6326_960); border:1px solid var(--border-img_6326_960); color:var(--text-img_6326_960); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_961: linear-gradient(180deg, #95d586 0%, #343739 100%); --border-img_6326_961: #778875; --text-img_6326_961: #e1e8e0; }
+.btn-img_6326_961 { background-image: var(--gradient-img_6326_961); border:1px solid var(--border-img_6326_961); color:var(--text-img_6326_961); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_961 { background-image: var(--gradient-img_6326_961); border:1px solid var(--border-img_6326_961); color:var(--text-img_6326_961); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_962: linear-gradient(180deg, #e9e8e8 0%, #343739 100%); --border-img_6326_962: #a3aaa2; --text-img_6326_962: #f0f0f0; }
+.btn-img_6326_962 { background-image: var(--gradient-img_6326_962); border:1px solid var(--border-img_6326_962); color:var(--text-img_6326_962); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_962 { background-image: var(--gradient-img_6326_962); border:1px solid var(--border-img_6326_962); color:var(--text-img_6326_962); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_963: linear-gradient(180deg, #dbd8d9 0%, #494d50 100%); --border-img_6326_963: #aeaeaf; --text-img_6326_963: #ededed; }
+.btn-img_6326_963 { background-image: var(--gradient-img_6326_963); border:1px solid var(--border-img_6326_963); color:var(--text-img_6326_963); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_963 { background-image: var(--gradient-img_6326_963); border:1px solid var(--border-img_6326_963); color:var(--text-img_6326_963); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_964: linear-gradient(180deg, #dbd8d9 0%, #343739 100%); --border-img_6326_964: #b2b2b3; --text-img_6326_964: #efefef; }
+.btn-img_6326_964 { background-image: var(--gradient-img_6326_964); border:1px solid var(--border-img_6326_964); color:var(--text-img_6326_964); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_964 { background-image: var(--gradient-img_6326_964); border:1px solid var(--border-img_6326_964); color:var(--text-img_6326_964); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6326_965: linear-gradient(180deg, #dbd9d9 0%, #343739 100%); --border-img_6326_965: #a9a9aa; --text-img_6326_965: #eeeeee; }
+.btn-img_6326_965 { background-image: var(--gradient-img_6326_965); border:1px solid var(--border-img_6326_965); color:var(--text-img_6326_965); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6326_965 { background-image: var(--gradient-img_6326_965); border:1px solid var(--border-img_6326_965); color:var(--text-img_6326_965); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_966: linear-gradient(180deg, #5e6367 0%, #c9c9c9 100%); --border-img_6327_966: #7f8183; --text-img_6327_966: #45494c; }
+.btn-img_6327_966 { background-image: var(--gradient-img_6327_966); border:1px solid var(--border-img_6327_966); color:var(--text-img_6327_966); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_966 { background-image: var(--gradient-img_6327_966); border:1px solid var(--border-img_6327_966); color:var(--text-img_6327_966); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_967: linear-gradient(180deg, #5e6367 0%, #dddddd 100%); --border-img_6327_967: #929496; --text-img_6327_967: #45494c; }
+.btn-img_6327_967 { background-image: var(--gradient-img_6327_967); border:1px solid var(--border-img_6327_967); color:var(--text-img_6327_967); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_967 { background-image: var(--gradient-img_6327_967); border:1px solid var(--border-img_6327_967); color:var(--text-img_6327_967); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_968: linear-gradient(180deg, #5e6367 0%, #dddddd 100%); --border-img_6327_968: #939697; --text-img_6327_968: #45494c; }
+.btn-img_6327_968 { background-image: var(--gradient-img_6327_968); border:1px solid var(--border-img_6327_968); color:var(--text-img_6327_968); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_968 { background-image: var(--gradient-img_6327_968); border:1px solid var(--border-img_6327_968); color:var(--text-img_6327_968); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_969: linear-gradient(180deg, #5e6367 0%, #dddddd 100%); --border-img_6327_969: #909294; --text-img_6327_969: #45494c; }
+.btn-img_6327_969 { background-image: var(--gradient-img_6327_969); border:1px solid var(--border-img_6327_969); color:var(--text-img_6327_969); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_969 { background-image: var(--gradient-img_6327_969); border:1px solid var(--border-img_6327_969); color:var(--text-img_6327_969); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_970: linear-gradient(180deg, #5e6367 0%, #dddddd 100%); --border-img_6327_970: #919395; --text-img_6327_970: #45494c; }
+.btn-img_6327_970 { background-image: var(--gradient-img_6327_970); border:1px solid var(--border-img_6327_970); color:var(--text-img_6327_970); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_970 { background-image: var(--gradient-img_6327_970); border:1px solid var(--border-img_6327_970); color:var(--text-img_6327_970); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_971: linear-gradient(180deg, #5e6367 0%, #b9b9b9 100%); --border-img_6327_971: #828486; --text-img_6327_971: #707274; }
+.btn-img_6327_971 { background-image: var(--gradient-img_6327_971); border:1px solid var(--border-img_6327_971); color:var(--text-img_6327_971); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_971 { background-image: var(--gradient-img_6327_971); border:1px solid var(--border-img_6327_971); color:var(--text-img_6327_971); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_972: linear-gradient(180deg, #5e6367 0%, #dadada 100%); --border-img_6327_972: #999c9d; --text-img_6327_972: #707274; }
+.btn-img_6327_972 { background-image: var(--gradient-img_6327_972); border:1px solid var(--border-img_6327_972); color:var(--text-img_6327_972); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_972 { background-image: var(--gradient-img_6327_972); border:1px solid var(--border-img_6327_972); color:var(--text-img_6327_972); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_973: linear-gradient(180deg, #5e6367 0%, #dadada 100%); --border-img_6327_973: #9a9c9e; --text-img_6327_973: #707274; }
+.btn-img_6327_973 { background-image: var(--gradient-img_6327_973); border:1px solid var(--border-img_6327_973); color:var(--text-img_6327_973); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_973 { background-image: var(--gradient-img_6327_973); border:1px solid var(--border-img_6327_973); color:var(--text-img_6327_973); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_974: linear-gradient(180deg, #5e6367 0%, #858585 100%); --border-img_6327_974: #919395; --text-img_6327_974: #afb0b1; }
+.btn-img_6327_974 { background-image: var(--gradient-img_6327_974); border:1px solid var(--border-img_6327_974); color:var(--text-img_6327_974); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_974 { background-image: var(--gradient-img_6327_974); border:1px solid var(--border-img_6327_974); color:var(--text-img_6327_974); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_975: linear-gradient(180deg, #5e6367 0%, #d6d6d6 100%); --border-img_6327_975: #9ea0a2; --text-img_6327_975: #afb0b1; }
+.btn-img_6327_975 { background-image: var(--gradient-img_6327_975); border:1px solid var(--border-img_6327_975); color:var(--text-img_6327_975); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_975 { background-image: var(--gradient-img_6327_975); border:1px solid var(--border-img_6327_975); color:var(--text-img_6327_975); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_976: linear-gradient(180deg, #5e6367 0%, #d6d6d6 100%); --border-img_6327_976: #a0a2a3; --text-img_6327_976: #afb0b1; }
+.btn-img_6327_976 { background-image: var(--gradient-img_6327_976); border:1px solid var(--border-img_6327_976); color:var(--text-img_6327_976); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_976 { background-image: var(--gradient-img_6327_976); border:1px solid var(--border-img_6327_976); color:var(--text-img_6327_976); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_977: linear-gradient(180deg, #5e6367 0%, #d6d6d6 100%); --border-img_6327_977: #9ea0a2; --text-img_6327_977: #afb0b1; }
+.btn-img_6327_977 { background-image: var(--gradient-img_6327_977); border:1px solid var(--border-img_6327_977); color:var(--text-img_6327_977); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_977 { background-image: var(--gradient-img_6327_977); border:1px solid var(--border-img_6327_977); color:var(--text-img_6327_977); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_978: linear-gradient(180deg, #d4d4d4 0%, #dddddd 100%); --border-img_6327_978: #bdbdbd; --text-img_6327_978: #d3d3d3; }
+.btn-img_6327_978 { background-image: var(--gradient-img_6327_978); border:1px solid var(--border-img_6327_978); color:var(--text-img_6327_978); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_978 { background-image: var(--gradient-img_6327_978); border:1px solid var(--border-img_6327_978); color:var(--text-img_6327_978); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_979: linear-gradient(180deg, #d4d4d4 0%, #dedede 100%); --border-img_6327_979: #d8d8d8; --text-img_6327_979: #d3d3d3; }
+.btn-img_6327_979 { background-image: var(--gradient-img_6327_979); border:1px solid var(--border-img_6327_979); color:var(--text-img_6327_979); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_979 { background-image: var(--gradient-img_6327_979); border:1px solid var(--border-img_6327_979); color:var(--text-img_6327_979); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_980: linear-gradient(180deg, #d4d4d4 0%, #dedede 100%); --border-img_6327_980: #d8d8d8; --text-img_6327_980: #d3d3d3; }
+.btn-img_6327_980 { background-image: var(--gradient-img_6327_980); border:1px solid var(--border-img_6327_980); color:var(--text-img_6327_980); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_980 { background-image: var(--gradient-img_6327_980); border:1px solid var(--border-img_6327_980); color:var(--text-img_6327_980); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_981: linear-gradient(180deg, #d4d4d4 0%, #dedede 100%); --border-img_6327_981: #d8d8d8; --text-img_6327_981: #d3d3d3; }
+.btn-img_6327_981 { background-image: var(--gradient-img_6327_981); border:1px solid var(--border-img_6327_981); color:var(--text-img_6327_981); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_981 { background-image: var(--gradient-img_6327_981); border:1px solid var(--border-img_6327_981); color:var(--text-img_6327_981); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_982: linear-gradient(180deg, #d4d4d4 0%, #dedede 100%); --border-img_6327_982: #d9d9d9; --text-img_6327_982: #d3d3d3; }
+.btn-img_6327_982 { background-image: var(--gradient-img_6327_982); border:1px solid var(--border-img_6327_982); color:var(--text-img_6327_982); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_982 { background-image: var(--gradient-img_6327_982); border:1px solid var(--border-img_6327_982); color:var(--text-img_6327_982); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_983: linear-gradient(180deg, #d0d0d0 0%, #a7a7a7 100%); --border-img_6327_983: #cccccc; --text-img_6327_983: #dddddd; }
+.btn-img_6327_983 { background-image: var(--gradient-img_6327_983); border:1px solid var(--border-img_6327_983); color:var(--text-img_6327_983); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_983 { background-image: var(--gradient-img_6327_983); border:1px solid var(--border-img_6327_983); color:var(--text-img_6327_983); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_984: linear-gradient(180deg, #d0d0d0 0%, #969696 100%); --border-img_6327_984: #c8c8c8; --text-img_6327_984: #dedede; }
+.btn-img_6327_984 { background-image: var(--gradient-img_6327_984); border:1px solid var(--border-img_6327_984); color:var(--text-img_6327_984); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_984 { background-image: var(--gradient-img_6327_984); border:1px solid var(--border-img_6327_984); color:var(--text-img_6327_984); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_985: linear-gradient(180deg, #d0d0d0 0%, #b8b8b8 100%); --border-img_6327_985: #cccccc; --text-img_6327_985: #dedede; }
+.btn-img_6327_985 { background-image: var(--gradient-img_6327_985); border:1px solid var(--border-img_6327_985); color:var(--text-img_6327_985); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_985 { background-image: var(--gradient-img_6327_985); border:1px solid var(--border-img_6327_985); color:var(--text-img_6327_985); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_986: linear-gradient(180deg, #cbcbcb 0%, #dedede 100%); --border-img_6327_986: #d6d6d6; --text-img_6327_986: #dddddd; }
+.btn-img_6327_986 { background-image: var(--gradient-img_6327_986); border:1px solid var(--border-img_6327_986); color:var(--text-img_6327_986); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_986 { background-image: var(--gradient-img_6327_986); border:1px solid var(--border-img_6327_986); color:var(--text-img_6327_986); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_987: linear-gradient(180deg, #cbcbcb 0%, #dfdfdf 100%); --border-img_6327_987: #d4d4d4; --text-img_6327_987: #dedede; }
+.btn-img_6327_987 { background-image: var(--gradient-img_6327_987); border:1px solid var(--border-img_6327_987); color:var(--text-img_6327_987); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_987 { background-image: var(--gradient-img_6327_987); border:1px solid var(--border-img_6327_987); color:var(--text-img_6327_987); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_988: linear-gradient(180deg, #cbcbcb 0%, #dfe0df 100%); --border-img_6327_988: #cfcfcf; --text-img_6327_988: #dfdfdf; }
+.btn-img_6327_988 { background-image: var(--gradient-img_6327_988); border:1px solid var(--border-img_6327_988); color:var(--text-img_6327_988); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_988 { background-image: var(--gradient-img_6327_988); border:1px solid var(--border-img_6327_988); color:var(--text-img_6327_988); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_989: linear-gradient(180deg, #cbcbcb 0%, #e0e0e0 100%); --border-img_6327_989: #d4d4d4; --text-img_6327_989: #dfdfdf; }
+.btn-img_6327_989 { background-image: var(--gradient-img_6327_989); border:1px solid var(--border-img_6327_989); color:var(--text-img_6327_989); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_989 { background-image: var(--gradient-img_6327_989); border:1px solid var(--border-img_6327_989); color:var(--text-img_6327_989); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_990: linear-gradient(180deg, #bdbdbd 0%, #dfdfdf 100%); --border-img_6327_990: #d1d1d1; --text-img_6327_990: #d5d5d5; }
+.btn-img_6327_990 { background-image: var(--gradient-img_6327_990); border:1px solid var(--border-img_6327_990); color:var(--text-img_6327_990); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_990 { background-image: var(--gradient-img_6327_990); border:1px solid var(--border-img_6327_990); color:var(--text-img_6327_990); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_991: linear-gradient(180deg, #b6b6b6 0%, #e0e0e0 100%); --border-img_6327_991: #c4c4c4; --text-img_6327_991: #dddddd; }
+.btn-img_6327_991 { background-image: var(--gradient-img_6327_991); border:1px solid var(--border-img_6327_991); color:var(--text-img_6327_991); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_991 { background-image: var(--gradient-img_6327_991); border:1px solid var(--border-img_6327_991); color:var(--text-img_6327_991); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_992: linear-gradient(180deg, #cacaca 0%, #e0e0e0 100%); --border-img_6327_992: #c6c6c6; --text-img_6327_992: #e0e0e0; }
+.btn-img_6327_992 { background-image: var(--gradient-img_6327_992); border:1px solid var(--border-img_6327_992); color:var(--text-img_6327_992); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_992 { background-image: var(--gradient-img_6327_992); border:1px solid var(--border-img_6327_992); color:var(--text-img_6327_992); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_993: linear-gradient(180deg, #acacac 0%, #e1e1e1 100%); --border-img_6327_993: #c4c4c4; --text-img_6327_993: #e0e0e0; }
+.btn-img_6327_993 { background-image: var(--gradient-img_6327_993); border:1px solid var(--border-img_6327_993); color:var(--text-img_6327_993); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_993 { background-image: var(--gradient-img_6327_993); border:1px solid var(--border-img_6327_993); color:var(--text-img_6327_993); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_994: linear-gradient(180deg, #cfcfcf 0%, #959595 100%); --border-img_6327_994: #c2c2c2; --text-img_6327_994: #e0e0e0; }
+.btn-img_6327_994 { background-image: var(--gradient-img_6327_994); border:1px solid var(--border-img_6327_994); color:var(--text-img_6327_994); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_994 { background-image: var(--gradient-img_6327_994); border:1px solid var(--border-img_6327_994); color:var(--text-img_6327_994); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_995: linear-gradient(180deg, #dfdfdf 0%, #e0e0e0 100%); --border-img_6327_995: #dedede; --text-img_6327_995: #dfdfdf; }
+.btn-img_6327_995 { background-image: var(--gradient-img_6327_995); border:1px solid var(--border-img_6327_995); color:var(--text-img_6327_995); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_995 { background-image: var(--gradient-img_6327_995); border:1px solid var(--border-img_6327_995); color:var(--text-img_6327_995); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_996: linear-gradient(180deg, #e0e0e0 0%, #e2e2e2 100%); --border-img_6327_996: #d9d9d9; --text-img_6327_996: #d3d3d3; }
+.btn-img_6327_996 { background-image: var(--gradient-img_6327_996); border:1px solid var(--border-img_6327_996); color:var(--text-img_6327_996); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_996 { background-image: var(--gradient-img_6327_996); border:1px solid var(--border-img_6327_996); color:var(--text-img_6327_996); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_997: linear-gradient(180deg, #dfdfdf 0%, #676767 100%); --border-img_6327_997: #b8b8b8; --text-img_6327_997: #e0e0e0; }
+.btn-img_6327_997 { background-image: var(--gradient-img_6327_997); border:1px solid var(--border-img_6327_997); color:var(--text-img_6327_997); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_997 { background-image: var(--gradient-img_6327_997); border:1px solid var(--border-img_6327_997); color:var(--text-img_6327_997); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_998: linear-gradient(180deg, #e0e0e0 0%, #4f4f4f 100%); --border-img_6327_998: #9e9e9e; --text-img_6327_998: #e1e1e1; }
+.btn-img_6327_998 { background-image: var(--gradient-img_6327_998); border:1px solid var(--border-img_6327_998); color:var(--text-img_6327_998); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_998 { background-image: var(--gradient-img_6327_998); border:1px solid var(--border-img_6327_998); color:var(--text-img_6327_998); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_999: linear-gradient(180deg, #e0e0e0 0%, #4f4f4f 100%); --border-img_6327_999: #aaaaaa; --text-img_6327_999: #e2e2e2; }
+.btn-img_6327_999 { background-image: var(--gradient-img_6327_999); border:1px solid var(--border-img_6327_999); color:var(--text-img_6327_999); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_999 { background-image: var(--gradient-img_6327_999); border:1px solid var(--border-img_6327_999); color:var(--text-img_6327_999); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1000: linear-gradient(180deg, #e0e1e1 0%, #78be66 100%); --border-img_6327_1000: #bacfb5; --text-img_6327_1000: #d9d9d9; }
+.btn-img_6327_1000 { background-image: var(--gradient-img_6327_1000); border:1px solid var(--border-img_6327_1000); color:var(--text-img_6327_1000); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1000 { background-image: var(--gradient-img_6327_1000); border:1px solid var(--border-img_6327_1000); color:var(--text-img_6327_1000); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1001: linear-gradient(180deg, #e0e0e0 0%, #7e7e7e 100%); --border-img_6327_1001: #c2c2c2; --text-img_6327_1001: #5f5f5f; }
+.btn-img_6327_1001 { background-image: var(--gradient-img_6327_1001); border:1px solid var(--border-img_6327_1001); color:var(--text-img_6327_1001); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1001 { background-image: var(--gradient-img_6327_1001); border:1px solid var(--border-img_6327_1001); color:var(--text-img_6327_1001); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1002: linear-gradient(180deg, #e1e1e1 0%, #4c4c4c 100%); --border-img_6327_1002: #9e9e9e; --text-img_6327_1002: #515151; }
+.btn-img_6327_1002 { background-image: var(--gradient-img_6327_1002); border:1px solid var(--border-img_6327_1002); color:var(--text-img_6327_1002); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1002 { background-image: var(--gradient-img_6327_1002); border:1px solid var(--border-img_6327_1002); color:var(--text-img_6327_1002); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1003: linear-gradient(180deg, #e1e1e1 0%, #4c4c4c 100%); --border-img_6327_1003: #8d8d8d; --text-img_6327_1003: #515151; }
+.btn-img_6327_1003 { background-image: var(--gradient-img_6327_1003); border:1px solid var(--border-img_6327_1003); color:var(--text-img_6327_1003); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1003 { background-image: var(--gradient-img_6327_1003); border:1px solid var(--border-img_6327_1003); color:var(--text-img_6327_1003); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1004: linear-gradient(180deg, #e1e1e1 0%, #6c6c6c 100%); --border-img_6327_1004: #b2b2b2; --text-img_6327_1004: #525252; }
+.btn-img_6327_1004 { background-image: var(--gradient-img_6327_1004); border:1px solid var(--border-img_6327_1004); color:var(--text-img_6327_1004); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1004 { background-image: var(--gradient-img_6327_1004); border:1px solid var(--border-img_6327_1004); color:var(--text-img_6327_1004); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1005: linear-gradient(180deg, #e1e2e2 0%, #9ccd8f 100%); --border-img_6327_1005: #9bbc92; --text-img_6327_1005: #7cc26a; }
+.btn-img_6327_1005 { background-image: var(--gradient-img_6327_1005); border:1px solid var(--border-img_6327_1005); color:var(--text-img_6327_1005); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1005 { background-image: var(--gradient-img_6327_1005); border:1px solid var(--border-img_6327_1005); color:var(--text-img_6327_1005); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1006: linear-gradient(180deg, #525251 0%, #474747 100%); --border-img_6327_1006: #7d7d7d; --text-img_6327_1006: #eeeeee; }
+.btn-img_6327_1006 { background-image: var(--gradient-img_6327_1006); border:1px solid var(--border-img_6327_1006); color:var(--text-img_6327_1006); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1006 { background-image: var(--gradient-img_6327_1006); border:1px solid var(--border-img_6327_1006); color:var(--text-img_6327_1006); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1007: linear-gradient(180deg, #505050 0%, #464646 100%); --border-img_6327_1007: #4b4b4b; --text-img_6327_1007: #4b4b4b; }
+.btn-img_6327_1007 { background-image: var(--gradient-img_6327_1007); border:1px solid var(--border-img_6327_1007); color:var(--text-img_6327_1007); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1007 { background-image: var(--gradient-img_6327_1007); border:1px solid var(--border-img_6327_1007); color:var(--text-img_6327_1007); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1008: linear-gradient(180deg, #95c887 0%, #89ba7e 100%); --border-img_6327_1008: #80a277; --text-img_6327_1008: #74b764; }
+.btn-img_6327_1008 { background-image: var(--gradient-img_6327_1008); border:1px solid var(--border-img_6327_1008); color:var(--text-img_6327_1008); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1008 { background-image: var(--gradient-img_6327_1008); border:1px solid var(--border-img_6327_1008); color:var(--text-img_6327_1008); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1009: linear-gradient(180deg, #bdbdbd 0%, #cccbcb 100%); --border-img_6327_1009: #c6c6c6; --text-img_6327_1009: #464646; }
+.btn-img_6327_1009 { background-image: var(--gradient-img_6327_1009); border:1px solid var(--border-img_6327_1009); color:var(--text-img_6327_1009); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1009 { background-image: var(--gradient-img_6327_1009); border:1px solid var(--border-img_6327_1009); color:var(--text-img_6327_1009); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1010: linear-gradient(180deg, #4a4a4a 0%, #cac9c9 100%); --border-img_6327_1010: #929191; --text-img_6327_1010: #464646; }
+.btn-img_6327_1010 { background-image: var(--gradient-img_6327_1010); border:1px solid var(--border-img_6327_1010); color:var(--text-img_6327_1010); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1010 { background-image: var(--gradient-img_6327_1010); border:1px solid var(--border-img_6327_1010); color:var(--text-img_6327_1010); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1011: linear-gradient(180deg, #4a4a4a 0%, #d4d1d1 100%); --border-img_6327_1011: #929191; --text-img_6327_1011: #464646; }
+.btn-img_6327_1011 { background-image: var(--gradient-img_6327_1011); border:1px solid var(--border-img_6327_1011); color:var(--text-img_6327_1011); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1011 { background-image: var(--gradient-img_6327_1011); border:1px solid var(--border-img_6327_1011); color:var(--text-img_6327_1011); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1012: linear-gradient(180deg, #d7ead2 0%, #d5d2d2 100%); --border-img_6327_1012: #cdd9c9; --text-img_6327_1012: #66a758; }
+.btn-img_6327_1012 { background-image: var(--gradient-img_6327_1012); border:1px solid var(--border-img_6327_1012); color:var(--text-img_6327_1012); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1012 { background-image: var(--gradient-img_6327_1012); border:1px solid var(--border-img_6327_1012); color:var(--text-img_6327_1012); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1013: linear-gradient(180deg, #7c7b7b 0%, #e4e4e4 100%); --border-img_6327_1013: #c0c0c0; --text-img_6327_1013: #525252; }
+.btn-img_6327_1013 { background-image: var(--gradient-img_6327_1013); border:1px solid var(--border-img_6327_1013); color:var(--text-img_6327_1013); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1013 { background-image: var(--gradient-img_6327_1013); border:1px solid var(--border-img_6327_1013); color:var(--text-img_6327_1013); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1014: linear-gradient(180deg, #484848 0%, #e5e5e5 100%); --border-img_6327_1014: #9c9c9c; --text-img_6327_1014: #434343; }
+.btn-img_6327_1014 { background-image: var(--gradient-img_6327_1014); border:1px solid var(--border-img_6327_1014); color:var(--text-img_6327_1014); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1014 { background-image: var(--gradient-img_6327_1014); border:1px solid var(--border-img_6327_1014); color:var(--text-img_6327_1014); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1015: linear-gradient(180deg, #484848 0%, #e5e5e5 100%); --border-img_6327_1015: #8b8b8b; --text-img_6327_1015: #434344; }
+.btn-img_6327_1015 { background-image: var(--gradient-img_6327_1015); border:1px solid var(--border-img_6327_1015); color:var(--text-img_6327_1015); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1015 { background-image: var(--gradient-img_6327_1015); border:1px solid var(--border-img_6327_1015); color:var(--text-img_6327_1015); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1016: linear-gradient(180deg, #6a6a69 0%, #e6e6e6 100%); --border-img_6327_1016: #b2b2b2; --text-img_6327_1016: #444444; }
+.btn-img_6327_1016 { background-image: var(--gradient-img_6327_1016); border:1px solid var(--border-img_6327_1016); color:var(--text-img_6327_1016); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1016 { background-image: var(--gradient-img_6327_1016); border:1px solid var(--border-img_6327_1016); color:var(--text-img_6327_1016); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1017: linear-gradient(180deg, #ffffff 0%, #e6e6e6 100%); --border-img_6327_1017: #bfd6ba; --text-img_6327_1017: #66a758; }
+.btn-img_6327_1017 { background-image: var(--gradient-img_6327_1017); border:1px solid var(--border-img_6327_1017); color:var(--text-img_6327_1017); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1017 { background-image: var(--gradient-img_6327_1017); border:1px solid var(--border-img_6327_1017); color:var(--text-img_6327_1017); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1018: linear-gradient(180deg, #e4e4e4 0%, #c7c7c7 100%); --border-img_6327_1018: #cccccc; --text-img_6327_1018: #c3c2c2; }
+.btn-img_6327_1018 { background-image: var(--gradient-img_6327_1018); border:1px solid var(--border-img_6327_1018); color:var(--text-img_6327_1018); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1018 { background-image: var(--gradient-img_6327_1018); border:1px solid var(--border-img_6327_1018); color:var(--text-img_6327_1018); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1019: linear-gradient(180deg, #e5e5e5 0%, #e4e4e4 100%); --border-img_6327_1019: #c7c7c7; --text-img_6327_1019: #cfcdcd; }
+.btn-img_6327_1019 { background-image: var(--gradient-img_6327_1019); border:1px solid var(--border-img_6327_1019); color:var(--text-img_6327_1019); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1019 { background-image: var(--gradient-img_6327_1019); border:1px solid var(--border-img_6327_1019); color:var(--text-img_6327_1019); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1020: linear-gradient(180deg, #d4dbd2 0%, #e8e8e8 100%); --border-img_6327_1020: #c8d4c4; --text-img_6327_1020: #d8d5d5; }
+.btn-img_6327_1020 { background-image: var(--gradient-img_6327_1020); border:1px solid var(--border-img_6327_1020); color:var(--text-img_6327_1020); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1020 { background-image: var(--gradient-img_6327_1020); border:1px solid var(--border-img_6327_1020); color:var(--text-img_6327_1020); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1021: linear-gradient(180deg, #cdcdcd 0%, #cecdce 100%); --border-img_6327_1021: #d2d2d2; --text-img_6327_1021: #c3c2c2; }
+.btn-img_6327_1021 { background-image: var(--gradient-img_6327_1021); border:1px solid var(--border-img_6327_1021); color:var(--text-img_6327_1021); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1021 { background-image: var(--gradient-img_6327_1021); border:1px solid var(--border-img_6327_1021); color:var(--text-img_6327_1021); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1022: linear-gradient(180deg, #c8c6c7 0%, #efefef 100%); --border-img_6327_1022: #c6c6c6; --text-img_6327_1022: #e8e8e8; }
+.btn-img_6327_1022 { background-image: var(--gradient-img_6327_1022); border:1px solid var(--border-img_6327_1022); color:var(--text-img_6327_1022); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1022 { background-image: var(--gradient-img_6327_1022); border:1px solid var(--border-img_6327_1022); color:var(--text-img_6327_1022); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1023: linear-gradient(180deg, #cfcdcd 0%, #efefee 100%); --border-img_6327_1023: #d7d6d6; --text-img_6327_1023: #e8e8e8; }
+.btn-img_6327_1023 { background-image: var(--gradient-img_6327_1023); border:1px solid var(--border-img_6327_1023); color:var(--text-img_6327_1023); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1023 { background-image: var(--gradient-img_6327_1023); border:1px solid var(--border-img_6327_1023); color:var(--text-img_6327_1023); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1024: linear-gradient(180deg, #d6d4d4 0%, #edeeed 100%); --border-img_6327_1024: #dbdbd9; --text-img_6327_1024: #e8e8e8; }
+.btn-img_6327_1024 { background-image: var(--gradient-img_6327_1024); border:1px solid var(--border-img_6327_1024); color:var(--text-img_6327_1024); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1024 { background-image: var(--gradient-img_6327_1024); border:1px solid var(--border-img_6327_1024); color:var(--text-img_6327_1024); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1025: linear-gradient(180deg, #d3d0d0 0%, #efefef 100%); --border-img_6327_1025: #d8dcd6; --text-img_6327_1025: #e8e8e8; }
+.btn-img_6327_1025 { background-image: var(--gradient-img_6327_1025); border:1px solid var(--border-img_6327_1025); color:var(--text-img_6327_1025); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1025 { background-image: var(--gradient-img_6327_1025); border:1px solid var(--border-img_6327_1025); color:var(--text-img_6327_1025); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1026: linear-gradient(180deg, #c8c8c8 0%, #c7c7c7 100%); --border-img_6327_1026: #d6d6d6; --text-img_6327_1026: #c1c0c0; }
+.btn-img_6327_1026 { background-image: var(--gradient-img_6327_1026); border:1px solid var(--border-img_6327_1026); color:var(--text-img_6327_1026); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1026 { background-image: var(--gradient-img_6327_1026); border:1px solid var(--border-img_6327_1026); color:var(--text-img_6327_1026); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1027: linear-gradient(180deg, #e5e5e6 0%, #717070 100%); --border-img_6327_1027: #d8d8d8; --text-img_6327_1027: #d3d3d3; }
+.btn-img_6327_1027 { background-image: var(--gradient-img_6327_1027); border:1px solid var(--border-img_6327_1027); color:var(--text-img_6327_1027); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1027 { background-image: var(--gradient-img_6327_1027); border:1px solid var(--border-img_6327_1027); color:var(--text-img_6327_1027); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1028: linear-gradient(180deg, #d1d1cf 0%, #dbdad9 100%); --border-img_6327_1028: #dce0db; --text-img_6327_1028: #d3d1d1; }
+.btn-img_6327_1028 { background-image: var(--gradient-img_6327_1028); border:1px solid var(--border-img_6327_1028); color:var(--text-img_6327_1028); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1028 { background-image: var(--gradient-img_6327_1028); border:1px solid var(--border-img_6327_1028); color:var(--text-img_6327_1028); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1029: linear-gradient(180deg, #e5e5e6 0%, #67a658 100%); --border-img_6327_1029: #d9e1d7; --text-img_6327_1029: #ededed; }
+.btn-img_6327_1029 { background-image: var(--gradient-img_6327_1029); border:1px solid var(--border-img_6327_1029); color:var(--text-img_6327_1029); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1029 { background-image: var(--gradient-img_6327_1029); border:1px solid var(--border-img_6327_1029); color:var(--text-img_6327_1029); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1030: linear-gradient(180deg, #c8c7c7 0%, #c9c9c9 100%); --border-img_6327_1030: #d9d9d9; --text-img_6327_1030: #c2c1c1; }
+.btn-img_6327_1030 { background-image: var(--gradient-img_6327_1030); border:1px solid var(--border-img_6327_1030); color:var(--text-img_6327_1030); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1030 { background-image: var(--gradient-img_6327_1030); border:1px solid var(--border-img_6327_1030); color:var(--text-img_6327_1030); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1031: linear-gradient(180deg, #e9e9e9 0%, #f6f6f6 100%); --border-img_6327_1031: #dad9d9; --text-img_6327_1031: #979696; }
+.btn-img_6327_1031 { background-image: var(--gradient-img_6327_1031); border:1px solid var(--border-img_6327_1031); color:var(--text-img_6327_1031); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1031 { background-image: var(--gradient-img_6327_1031); border:1px solid var(--border-img_6327_1031); color:var(--text-img_6327_1031); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1032: linear-gradient(180deg, #ededed 0%, #fbfbfb 100%); --border-img_6327_1032: #f4f4f4; --text-img_6327_1032: #67a658; }
+.btn-img_6327_1032 { background-image: var(--gradient-img_6327_1032); border:1px solid var(--border-img_6327_1032); color:var(--text-img_6327_1032); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1032 { background-image: var(--gradient-img_6327_1032); border:1px solid var(--border-img_6327_1032); color:var(--text-img_6327_1032); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1033: linear-gradient(180deg, #cecdcd 0%, #cdcdcd 100%); --border-img_6327_1033: #d2d2d2; --text-img_6327_1033: #c2c1c1; }
+.btn-img_6327_1033 { background-image: var(--gradient-img_6327_1033); border:1px solid var(--border-img_6327_1033); color:var(--text-img_6327_1033); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1033 { background-image: var(--gradient-img_6327_1033); border:1px solid var(--border-img_6327_1033); color:var(--text-img_6327_1033); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1034: linear-gradient(180deg, #969595 0%, #c5c4c4 100%); --border-img_6327_1034: #bab9b9; --text-img_6327_1034: #fafafa; }
+.btn-img_6327_1034 { background-image: var(--gradient-img_6327_1034); border:1px solid var(--border-img_6327_1034); color:var(--text-img_6327_1034); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1034 { background-image: var(--gradient-img_6327_1034); border:1px solid var(--border-img_6327_1034); color:var(--text-img_6327_1034); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1035: linear-gradient(180deg, #9e9e9e 0%, #cccaca 100%); --border-img_6327_1035: #c3c1c1; --text-img_6327_1035: #fafafa; }
+.btn-img_6327_1035 { background-image: var(--gradient-img_6327_1035); border:1px solid var(--border-img_6327_1035); color:var(--text-img_6327_1035); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1035 { background-image: var(--gradient-img_6327_1035); border:1px solid var(--border-img_6327_1035); color:var(--text-img_6327_1035); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1036: linear-gradient(180deg, #b9d3b3 0%, #d2d0d0 100%); --border-img_6327_1036: #c9d3c5; --text-img_6327_1036: #fafafa; }
+.btn-img_6327_1036 { background-image: var(--gradient-img_6327_1036); border:1px solid var(--border-img_6327_1036); color:var(--text-img_6327_1036); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1036 { background-image: var(--gradient-img_6327_1036); border:1px solid var(--border-img_6327_1036); color:var(--text-img_6327_1036); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1037: linear-gradient(180deg, #6da95e 0%, #d9d6d6 100%); --border-img_6327_1037: #cbd9c6; --text-img_6327_1037: #fafafa; }
+.btn-img_6327_1037 { background-image: var(--gradient-img_6327_1037); border:1px solid var(--border-img_6327_1037); color:var(--text-img_6327_1037); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1037 { background-image: var(--gradient-img_6327_1037); border:1px solid var(--border-img_6327_1037); color:var(--text-img_6327_1037); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1038: linear-gradient(180deg, #c7c7c7 0%, #e9e9e9 100%); --border-img_6327_1038: #d9dbd8; --text-img_6327_1038: #c0c0c0; }
+.btn-img_6327_1038 { background-image: var(--gradient-img_6327_1038); border:1px solid var(--border-img_6327_1038); color:var(--text-img_6327_1038); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1038 { background-image: var(--gradient-img_6327_1038); border:1px solid var(--border-img_6327_1038); color:var(--text-img_6327_1038); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1039: linear-gradient(180deg, #fcfcfc 0%, #ebebeb 100%); --border-img_6327_1039: #e8e8e8; --text-img_6327_1039: #c7c6c6; }
+.btn-img_6327_1039 { background-image: var(--gradient-img_6327_1039); border:1px solid var(--border-img_6327_1039); color:var(--text-img_6327_1039); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1039 { background-image: var(--gradient-img_6327_1039); border:1px solid var(--border-img_6327_1039); color:var(--text-img_6327_1039); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1040: linear-gradient(180deg, #dddcdb 0%, #ececec 100%); --border-img_6327_1040: #e5e4e4; --text-img_6327_1040: #cfcdcd; }
+.btn-img_6327_1040 { background-image: var(--gradient-img_6327_1040); border:1px solid var(--border-img_6327_1040); color:var(--text-img_6327_1040); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1040 { background-image: var(--gradient-img_6327_1040); border:1px solid var(--border-img_6327_1040); color:var(--text-img_6327_1040); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1041: linear-gradient(180deg, #fcfcfc 0%, #ececec 100%); --border-img_6327_1041: #eaeaea; --text-img_6327_1041: #d6d4d4; }
+.btn-img_6327_1041 { background-image: var(--gradient-img_6327_1041); border:1px solid var(--border-img_6327_1041); color:var(--text-img_6327_1041); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1041 { background-image: var(--gradient-img_6327_1041); border:1px solid var(--border-img_6327_1041); color:var(--text-img_6327_1041); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1042: linear-gradient(180deg, #c1c0c0 0%, #7cc269 100%); --border-img_6327_1042: #c5d4c0; --text-img_6327_1042: #e9e9e9; }
+.btn-img_6327_1042 { background-image: var(--gradient-img_6327_1042); border:1px solid var(--border-img_6327_1042); color:var(--text-img_6327_1042); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1042 { background-image: var(--gradient-img_6327_1042); border:1px solid var(--border-img_6327_1042); color:var(--text-img_6327_1042); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1043: linear-gradient(180deg, #cccaca 0%, #e9e9e9 100%); --border-img_6327_1043: #dcdcdc; --text-img_6327_1043: #ebebeb; }
+.btn-img_6327_1043 { background-image: var(--gradient-img_6327_1043); border:1px solid var(--border-img_6327_1043); color:var(--text-img_6327_1043); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1043 { background-image: var(--gradient-img_6327_1043); border:1px solid var(--border-img_6327_1043); color:var(--text-img_6327_1043); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1044: linear-gradient(180deg, #d6d4d4 0%, #e9e9e9 100%); --border-img_6327_1044: #e1e0e0; --text-img_6327_1044: #ececec; }
+.btn-img_6327_1044 { background-image: var(--gradient-img_6327_1044); border:1px solid var(--border-img_6327_1044); color:var(--text-img_6327_1044); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1044 { background-image: var(--gradient-img_6327_1044); border:1px solid var(--border-img_6327_1044); color:var(--text-img_6327_1044); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1045: linear-gradient(180deg, #d4d4d4 0%, #94c788 100%); --border-img_6327_1045: #c5d6c1; --text-img_6327_1045: #e9e9e9; }
+.btn-img_6327_1045 { background-image: var(--gradient-img_6327_1045); border:1px solid var(--border-img_6327_1045); color:var(--text-img_6327_1045); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1045 { background-image: var(--gradient-img_6327_1045); border:1px solid var(--border-img_6327_1045); color:var(--text-img_6327_1045); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1046: linear-gradient(180deg, #c4c3c3 0%, #b5d4ad 100%); --border-img_6327_1046: #c7d5c3; --text-img_6327_1046: #eaeaea; }
+.btn-img_6327_1046 { background-image: var(--gradient-img_6327_1046); border:1px solid var(--border-img_6327_1046); color:var(--text-img_6327_1046); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1046 { background-image: var(--gradient-img_6327_1046); border:1px solid var(--border-img_6327_1046); color:var(--text-img_6327_1046); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1047: linear-gradient(180deg, #cbc9c9 0%, #e8e8e8 100%); --border-img_6327_1047: #e0e0e0; --text-img_6327_1047: #ebebeb; }
+.btn-img_6327_1047 { background-image: var(--gradient-img_6327_1047); border:1px solid var(--border-img_6327_1047); color:var(--text-img_6327_1047); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1047 { background-image: var(--gradient-img_6327_1047); border:1px solid var(--border-img_6327_1047); color:var(--text-img_6327_1047); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1048: linear-gradient(180deg, #d1cfcf 0%, #e8e8e8 100%); --border-img_6327_1048: #e2e2e2; --text-img_6327_1048: #ececec; }
+.btn-img_6327_1048 { background-image: var(--gradient-img_6327_1048); border:1px solid var(--border-img_6327_1048); color:var(--text-img_6327_1048); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1048 { background-image: var(--gradient-img_6327_1048); border:1px solid var(--border-img_6327_1048); color:var(--text-img_6327_1048); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1049: linear-gradient(180deg, #d7d5d5 0%, #e8e8e8 100%); --border-img_6327_1049: #e4e3e3; --text-img_6327_1049: #ececec; }
+.btn-img_6327_1049 { background-image: var(--gradient-img_6327_1049); border:1px solid var(--border-img_6327_1049); color:var(--text-img_6327_1049); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1049 { background-image: var(--gradient-img_6327_1049); border:1px solid var(--border-img_6327_1049); color:var(--text-img_6327_1049); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1050: linear-gradient(180deg, #82bf73 0%, #343739 100%); --border-img_6327_1050: #92a78e; --text-img_6327_1050: #69aa5a; }
+.btn-img_6327_1050 { background-image: var(--gradient-img_6327_1050); border:1px solid var(--border-img_6327_1050); color:var(--text-img_6327_1050); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1050 { background-image: var(--gradient-img_6327_1050); border:1px solid var(--border-img_6327_1050); color:var(--text-img_6327_1050); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1051: linear-gradient(180deg, #e9e9e9 0%, #343739 100%); --border-img_6327_1051: #9baa99; --text-img_6327_1051: #ebebeb; }
+.btn-img_6327_1051 { background-image: var(--gradient-img_6327_1051); border:1px solid var(--border-img_6327_1051); color:var(--text-img_6327_1051); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1051 { background-image: var(--gradient-img_6327_1051); border:1px solid var(--border-img_6327_1051); color:var(--text-img_6327_1051); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1052: linear-gradient(180deg, #e8e8e8 0%, #343739 100%); --border-img_6327_1052: #b0b1b1; --text-img_6327_1052: #e6e5e5; }
+.btn-img_6327_1052 { background-image: var(--gradient-img_6327_1052); border:1px solid var(--border-img_6327_1052); color:var(--text-img_6327_1052); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1052 { background-image: var(--gradient-img_6327_1052); border:1px solid var(--border-img_6327_1052); color:var(--text-img_6327_1052); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1053: linear-gradient(180deg, #e8e8e8 0%, #343739 100%); --border-img_6327_1053: #abadac; --text-img_6327_1053: #e6e5e5; }
+.btn-img_6327_1053 { background-image: var(--gradient-img_6327_1053); border:1px solid var(--border-img_6327_1053); color:var(--text-img_6327_1053); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1053 { background-image: var(--gradient-img_6327_1053); border:1px solid var(--border-img_6327_1053); color:var(--text-img_6327_1053); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1054: linear-gradient(180deg, #bfdeb8 0%, #343739 100%); --border-img_6327_1054: #98a597; --text-img_6327_1054: #66a758; }
+.btn-img_6327_1054 { background-image: var(--gradient-img_6327_1054); border:1px solid var(--border-img_6327_1054); color:var(--text-img_6327_1054); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1054 { background-image: var(--gradient-img_6327_1054); border:1px solid var(--border-img_6327_1054); color:var(--text-img_6327_1054); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1055: linear-gradient(180deg, #9c9b9b 0%, #3c4042 100%); --border-img_6327_1055: #aaabac; --text-img_6327_1055: #e6e5e5; }
+.btn-img_6327_1055 { background-image: var(--gradient-img_6327_1055); border:1px solid var(--border-img_6327_1055); color:var(--text-img_6327_1055); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1055 { background-image: var(--gradient-img_6327_1055); border:1px solid var(--border-img_6327_1055); color:var(--text-img_6327_1055); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1056: linear-gradient(180deg, #7e7e7e 0%, #343739 100%); --border-img_6327_1056: #aaaaab; --text-img_6327_1056: #e6e5e5; }
+.btn-img_6327_1056 { background-image: var(--gradient-img_6327_1056); border:1px solid var(--border-img_6327_1056); color:var(--text-img_6327_1056); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1056 { background-image: var(--gradient-img_6327_1056); border:1px solid var(--border-img_6327_1056); color:var(--text-img_6327_1056); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1057: linear-gradient(180deg, #c3dcbe 0%, #343739 100%); --border-img_6327_1057: #9da89c; --text-img_6327_1057: #84b378; }
+.btn-img_6327_1057 { background-image: var(--gradient-img_6327_1057); border:1px solid var(--border-img_6327_1057); color:var(--text-img_6327_1057); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1057 { background-image: var(--gradient-img_6327_1057); border:1px solid var(--border-img_6327_1057); color:var(--text-img_6327_1057); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1058: linear-gradient(180deg, #c6dbc1 0%, #343739 100%); --border-img_6327_1058: #9ea99d; --text-img_6327_1058: #d4dfd2; }
+.btn-img_6327_1058 { background-image: var(--gradient-img_6327_1058); border:1px solid var(--border-img_6327_1058); color:var(--text-img_6327_1058); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1058 { background-image: var(--gradient-img_6327_1058); border:1px solid var(--border-img_6327_1058); color:var(--text-img_6327_1058); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1059: linear-gradient(180deg, #aaaaaa 0%, #494d50 100%); --border-img_6327_1059: #a5a6a7; --text-img_6327_1059: #e5e4e4; }
+.btn-img_6327_1059 { background-image: var(--gradient-img_6327_1059); border:1px solid var(--border-img_6327_1059); color:var(--text-img_6327_1059); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1059 { background-image: var(--gradient-img_6327_1059); border:1px solid var(--border-img_6327_1059); color:var(--text-img_6327_1059); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1060: linear-gradient(180deg, #898888 0%, #343739 100%); --border-img_6327_1060: #9c9f9d; --text-img_6327_1060: #e5e4e4; }
+.btn-img_6327_1060 { background-image: var(--gradient-img_6327_1060); border:1px solid var(--border-img_6327_1060); color:var(--text-img_6327_1060); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1060 { background-image: var(--gradient-img_6327_1060); border:1px solid var(--border-img_6327_1060); color:var(--text-img_6327_1060); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6327_1061: linear-gradient(180deg, #868686 0%, #343739 100%); --border-img_6327_1061: #8d908d; --text-img_6327_1061: #e5e4e4; }
+.btn-img_6327_1061 { background-image: var(--gradient-img_6327_1061); border:1px solid var(--border-img_6327_1061); color:var(--text-img_6327_1061); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6327_1061 { background-image: var(--gradient-img_6327_1061); border:1px solid var(--border-img_6327_1061); color:var(--text-img_6327_1061); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1062: linear-gradient(180deg, #5e6367 0%, #323232 100%); --border-img_6328_1062: #6b6e6f; --text-img_6328_1062: #45494c; }
+.btn-img_6328_1062 { background-image: var(--gradient-img_6328_1062); border:1px solid var(--border-img_6328_1062); color:var(--text-img_6328_1062); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1062 { background-image: var(--gradient-img_6328_1062); border:1px solid var(--border-img_6328_1062); color:var(--text-img_6328_1062); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1063: linear-gradient(180deg, #5e6367 0%, #b8ccb1 100%); --border-img_6328_1063: #7c8b7d; --text-img_6328_1063: #45494c; }
+.btn-img_6328_1063 { background-image: var(--gradient-img_6328_1063); border:1px solid var(--border-img_6328_1063); color:var(--text-img_6328_1063); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1063 { background-image: var(--gradient-img_6328_1063); border:1px solid var(--border-img_6328_1063); color:var(--text-img_6328_1063); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1064: linear-gradient(180deg, #5e6367 0%, #67a658 100%); --border-img_6328_1064: #5f7d5d; --text-img_6328_1064: #45494c; }
+.btn-img_6328_1064 { background-image: var(--gradient-img_6328_1064); border:1px solid var(--border-img_6328_1064); color:var(--text-img_6328_1064); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1064 { background-image: var(--gradient-img_6328_1064); border:1px solid var(--border-img_6328_1064); color:var(--text-img_6328_1064); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1065: linear-gradient(180deg, #5e6367 0%, #67a658 100%); --border-img_6328_1065: #6e826d; --text-img_6328_1065: #45494c; }
+.btn-img_6328_1065 { background-image: var(--gradient-img_6328_1065); border:1px solid var(--border-img_6328_1065); color:var(--text-img_6328_1065); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1065 { background-image: var(--gradient-img_6328_1065); border:1px solid var(--border-img_6328_1065); color:var(--text-img_6328_1065); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1066: linear-gradient(180deg, #5e6367 0%, #e8e7e7 100%); --border-img_6328_1066: #959799; --text-img_6328_1066: #45494c; }
+.btn-img_6328_1066 { background-image: var(--gradient-img_6328_1066); border:1px solid var(--border-img_6328_1066); color:var(--text-img_6328_1066); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1066 { background-image: var(--gradient-img_6328_1066); border:1px solid var(--border-img_6328_1066); color:var(--text-img_6328_1066); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1067: linear-gradient(180deg, #5e6367 0%, #808080 100%); --border-img_6328_1067: #949697; --text-img_6328_1067: #47494b; }
+.btn-img_6328_1067 { background-image: var(--gradient-img_6328_1067); border:1px solid var(--border-img_6328_1067); color:var(--text-img_6328_1067); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1067 { background-image: var(--gradient-img_6328_1067); border:1px solid var(--border-img_6328_1067); color:var(--text-img_6328_1067); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1068: linear-gradient(180deg, #5e6367 0%, #67a658 100%); --border-img_6328_1068: #658462; --text-img_6328_1068: #485e46; }
+.btn-img_6328_1068 { background-image: var(--gradient-img_6328_1068); border:1px solid var(--border-img_6328_1068); color:var(--text-img_6328_1068); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1068 { background-image: var(--gradient-img_6328_1068); border:1px solid var(--border-img_6328_1068); color:var(--text-img_6328_1068); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1069: linear-gradient(180deg, #5e6367 0%, #d7dcd5 100%); --border-img_6328_1069: #8d988f; --text-img_6328_1069: #707173; }
+.btn-img_6328_1069 { background-image: var(--gradient-img_6328_1069); border:1px solid var(--border-img_6328_1069); color:var(--text-img_6328_1069); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1069 { background-image: var(--gradient-img_6328_1069); border:1px solid var(--border-img_6328_1069); color:var(--text-img_6328_1069); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1070: linear-gradient(180deg, #5e6367 0%, #ededed 100%); --border-img_6328_1070: #a0a7a3; --text-img_6328_1070: #4d6349; }
+.btn-img_6328_1070 { background-image: var(--gradient-img_6328_1070); border:1px solid var(--border-img_6328_1070); color:var(--text-img_6328_1070); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1070 { background-image: var(--gradient-img_6328_1070); border:1px solid var(--border-img_6328_1070); color:var(--text-img_6328_1070); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1071: linear-gradient(180deg, #5e6367 0%, #6ca85e 100%); --border-img_6328_1071: #7c927b; --text-img_6328_1071: #769470; }
+.btn-img_6328_1071 { background-image: var(--gradient-img_6328_1071); border:1px solid var(--border-img_6328_1071); color:var(--text-img_6328_1071); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1071 { background-image: var(--gradient-img_6328_1071); border:1px solid var(--border-img_6328_1071); color:var(--text-img_6328_1071); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1072: linear-gradient(180deg, #5e6367 0%, #67a658 100%); --border-img_6328_1072: #688964; --text-img_6328_1072: #688d60; }
+.btn-img_6328_1072 { background-image: var(--gradient-img_6328_1072); border:1px solid var(--border-img_6328_1072); color:var(--text-img_6328_1072); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1072 { background-image: var(--gradient-img_6328_1072); border:1px solid var(--border-img_6328_1072); color:var(--text-img_6328_1072); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1073: linear-gradient(180deg, #5e6367 0%, #e4e3e3 100%); --border-img_6328_1073: #a5a6a8; --text-img_6328_1073: #b0b0b1; }
+.btn-img_6328_1073 { background-image: var(--gradient-img_6328_1073); border:1px solid var(--border-img_6328_1073); color:var(--text-img_6328_1073); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1073 { background-image: var(--gradient-img_6328_1073); border:1px solid var(--border-img_6328_1073); color:var(--text-img_6328_1073); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1074: linear-gradient(180deg, #eaecea 0%, #ededed 100%); --border-img_6328_1074: #dfe7dd; --text-img_6328_1074: #54624f; }
+.btn-img_6328_1074 { background-image: var(--gradient-img_6328_1074); border:1px solid var(--border-img_6328_1074); color:var(--text-img_6328_1074); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1074 { background-image: var(--gradient-img_6328_1074); border:1px solid var(--border-img_6328_1074); color:var(--text-img_6328_1074); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1075: linear-gradient(180deg, #c4d0be 0%, #f1f1f1 100%); --border-img_6328_1075: #d7dfd5; --text-img_6328_1075: #cfcccc; }
+.btn-img_6328_1075 { background-image: var(--gradient-img_6328_1075); border:1px solid var(--border-img_6328_1075); color:var(--text-img_6328_1075); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1075 { background-image: var(--gradient-img_6328_1075); border:1px solid var(--border-img_6328_1075); color:var(--text-img_6328_1075); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1076: linear-gradient(180deg, #67a658 0%, #f4f4f4 100%); --border-img_6328_1076: #bdd0b7; --text-img_6328_1076: #cac8c8; }
+.btn-img_6328_1076 { background-image: var(--gradient-img_6328_1076); border:1px solid var(--border-img_6328_1076); color:var(--text-img_6328_1076); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1076 { background-image: var(--gradient-img_6328_1076); border:1px solid var(--border-img_6328_1076); color:var(--text-img_6328_1076); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1077: linear-gradient(180deg, #6da95f 0%, #f1f1f1 100%); --border-img_6328_1077: #c7d5c2; --text-img_6328_1077: #dcd9d9; }
+.btn-img_6328_1077 { background-image: var(--gradient-img_6328_1077); border:1px solid var(--border-img_6328_1077); color:var(--text-img_6328_1077); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1077 { background-image: var(--gradient-img_6328_1077); border:1px solid var(--border-img_6328_1077); color:var(--text-img_6328_1077); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1078: linear-gradient(180deg, #e7e7e7 0%, #eeeeee 100%); --border-img_6328_1078: #e8e8e8; --text-img_6328_1078: #ebebeb; }
+.btn-img_6328_1078 { background-image: var(--gradient-img_6328_1078); border:1px solid var(--border-img_6328_1078); color:var(--text-img_6328_1078); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1078 { background-image: var(--gradient-img_6328_1078); border:1px solid var(--border-img_6328_1078); color:var(--text-img_6328_1078); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1079: linear-gradient(180deg, #c1e6ba 0%, #efeeef 100%); --border-img_6328_1079: #e1e9df; --text-img_6328_1079: #b9dbb1; }
+.btn-img_6328_1079 { background-image: var(--gradient-img_6328_1079); border:1px solid var(--border-img_6328_1079); color:var(--text-img_6328_1079); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1079 { background-image: var(--gradient-img_6328_1079); border:1px solid var(--border-img_6328_1079); color:var(--text-img_6328_1079); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1080: linear-gradient(180deg, #dddbdb 0%, #f3f3f3 100%); --border-img_6328_1080: #e5e5e4; --text-img_6328_1080: #e1dfdf; }
+.btn-img_6328_1080 { background-image: var(--gradient-img_6328_1080); border:1px solid var(--border-img_6328_1080); color:var(--text-img_6328_1080); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1080 { background-image: var(--gradient-img_6328_1080); border:1px solid var(--border-img_6328_1080); color:var(--text-img_6328_1080); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1081: linear-gradient(180deg, #e0dede 0%, #efefef 100%); --border-img_6328_1081: #e9e8e8; --text-img_6328_1081: #dfdddd; }
+.btn-img_6328_1081 { background-image: var(--gradient-img_6328_1081); border:1px solid var(--border-img_6328_1081); color:var(--text-img_6328_1081); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1081 { background-image: var(--gradient-img_6328_1081); border:1px solid var(--border-img_6328_1081); color:var(--text-img_6328_1081); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1082: linear-gradient(180deg, #5c6b57 0%, #ededed 100%); --border-img_6328_1082: #dee4dc; --text-img_6328_1082: #eeeeee; }
+.btn-img_6328_1082 { background-image: var(--gradient-img_6328_1082); border:1px solid var(--border-img_6328_1082); color:var(--text-img_6328_1082); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1082 { background-image: var(--gradient-img_6328_1082); border:1px solid var(--border-img_6328_1082); color:var(--text-img_6328_1082); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1083: linear-gradient(180deg, #bcbaba 0%, #f1f1f1 100%); --border-img_6328_1083: #e3e3e3; --text-img_6328_1083: #f2f2f2; }
+.btn-img_6328_1083 { background-image: var(--gradient-img_6328_1083); border:1px solid var(--border-img_6328_1083); color:var(--text-img_6328_1083); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1083 { background-image: var(--gradient-img_6328_1083); border:1px solid var(--border-img_6328_1083); color:var(--text-img_6328_1083); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1084: linear-gradient(180deg, #bfbdbd 0%, #f1f2f2 100%); --border-img_6328_1084: #e5e4e4; --text-img_6328_1084: #f3f3f3; }
+.btn-img_6328_1084 { background-image: var(--gradient-img_6328_1084); border:1px solid var(--border-img_6328_1084); color:var(--text-img_6328_1084); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1084 { background-image: var(--gradient-img_6328_1084); border:1px solid var(--border-img_6328_1084); color:var(--text-img_6328_1084); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1085: linear-gradient(180deg, #e3e1e1 0%, #eeeeee 100%); --border-img_6328_1085: #eae9e9; --text-img_6328_1085: #eeeeee; }
+.btn-img_6328_1085 { background-image: var(--gradient-img_6328_1085); border:1px solid var(--border-img_6328_1085); color:var(--text-img_6328_1085); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1085 { background-image: var(--gradient-img_6328_1085); border:1px solid var(--border-img_6328_1085); color:var(--text-img_6328_1085); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1086: linear-gradient(180deg, #ededed 0%, #f7f7f7 100%); --border-img_6328_1086: #efefef; --text-img_6328_1086: #ededed; }
+.btn-img_6328_1086 { background-image: var(--gradient-img_6328_1086); border:1px solid var(--border-img_6328_1086); color:var(--text-img_6328_1086); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1086 { background-image: var(--gradient-img_6328_1086); border:1px solid var(--border-img_6328_1086); color:var(--text-img_6328_1086); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1087: linear-gradient(180deg, #f1f1f1 0%, #f7f7f7 100%); --border-img_6328_1087: #eaeaea; --text-img_6328_1087: #f0f0f0; }
+.btn-img_6328_1087 { background-image: var(--gradient-img_6328_1087); border:1px solid var(--border-img_6328_1087); color:var(--text-img_6328_1087); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1087 { background-image: var(--gradient-img_6328_1087); border:1px solid var(--border-img_6328_1087); color:var(--text-img_6328_1087); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1088: linear-gradient(180deg, #f3f3f3 0%, #f6f6f5 100%); --border-img_6328_1088: #f4f4f4; --text-img_6328_1088: #f2f2f2; }
+.btn-img_6328_1088 { background-image: var(--gradient-img_6328_1088); border:1px solid var(--border-img_6328_1088); color:var(--text-img_6328_1088); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1088 { background-image: var(--gradient-img_6328_1088); border:1px solid var(--border-img_6328_1088); color:var(--text-img_6328_1088); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1089: linear-gradient(180deg, #f1f1f1 0%, #fcfcfc 100%); --border-img_6328_1089: #f5f5f5; --text-img_6328_1089: #f0f0f0; }
+.btn-img_6328_1089 { background-image: var(--gradient-img_6328_1089); border:1px solid var(--border-img_6328_1089); color:var(--text-img_6328_1089); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1089 { background-image: var(--gradient-img_6328_1089); border:1px solid var(--border-img_6328_1089); color:var(--text-img_6328_1089); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1090: linear-gradient(180deg, #eeeeee 0%, #fcfcfc 100%); --border-img_6328_1090: #f2f3f2; --text-img_6328_1090: #ededed; }
+.btn-img_6328_1090 { background-image: var(--gradient-img_6328_1090); border:1px solid var(--border-img_6328_1090); color:var(--text-img_6328_1090); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1090 { background-image: var(--gradient-img_6328_1090); border:1px solid var(--border-img_6328_1090); color:var(--text-img_6328_1090); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1091: linear-gradient(180deg, #eeeeee 0%, #f7f7f7 100%); --border-img_6328_1091: #f1f1f1; --text-img_6328_1091: #f7f7f7; }
+.btn-img_6328_1091 { background-image: var(--gradient-img_6328_1091); border:1px solid var(--border-img_6328_1091); color:var(--text-img_6328_1091); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1091 { background-image: var(--gradient-img_6328_1091); border:1px solid var(--border-img_6328_1091); color:var(--text-img_6328_1091); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1092: linear-gradient(180deg, #f2f2f2 0%, #f3f3f3 100%); --border-img_6328_1092: #f1f2f0; --text-img_6328_1092: #f5f7f5; }
+.btn-img_6328_1092 { background-image: var(--gradient-img_6328_1092); border:1px solid var(--border-img_6328_1092); color:var(--text-img_6328_1092); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1092 { background-image: var(--gradient-img_6328_1092); border:1px solid var(--border-img_6328_1092); color:var(--text-img_6328_1092); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1093: linear-gradient(180deg, #eeeeee 0%, #f7f7f7 100%); --border-img_6328_1093: #f4f4f4; --text-img_6328_1093: #fdfdfd; }
+.btn-img_6328_1093 { background-image: var(--gradient-img_6328_1093); border:1px solid var(--border-img_6328_1093); color:var(--text-img_6328_1093); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1093 { background-image: var(--gradient-img_6328_1093); border:1px solid var(--border-img_6328_1093); color:var(--text-img_6328_1093); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1094: linear-gradient(180deg, #f7f7f7 0%, #f7f7f7 100%); --border-img_6328_1094: #e8e8e8; --text-img_6328_1094: #f7f7f7; }
+.btn-img_6328_1094 { background-image: var(--gradient-img_6328_1094); border:1px solid var(--border-img_6328_1094); color:var(--text-img_6328_1094); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1094 { background-image: var(--gradient-img_6328_1094); border:1px solid var(--border-img_6328_1094); color:var(--text-img_6328_1094); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1095: linear-gradient(180deg, #f7f7f7 0%, #f7f7f7 100%); --border-img_6328_1095: #ececec; --text-img_6328_1095: #f7f7f7; }
+.btn-img_6328_1095 { background-image: var(--gradient-img_6328_1095); border:1px solid var(--border-img_6328_1095); color:var(--text-img_6328_1095); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1095 { background-image: var(--gradient-img_6328_1095); border:1px solid var(--border-img_6328_1095); color:var(--text-img_6328_1095); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1096: linear-gradient(180deg, #fefefe 0%, #f1f1f1 100%); --border-img_6328_1096: #f3f5f3; --text-img_6328_1096: #eff3ee; }
+.btn-img_6328_1096 { background-image: var(--gradient-img_6328_1096); border:1px solid var(--border-img_6328_1096); color:var(--text-img_6328_1096); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1096 { background-image: var(--gradient-img_6328_1096); border:1px solid var(--border-img_6328_1096); color:var(--text-img_6328_1096); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1097: linear-gradient(180deg, #fefefe 0%, #f1f1f1 100%); --border-img_6328_1097: #f3f5f2; --text-img_6328_1097: #f7f7f7; }
+.btn-img_6328_1097 { background-image: var(--gradient-img_6328_1097); border:1px solid var(--border-img_6328_1097); color:var(--text-img_6328_1097); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1097 { background-image: var(--gradient-img_6328_1097); border:1px solid var(--border-img_6328_1097); color:var(--text-img_6328_1097); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1098: linear-gradient(180deg, #f7f7f7 0%, #d4d3d3 100%); --border-img_6328_1098: #ededed; --text-img_6328_1098: #f5f5f5; }
+.btn-img_6328_1098 { background-image: var(--gradient-img_6328_1098); border:1px solid var(--border-img_6328_1098); color:var(--text-img_6328_1098); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1098 { background-image: var(--gradient-img_6328_1098); border:1px solid var(--border-img_6328_1098); color:var(--text-img_6328_1098); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1099: linear-gradient(180deg, #f3f4f3 0%, #ecedec 100%); --border-img_6328_1099: #e9eee8; --text-img_6328_1099: #eef0ed; }
+.btn-img_6328_1099 { background-image: var(--gradient-img_6328_1099); border:1px solid var(--border-img_6328_1099); color:var(--text-img_6328_1099); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1099 { background-image: var(--gradient-img_6328_1099); border:1px solid var(--border-img_6328_1099); color:var(--text-img_6328_1099); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1100: linear-gradient(180deg, #f8f8f8 0%, #eeeeee 100%); --border-img_6328_1100: #edefec; --text-img_6328_1100: #f3f3f3; }
+.btn-img_6328_1100 { background-image: var(--gradient-img_6328_1100); border:1px solid var(--border-img_6328_1100); color:var(--text-img_6328_1100); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1100 { background-image: var(--gradient-img_6328_1100); border:1px solid var(--border-img_6328_1100); color:var(--text-img_6328_1100); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1101: linear-gradient(180deg, #f8f8f8 0%, #eeeeee 100%); --border-img_6328_1101: #f3f3f3; --text-img_6328_1101: #f3f3f3; }
+.btn-img_6328_1101 { background-image: var(--gradient-img_6328_1101); border:1px solid var(--border-img_6328_1101); color:var(--text-img_6328_1101); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1101 { background-image: var(--gradient-img_6328_1101); border:1px solid var(--border-img_6328_1101); color:var(--text-img_6328_1101); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1102: linear-gradient(180deg, #f7f7f7 0%, #f7f7f7 100%); --border-img_6328_1102: #f3f3f3; --text-img_6328_1102: #ebeaea; }
+.btn-img_6328_1102 { background-image: var(--gradient-img_6328_1102); border:1px solid var(--border-img_6328_1102); color:var(--text-img_6328_1102); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1102 { background-image: var(--gradient-img_6328_1102); border:1px solid var(--border-img_6328_1102); color:var(--text-img_6328_1102); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1103: linear-gradient(180deg, #f0f0f0 0%, #e9e9e9 100%); --border-img_6328_1103: #f0f0f0; --text-img_6328_1103: #eaecea; }
+.btn-img_6328_1103 { background-image: var(--gradient-img_6328_1103); border:1px solid var(--border-img_6328_1103); color:var(--text-img_6328_1103); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1103 { background-image: var(--gradient-img_6328_1103); border:1px solid var(--border-img_6328_1103); color:var(--text-img_6328_1103); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1104: linear-gradient(180deg, #f3f3f3 0%, #e7e7e7 100%); --border-img_6328_1104: #ededed; --text-img_6328_1104: #ededed; }
+.btn-img_6328_1104 { background-image: var(--gradient-img_6328_1104); border:1px solid var(--border-img_6328_1104); color:var(--text-img_6328_1104); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1104 { background-image: var(--gradient-img_6328_1104); border:1px solid var(--border-img_6328_1104); color:var(--text-img_6328_1104); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1105: linear-gradient(180deg, #f7f7f7 0%, #abe79f 100%); --border-img_6328_1105: #d1decf; --text-img_6328_1105: #efefef; }
+.btn-img_6328_1105 { background-image: var(--gradient-img_6328_1105); border:1px solid var(--border-img_6328_1105); color:var(--text-img_6328_1105); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1105 { background-image: var(--gradient-img_6328_1105); border:1px solid var(--border-img_6328_1105); color:var(--text-img_6328_1105); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1106: linear-gradient(180deg, #f7f7f7 0%, #abe79f 100%); --border-img_6328_1106: #d8e6d5; --text-img_6328_1106: #efefef; }
+.btn-img_6328_1106 { background-image: var(--gradient-img_6328_1106); border:1px solid var(--border-img_6328_1106); color:var(--text-img_6328_1106); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1106 { background-image: var(--gradient-img_6328_1106); border:1px solid var(--border-img_6328_1106); color:var(--text-img_6328_1106); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1107: linear-gradient(180deg, #ebebeb 0%, #7a7a7a 100%); --border-img_6328_1107: #bebebe; --text-img_6328_1107: #e5e6e4; }
+.btn-img_6328_1107 { background-image: var(--gradient-img_6328_1107); border:1px solid var(--border-img_6328_1107); color:var(--text-img_6328_1107); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1107 { background-image: var(--gradient-img_6328_1107); border:1px solid var(--border-img_6328_1107); color:var(--text-img_6328_1107); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1108: linear-gradient(180deg, #ebebeb 0%, #7a7a7a 100%); --border-img_6328_1108: #bebebe; --text-img_6328_1108: #e4e6e4; }
+.btn-img_6328_1108 { background-image: var(--gradient-img_6328_1108); border:1px solid var(--border-img_6328_1108); color:var(--text-img_6328_1108); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1108 { background-image: var(--gradient-img_6328_1108); border:1px solid var(--border-img_6328_1108); color:var(--text-img_6328_1108); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1109: linear-gradient(180deg, #f7f7f7 0%, #aee9a1 100%); --border-img_6328_1109: #dcecd9; --text-img_6328_1109: #efefef; }
+.btn-img_6328_1109 { background-image: var(--gradient-img_6328_1109); border:1px solid var(--border-img_6328_1109); color:var(--text-img_6328_1109); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1109 { background-image: var(--gradient-img_6328_1109); border:1px solid var(--border-img_6328_1109); color:var(--text-img_6328_1109); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1110: linear-gradient(180deg, #f7f7f7 0%, #aee9a1 100%); --border-img_6328_1110: #d5e8d1; --text-img_6328_1110: #efefef; }
+.btn-img_6328_1110 { background-image: var(--gradient-img_6328_1110); border:1px solid var(--border-img_6328_1110); color:var(--text-img_6328_1110); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1110 { background-image: var(--gradient-img_6328_1110); border:1px solid var(--border-img_6328_1110); color:var(--text-img_6328_1110); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1111: linear-gradient(180deg, #e9eae9 0%, #a6a6a6 100%); --border-img_6328_1111: #cfd5ce; --text-img_6328_1111: #e4e7e4; }
+.btn-img_6328_1111 { background-image: var(--gradient-img_6328_1111); border:1px solid var(--border-img_6328_1111); color:var(--text-img_6328_1111); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1111 { background-image: var(--gradient-img_6328_1111); border:1px solid var(--border-img_6328_1111); color:var(--text-img_6328_1111); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1112: linear-gradient(180deg, #eaeaea 0%, #7c7c7c 100%); --border-img_6328_1112: #c1c1c1; --text-img_6328_1112: #e4e6e3; }
+.btn-img_6328_1112 { background-image: var(--gradient-img_6328_1112); border:1px solid var(--border-img_6328_1112); color:var(--text-img_6328_1112); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1112 { background-image: var(--gradient-img_6328_1112); border:1px solid var(--border-img_6328_1112); color:var(--text-img_6328_1112); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1113: linear-gradient(180deg, #eaeaea 0%, #7c7c7c 100%); --border-img_6328_1113: #c1c1c1; --text-img_6328_1113: #e3e5e3; }
+.btn-img_6328_1113 { background-image: var(--gradient-img_6328_1113); border:1px solid var(--border-img_6328_1113); color:var(--text-img_6328_1113); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1113 { background-image: var(--gradient-img_6328_1113); border:1px solid var(--border-img_6328_1113); color:var(--text-img_6328_1113); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1114: linear-gradient(180deg, #e7e7e7 0%, #a0de92 100%); --border-img_6328_1114: #c6e3bf; --text-img_6328_1114: #a4de98; }
+.btn-img_6328_1114 { background-image: var(--gradient-img_6328_1114); border:1px solid var(--border-img_6328_1114); color:var(--text-img_6328_1114); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1114 { background-image: var(--gradient-img_6328_1114); border:1px solid var(--border-img_6328_1114); color:var(--text-img_6328_1114); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1115: linear-gradient(180deg, #e9e9e9 0%, #98a196 100%); --border-img_6328_1115: #b5c5b1; --text-img_6328_1115: #9a9a9a; }
+.btn-img_6328_1115 { background-image: var(--gradient-img_6328_1115); border:1px solid var(--border-img_6328_1115); color:var(--text-img_6328_1115); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1115 { background-image: var(--gradient-img_6328_1115); border:1px solid var(--border-img_6328_1115); color:var(--text-img_6328_1115); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1116: linear-gradient(180deg, #e7e7e7 0%, #a3a3a3 100%); --border-img_6328_1116: #b3b2b2; --text-img_6328_1116: #787878; }
+.btn-img_6328_1116 { background-image: var(--gradient-img_6328_1116); border:1px solid var(--border-img_6328_1116); color:var(--text-img_6328_1116); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1116 { background-image: var(--gradient-img_6328_1116); border:1px solid var(--border-img_6328_1116); color:var(--text-img_6328_1116); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1117: linear-gradient(180deg, #a7e49a 0%, #98d788 100%); --border-img_6328_1117: #b5dfac; --text-img_6328_1117: #9fde91; }
+.btn-img_6328_1117 { background-image: var(--gradient-img_6328_1117); border:1px solid var(--border-img_6328_1117); color:var(--text-img_6328_1117); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1117 { background-image: var(--gradient-img_6328_1117); border:1px solid var(--border-img_6328_1117); color:var(--text-img_6328_1117); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1118: linear-gradient(180deg, #a7e49a 0%, #98d788 100%); --border-img_6328_1118: #9fdd91; --text-img_6328_1118: #9fde91; }
+.btn-img_6328_1118 { background-image: var(--gradient-img_6328_1118); border:1px solid var(--border-img_6328_1118); color:var(--text-img_6328_1118); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1118 { background-image: var(--gradient-img_6328_1118); border:1px solid var(--border-img_6328_1118); color:var(--text-img_6328_1118); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1119: linear-gradient(180deg, #a2a2a2 0%, #999898 100%); --border-img_6328_1119: #97ac92; --text-img_6328_1119: #838383; }
+.btn-img_6328_1119 { background-image: var(--gradient-img_6328_1119); border:1px solid var(--border-img_6328_1119); color:var(--text-img_6328_1119); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1119 { background-image: var(--gradient-img_6328_1119); border:1px solid var(--border-img_6328_1119); color:var(--text-img_6328_1119); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1120: linear-gradient(180deg, #767676 0%, #d5d5d5 100%); --border-img_6328_1120: #ababab; --text-img_6328_1120: #d5d5d5; }
+.btn-img_6328_1120 { background-image: var(--gradient-img_6328_1120); border:1px solid var(--border-img_6328_1120); color:var(--text-img_6328_1120); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1120 { background-image: var(--gradient-img_6328_1120); border:1px solid var(--border-img_6328_1120); color:var(--text-img_6328_1120); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1121: linear-gradient(180deg, #767676 0%, #afafaf 100%); --border-img_6328_1121: #8a8989; --text-img_6328_1121: #8a8989; }
+.btn-img_6328_1121 { background-image: var(--gradient-img_6328_1121); border:1px solid var(--border-img_6328_1121); color:var(--text-img_6328_1121); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1121 { background-image: var(--gradient-img_6328_1121); border:1px solid var(--border-img_6328_1121); color:var(--text-img_6328_1121); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1122: linear-gradient(180deg, #a3e095 0%, #8fd07f 100%); --border-img_6328_1122: #afdba5; --text-img_6328_1122: #99d88a; }
+.btn-img_6328_1122 { background-image: var(--gradient-img_6328_1122); border:1px solid var(--border-img_6328_1122); color:var(--text-img_6328_1122); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1122 { background-image: var(--gradient-img_6328_1122); border:1px solid var(--border-img_6328_1122); color:var(--text-img_6328_1122); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1123: linear-gradient(180deg, #a3e095 0%, #8fd07f 100%); --border-img_6328_1123: #b3dcaa; --text-img_6328_1123: #99d88a; }
+.btn-img_6328_1123 { background-image: var(--gradient-img_6328_1123); border:1px solid var(--border-img_6328_1123); color:var(--text-img_6328_1123); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1123 { background-image: var(--gradient-img_6328_1123); border:1px solid var(--border-img_6328_1123); color:var(--text-img_6328_1123); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1124: linear-gradient(180deg, #7d7c7c 0%, #605f5f 100%); --border-img_6328_1124: #7e7e7e; --text-img_6328_1124: #d5d5d5; }
+.btn-img_6328_1124 { background-image: var(--gradient-img_6328_1124); border:1px solid var(--border-img_6328_1124); color:var(--text-img_6328_1124); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1124 { background-image: var(--gradient-img_6328_1124); border:1px solid var(--border-img_6328_1124); color:var(--text-img_6328_1124); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1125: linear-gradient(180deg, #727272 0%, #605f5f 100%); --border-img_6328_1125: #7a7979; --text-img_6328_1125: #d5d5d5; }
+.btn-img_6328_1125 { background-image: var(--gradient-img_6328_1125); border:1px solid var(--border-img_6328_1125); color:var(--text-img_6328_1125); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1125 { background-image: var(--gradient-img_6328_1125); border:1px solid var(--border-img_6328_1125); color:var(--text-img_6328_1125); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1126: linear-gradient(180deg, #99d88a 0%, #e0e0e0 100%); --border-img_6328_1126: #bfdbb8; --text-img_6328_1126: #90d180; }
+.btn-img_6328_1126 { background-image: var(--gradient-img_6328_1126); border:1px solid var(--border-img_6328_1126); color:var(--text-img_6328_1126); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1126 { background-image: var(--gradient-img_6328_1126); border:1px solid var(--border-img_6328_1126); color:var(--text-img_6328_1126); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1127: linear-gradient(180deg, #9ca599 0%, #e1e1e1 100%); --border-img_6328_1127: #b2c3ae; --text-img_6328_1127: #8b8a8a; }
+.btn-img_6328_1127 { background-image: var(--gradient-img_6328_1127); border:1px solid var(--border-img_6328_1127); color:var(--text-img_6328_1127); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1127 { background-image: var(--gradient-img_6328_1127); border:1px solid var(--border-img_6328_1127); color:var(--text-img_6328_1127); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1128: linear-gradient(180deg, #d5d5d5 0%, #e0e0e0 100%); --border-img_6328_1128: #b2b1b1; --text-img_6328_1128: #616161; }
+.btn-img_6328_1128 { background-image: var(--gradient-img_6328_1128); border:1px solid var(--border-img_6328_1128); color:var(--text-img_6328_1128); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1128 { background-image: var(--gradient-img_6328_1128); border:1px solid var(--border-img_6328_1128); color:var(--text-img_6328_1128); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1129: linear-gradient(180deg, #91d281 0%, #dfdfdf 100%); --border-img_6328_1129: #c5dac0; --text-img_6328_1129: #c4d7bf; }
+.btn-img_6328_1129 { background-image: var(--gradient-img_6328_1129); border:1px solid var(--border-img_6328_1129); color:var(--text-img_6328_1129); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1129 { background-image: var(--gradient-img_6328_1129); border:1px solid var(--border-img_6328_1129); color:var(--text-img_6328_1129); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1130: linear-gradient(180deg, #91d281 0%, #dfdfdf 100%); --border-img_6328_1130: #b9d8b2; --text-img_6328_1130: #c5d8c0; }
+.btn-img_6328_1130 { background-image: var(--gradient-img_6328_1130); border:1px solid var(--border-img_6328_1130); color:var(--text-img_6328_1130); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1130 { background-image: var(--gradient-img_6328_1130); border:1px solid var(--border-img_6328_1130); color:var(--text-img_6328_1130); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1131: linear-gradient(180deg, #959494 0%, #e0e0e0 100%); --border-img_6328_1131: #b3bdb0; --text-img_6328_1131: #c9c9c9; }
+.btn-img_6328_1131 { background-image: var(--gradient-img_6328_1131); border:1px solid var(--border-img_6328_1131); color:var(--text-img_6328_1131); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1131 { background-image: var(--gradient-img_6328_1131); border:1px solid var(--border-img_6328_1131); color:var(--text-img_6328_1131); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1132: linear-gradient(180deg, #626161 0%, #e0e0df 100%); --border-img_6328_1132: #a3a3a3; --text-img_6328_1132: #b8b8b8; }
+.btn-img_6328_1132 { background-image: var(--gradient-img_6328_1132); border:1px solid var(--border-img_6328_1132); color:var(--text-img_6328_1132); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1132 { background-image: var(--gradient-img_6328_1132); border:1px solid var(--border-img_6328_1132); color:var(--text-img_6328_1132); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1133: linear-gradient(180deg, #626161 0%, #dfdfdf 100%); --border-img_6328_1133: #a4a3a3; --text-img_6328_1133: #b7b7b7; }
+.btn-img_6328_1133 { background-image: var(--gradient-img_6328_1133); border:1px solid var(--border-img_6328_1133); color:var(--text-img_6328_1133); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1133 { background-image: var(--gradient-img_6328_1133); border:1px solid var(--border-img_6328_1133); color:var(--text-img_6328_1133); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1134: linear-gradient(180deg, #e0e0e0 0%, #dcdcdc 100%); --border-img_6328_1134: #dedede; --text-img_6328_1134: #dedede; }
+.btn-img_6328_1134 { background-image: var(--gradient-img_6328_1134); border:1px solid var(--border-img_6328_1134); color:var(--text-img_6328_1134); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1134 { background-image: var(--gradient-img_6328_1134); border:1px solid var(--border-img_6328_1134); color:var(--text-img_6328_1134); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1135: linear-gradient(180deg, #e1e1e1 0%, #dddddd 100%); --border-img_6328_1135: #dfdfdf; --text-img_6328_1135: #dfdfdf; }
+.btn-img_6328_1135 { background-image: var(--gradient-img_6328_1135); border:1px solid var(--border-img_6328_1135); color:var(--text-img_6328_1135); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1135 { background-image: var(--gradient-img_6328_1135); border:1px solid var(--border-img_6328_1135); color:var(--text-img_6328_1135); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1136: linear-gradient(180deg, #e1e1e1 0%, #dddddd 100%); --border-img_6328_1136: #dfdfdf; --text-img_6328_1136: #dfdfdf; }
+.btn-img_6328_1136 { background-image: var(--gradient-img_6328_1136); border:1px solid var(--border-img_6328_1136); color:var(--text-img_6328_1136); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1136 { background-image: var(--gradient-img_6328_1136); border:1px solid var(--border-img_6328_1136); color:var(--text-img_6328_1136); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1137: linear-gradient(180deg, #e0e0e0 0%, #dcdcdc 100%); --border-img_6328_1137: #dedede; --text-img_6328_1137: #dedede; }
+.btn-img_6328_1137 { background-image: var(--gradient-img_6328_1137); border:1px solid var(--border-img_6328_1137); color:var(--text-img_6328_1137); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1137 { background-image: var(--gradient-img_6328_1137); border:1px solid var(--border-img_6328_1137); color:var(--text-img_6328_1137); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1138: linear-gradient(180deg, #dfdfdf 0%, #dcdcdc 100%); --border-img_6328_1138: #dddddd; --text-img_6328_1138: #dddddd; }
+.btn-img_6328_1138 { background-image: var(--gradient-img_6328_1138); border:1px solid var(--border-img_6328_1138); color:var(--text-img_6328_1138); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1138 { background-image: var(--gradient-img_6328_1138); border:1px solid var(--border-img_6328_1138); color:var(--text-img_6328_1138); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1139: linear-gradient(180deg, #dfe0df 0%, #dcdcdc 100%); --border-img_6328_1139: #dedede; --text-img_6328_1139: #dedede; }
+.btn-img_6328_1139 { background-image: var(--gradient-img_6328_1139); border:1px solid var(--border-img_6328_1139); color:var(--text-img_6328_1139); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1139 { background-image: var(--gradient-img_6328_1139); border:1px solid var(--border-img_6328_1139); color:var(--text-img_6328_1139); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1140: linear-gradient(180deg, #dfdfdf 0%, #dcdcdc 100%); --border-img_6328_1140: #dddddd; --text-img_6328_1140: #dddddd; }
+.btn-img_6328_1140 { background-image: var(--gradient-img_6328_1140); border:1px solid var(--border-img_6328_1140); color:var(--text-img_6328_1140); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1140 { background-image: var(--gradient-img_6328_1140); border:1px solid var(--border-img_6328_1140); color:var(--text-img_6328_1140); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1141: linear-gradient(180deg, #dedede 0%, #dbdbdb 100%); --border-img_6328_1141: #c8c8c8; --text-img_6328_1141: #dcdcdc; }
+.btn-img_6328_1141 { background-image: var(--gradient-img_6328_1141); border:1px solid var(--border-img_6328_1141); color:var(--text-img_6328_1141); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1141 { background-image: var(--gradient-img_6328_1141); border:1px solid var(--border-img_6328_1141); color:var(--text-img_6328_1141); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1142: linear-gradient(180deg, #dedede 0%, #dcdcdc 100%); --border-img_6328_1142: #c9c9c9; --text-img_6328_1142: #dddddd; }
+.btn-img_6328_1142 { background-image: var(--gradient-img_6328_1142); border:1px solid var(--border-img_6328_1142); color:var(--text-img_6328_1142); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1142 { background-image: var(--gradient-img_6328_1142); border:1px solid var(--border-img_6328_1142); color:var(--text-img_6328_1142); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1143: linear-gradient(180deg, #dfdfdf 0%, #dcdcdc 100%); --border-img_6328_1143: #c9c9c9; --text-img_6328_1143: #dddddd; }
+.btn-img_6328_1143 { background-image: var(--gradient-img_6328_1143); border:1px solid var(--border-img_6328_1143); color:var(--text-img_6328_1143); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1143 { background-image: var(--gradient-img_6328_1143); border:1px solid var(--border-img_6328_1143); color:var(--text-img_6328_1143); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1144: linear-gradient(180deg, #dedede 0%, #dcdcdc 100%); --border-img_6328_1144: #c9c9c9; --text-img_6328_1144: #dddddd; }
+.btn-img_6328_1144 { background-image: var(--gradient-img_6328_1144); border:1px solid var(--border-img_6328_1144); color:var(--text-img_6328_1144); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1144 { background-image: var(--gradient-img_6328_1144); border:1px solid var(--border-img_6328_1144); color:var(--text-img_6328_1144); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1145: linear-gradient(180deg, #dedede 0%, #dbdbdb 100%); --border-img_6328_1145: #c8c8c8; --text-img_6328_1145: #dcdcdc; }
+.btn-img_6328_1145 { background-image: var(--gradient-img_6328_1145); border:1px solid var(--border-img_6328_1145); color:var(--text-img_6328_1145); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1145 { background-image: var(--gradient-img_6328_1145); border:1px solid var(--border-img_6328_1145); color:var(--text-img_6328_1145); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1146: linear-gradient(180deg, #7f7f7f 0%, #343739 100%); --border-img_6328_1146: #9d9e9e; --text-img_6328_1146: #c8c8c8; }
+.btn-img_6328_1146 { background-image: var(--gradient-img_6328_1146); border:1px solid var(--border-img_6328_1146); color:var(--text-img_6328_1146); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1146 { background-image: var(--gradient-img_6328_1146); border:1px solid var(--border-img_6328_1146); color:var(--text-img_6328_1146); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1147: linear-gradient(180deg, #7f7f7f 0%, #343739 100%); --border-img_6328_1147: #9d9e9f; --text-img_6328_1147: #c6c5c5; }
+.btn-img_6328_1147 { background-image: var(--gradient-img_6328_1147); border:1px solid var(--border-img_6328_1147); color:var(--text-img_6328_1147); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1147 { background-image: var(--gradient-img_6328_1147); border:1px solid var(--border-img_6328_1147); color:var(--text-img_6328_1147); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1148: linear-gradient(180deg, #7f7f7f 0%, #343739 100%); --border-img_6328_1148: #9fa0a1; --text-img_6328_1148: #c6c5c5; }
+.btn-img_6328_1148 { background-image: var(--gradient-img_6328_1148); border:1px solid var(--border-img_6328_1148); color:var(--text-img_6328_1148); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1148 { background-image: var(--gradient-img_6328_1148); border:1px solid var(--border-img_6328_1148); color:var(--text-img_6328_1148); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1149: linear-gradient(180deg, #7f7f7f 0%, #343739 100%); --border-img_6328_1149: #9d9d9e; --text-img_6328_1149: #c8c7c7; }
+.btn-img_6328_1149 { background-image: var(--gradient-img_6328_1149); border:1px solid var(--border-img_6328_1149); color:var(--text-img_6328_1149); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1149 { background-image: var(--gradient-img_6328_1149); border:1px solid var(--border-img_6328_1149); color:var(--text-img_6328_1149); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1150: linear-gradient(180deg, #cfcece 0%, #343739 100%); --border-img_6328_1150: #7e7f80; --text-img_6328_1150: #c8c7c7; }
+.btn-img_6328_1150 { background-image: var(--gradient-img_6328_1150); border:1px solid var(--border-img_6328_1150); color:var(--text-img_6328_1150); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1150 { background-image: var(--gradient-img_6328_1150); border:1px solid var(--border-img_6328_1150); color:var(--text-img_6328_1150); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1151: linear-gradient(180deg, #cecdcd 0%, #3c4042 100%); --border-img_6328_1151: #818182; --text-img_6328_1151: #c6c4c4; }
+.btn-img_6328_1151 { background-image: var(--gradient-img_6328_1151); border:1px solid var(--border-img_6328_1151); color:var(--text-img_6328_1151); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1151 { background-image: var(--gradient-img_6328_1151); border:1px solid var(--border-img_6328_1151); color:var(--text-img_6328_1151); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1152: linear-gradient(180deg, #cfcece 0%, #343739 100%); --border-img_6328_1152: #838384; --text-img_6328_1152: #c8c7c7; }
+.btn-img_6328_1152 { background-image: var(--gradient-img_6328_1152); border:1px solid var(--border-img_6328_1152); color:var(--text-img_6328_1152); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1152 { background-image: var(--gradient-img_6328_1152); border:1px solid var(--border-img_6328_1152); color:var(--text-img_6328_1152); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1153: linear-gradient(180deg, #c8c8c8 0%, #343739 100%); --border-img_6328_1153: #989999; --text-img_6328_1153: #c8c8c8; }
+.btn-img_6328_1153 { background-image: var(--gradient-img_6328_1153); border:1px solid var(--border-img_6328_1153); color:var(--text-img_6328_1153); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1153 { background-image: var(--gradient-img_6328_1153); border:1px solid var(--border-img_6328_1153); color:var(--text-img_6328_1153); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1154: linear-gradient(180deg, #c7c6c6 0%, #343739 100%); --border-img_6328_1154: #979798; --text-img_6328_1154: #c7c6c6; }
+.btn-img_6328_1154 { background-image: var(--gradient-img_6328_1154); border:1px solid var(--border-img_6328_1154); color:var(--text-img_6328_1154); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1154 { background-image: var(--gradient-img_6328_1154); border:1px solid var(--border-img_6328_1154); color:var(--text-img_6328_1154); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1155: linear-gradient(180deg, #c6c5c5 0%, #494d50 100%); --border-img_6328_1155: #9b9b9c; --text-img_6328_1155: #c6c4c4; }
+.btn-img_6328_1155 { background-image: var(--gradient-img_6328_1155); border:1px solid var(--border-img_6328_1155); color:var(--text-img_6328_1155); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1155 { background-image: var(--gradient-img_6328_1155); border:1px solid var(--border-img_6328_1155); color:var(--text-img_6328_1155); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1156: linear-gradient(180deg, #c7c6c6 0%, #343739 100%); --border-img_6328_1156: #9fa0a0; --text-img_6328_1156: #c7c5c5; }
+.btn-img_6328_1156 { background-image: var(--gradient-img_6328_1156); border:1px solid var(--border-img_6328_1156); color:var(--text-img_6328_1156); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1156 { background-image: var(--gradient-img_6328_1156); border:1px solid var(--border-img_6328_1156); color:var(--text-img_6328_1156); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6328_1157: linear-gradient(180deg, #c8c8c8 0%, #343739 100%); --border-img_6328_1157: #989999; --text-img_6328_1157: #c8c7c7; }
+.btn-img_6328_1157 { background-image: var(--gradient-img_6328_1157); border:1px solid var(--border-img_6328_1157); color:var(--text-img_6328_1157); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6328_1157 { background-image: var(--gradient-img_6328_1157); border:1px solid var(--border-img_6328_1157); color:var(--text-img_6328_1157); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1158: linear-gradient(180deg, #5e6367 0%, #f7f7f7 100%); --border-img_6329_1158: #9c9ea0; --text-img_6329_1158: #45494c; }
+.btn-img_6329_1158 { background-image: var(--gradient-img_6329_1158); border:1px solid var(--border-img_6329_1158); color:var(--text-img_6329_1158); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1158 { background-image: var(--gradient-img_6329_1158); border:1px solid var(--border-img_6329_1158); color:var(--text-img_6329_1158); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1159: linear-gradient(180deg, #5e6367 0%, #f7f7f7 100%); --border-img_6329_1159: #9b9d9f; --text-img_6329_1159: #45494c; }
+.btn-img_6329_1159 { background-image: var(--gradient-img_6329_1159); border:1px solid var(--border-img_6329_1159); color:var(--text-img_6329_1159); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1159 { background-image: var(--gradient-img_6329_1159); border:1px solid var(--border-img_6329_1159); color:var(--text-img_6329_1159); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1160: linear-gradient(180deg, #5e6367 0%, #eeeeee 100%); --border-img_6329_1160: #9b9d9f; --text-img_6329_1160: #45494c; }
+.btn-img_6329_1160 { background-image: var(--gradient-img_6329_1160); border:1px solid var(--border-img_6329_1160); color:var(--text-img_6329_1160); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1160 { background-image: var(--gradient-img_6329_1160); border:1px solid var(--border-img_6329_1160); color:var(--text-img_6329_1160); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1161: linear-gradient(180deg, #5e6367 0%, #f3f3f3 100%); --border-img_6329_1161: #999c9e; --text-img_6329_1161: #45494c; }
+.btn-img_6329_1161 { background-image: var(--gradient-img_6329_1161); border:1px solid var(--border-img_6329_1161); color:var(--text-img_6329_1161); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1161 { background-image: var(--gradient-img_6329_1161); border:1px solid var(--border-img_6329_1161); color:var(--text-img_6329_1161); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1162: linear-gradient(180deg, #5e6367 0%, #f3f3f3 100%); --border-img_6329_1162: #9a9d9e; --text-img_6329_1162: #45494c; }
+.btn-img_6329_1162 { background-image: var(--gradient-img_6329_1162); border:1px solid var(--border-img_6329_1162); color:var(--text-img_6329_1162); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1162 { background-image: var(--gradient-img_6329_1162); border:1px solid var(--border-img_6329_1162); color:var(--text-img_6329_1162); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1163: linear-gradient(180deg, #5e6367 0%, #f7f7f7 100%); --border-img_6329_1163: #a9abad; --text-img_6329_1163: #76797a; }
+.btn-img_6329_1163 { background-image: var(--gradient-img_6329_1163); border:1px solid var(--border-img_6329_1163); color:var(--text-img_6329_1163); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1163 { background-image: var(--gradient-img_6329_1163); border:1px solid var(--border-img_6329_1163); color:var(--text-img_6329_1163); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1164: linear-gradient(180deg, #5e6367 0%, #ebedeb 100%); --border-img_6329_1164: #9da0a1; --text-img_6329_1164: #747677; }
+.btn-img_6329_1164 { background-image: var(--gradient-img_6329_1164); border:1px solid var(--border-img_6329_1164); color:var(--text-img_6329_1164); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1164 { background-image: var(--gradient-img_6329_1164); border:1px solid var(--border-img_6329_1164); color:var(--text-img_6329_1164); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1165: linear-gradient(180deg, #5e6367 0%, #f3f3f3 100%); --border-img_6329_1165: #a6a8aa; --text-img_6329_1165: #767879; }
+.btn-img_6329_1165 { background-image: var(--gradient-img_6329_1165); border:1px solid var(--border-img_6329_1165); color:var(--text-img_6329_1165); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1165 { background-image: var(--gradient-img_6329_1165); border:1px solid var(--border-img_6329_1165); color:var(--text-img_6329_1165); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1166: linear-gradient(180deg, #5e6367 0%, #f7f7f7 100%); --border-img_6329_1166: #adb0b1; --text-img_6329_1166: #bebfc0; }
+.btn-img_6329_1166 { background-image: var(--gradient-img_6329_1166); border:1px solid var(--border-img_6329_1166); color:var(--text-img_6329_1166); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1166 { background-image: var(--gradient-img_6329_1166); border:1px solid var(--border-img_6329_1166); color:var(--text-img_6329_1166); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1167: linear-gradient(180deg, #5e6367 0%, #ececec 100%); --border-img_6329_1167: #aaadae; --text-img_6329_1167: #aeafb0; }
+.btn-img_6329_1167 { background-image: var(--gradient-img_6329_1167); border:1px solid var(--border-img_6329_1167); color:var(--text-img_6329_1167); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1167 { background-image: var(--gradient-img_6329_1167); border:1px solid var(--border-img_6329_1167); color:var(--text-img_6329_1167); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1168: linear-gradient(180deg, #5e6367 0%, #f1f2f1 100%); --border-img_6329_1168: #acaeb0; --text-img_6329_1168: #bcbdbd; }
+.btn-img_6329_1168 { background-image: var(--gradient-img_6329_1168); border:1px solid var(--border-img_6329_1168); color:var(--text-img_6329_1168); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1168 { background-image: var(--gradient-img_6329_1168); border:1px solid var(--border-img_6329_1168); color:var(--text-img_6329_1168); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1169: linear-gradient(180deg, #5e6367 0%, #f2f2f2 100%); --border-img_6329_1169: #acaeb0; --text-img_6329_1169: #bcbdbd; }
+.btn-img_6329_1169 { background-image: var(--gradient-img_6329_1169); border:1px solid var(--border-img_6329_1169); color:var(--text-img_6329_1169); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1169 { background-image: var(--gradient-img_6329_1169); border:1px solid var(--border-img_6329_1169); color:var(--text-img_6329_1169); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1170: linear-gradient(180deg, #f7f7f7 0%, #f7f7f7 100%); --border-img_6329_1170: #f2f2f2; --text-img_6329_1170: #f7f7f7; }
+.btn-img_6329_1170 { background-image: var(--gradient-img_6329_1170); border:1px solid var(--border-img_6329_1170); color:var(--text-img_6329_1170); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1170 { background-image: var(--gradient-img_6329_1170); border:1px solid var(--border-img_6329_1170); color:var(--text-img_6329_1170); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1171: linear-gradient(180deg, #f2f2f2 0%, #f0f0f0 100%); --border-img_6329_1171: #f1f1f1; --text-img_6329_1171: #f1f1f1; }
+.btn-img_6329_1171 { background-image: var(--gradient-img_6329_1171); border:1px solid var(--border-img_6329_1171); color:var(--text-img_6329_1171); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1171 { background-image: var(--gradient-img_6329_1171); border:1px solid var(--border-img_6329_1171); color:var(--text-img_6329_1171); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1172: linear-gradient(180deg, #f2f2f2 0%, #f0f0f0 100%); --border-img_6329_1172: #f1f1f1; --text-img_6329_1172: #f1f1f1; }
+.btn-img_6329_1172 { background-image: var(--gradient-img_6329_1172); border:1px solid var(--border-img_6329_1172); color:var(--text-img_6329_1172); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1172 { background-image: var(--gradient-img_6329_1172); border:1px solid var(--border-img_6329_1172); color:var(--text-img_6329_1172); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1173: linear-gradient(180deg, #ebedea 0%, #eaebe9 100%); --border-img_6329_1173: #e1e1e1; --text-img_6329_1173: #ededed; }
+.btn-img_6329_1173 { background-image: var(--gradient-img_6329_1173); border:1px solid var(--border-img_6329_1173); color:var(--text-img_6329_1173); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1173 { background-image: var(--gradient-img_6329_1173); border:1px solid var(--border-img_6329_1173); color:var(--text-img_6329_1173); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1174: linear-gradient(180deg, #f2f2f2 0%, #efefef 100%); --border-img_6329_1174: #f0f0f0; --text-img_6329_1174: #f0f0f0; }
+.btn-img_6329_1174 { background-image: var(--gradient-img_6329_1174); border:1px solid var(--border-img_6329_1174); color:var(--text-img_6329_1174); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1174 { background-image: var(--gradient-img_6329_1174); border:1px solid var(--border-img_6329_1174); color:var(--text-img_6329_1174); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1175: linear-gradient(180deg, #ececec 0%, #ebebeb 100%); --border-img_6329_1175: #f0f0f0; --text-img_6329_1175: #dfdfdf; }
+.btn-img_6329_1175 { background-image: var(--gradient-img_6329_1175); border:1px solid var(--border-img_6329_1175); color:var(--text-img_6329_1175); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1175 { background-image: var(--gradient-img_6329_1175); border:1px solid var(--border-img_6329_1175); color:var(--text-img_6329_1175); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1176: linear-gradient(180deg, #f0f0f0 0%, #ecedec 100%); --border-img_6329_1176: #edeeed; --text-img_6329_1176: #efefef; }
+.btn-img_6329_1176 { background-image: var(--gradient-img_6329_1176); border:1px solid var(--border-img_6329_1176); color:var(--text-img_6329_1176); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1176 { background-image: var(--gradient-img_6329_1176); border:1px solid var(--border-img_6329_1176); color:var(--text-img_6329_1176); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1177: linear-gradient(180deg, #f1f1f1 0%, #eeeeee 100%); --border-img_6329_1177: #efefef; --text-img_6329_1177: #efefef; }
+.btn-img_6329_1177 { background-image: var(--gradient-img_6329_1177); border:1px solid var(--border-img_6329_1177); color:var(--text-img_6329_1177); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1177 { background-image: var(--gradient-img_6329_1177); border:1px solid var(--border-img_6329_1177); color:var(--text-img_6329_1177); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1178: linear-gradient(180deg, #f7f7f7 0%, #f7f7f7 100%); --border-img_6329_1178: #f2f2f2; --text-img_6329_1178: #f7f7f7; }
+.btn-img_6329_1178 { background-image: var(--gradient-img_6329_1178); border:1px solid var(--border-img_6329_1178); color:var(--text-img_6329_1178); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1178 { background-image: var(--gradient-img_6329_1178); border:1px solid var(--border-img_6329_1178); color:var(--text-img_6329_1178); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1179: linear-gradient(180deg, #eeeeee 0%, #ececec 100%); --border-img_6329_1179: #ededed; --text-img_6329_1179: #ededed; }
+.btn-img_6329_1179 { background-image: var(--gradient-img_6329_1179); border:1px solid var(--border-img_6329_1179); color:var(--text-img_6329_1179); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1179 { background-image: var(--gradient-img_6329_1179); border:1px solid var(--border-img_6329_1179); color:var(--text-img_6329_1179); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1180: linear-gradient(180deg, #eeeeee 0%, #ececec 100%); --border-img_6329_1180: #ededed; --text-img_6329_1180: #ededed; }
+.btn-img_6329_1180 { background-image: var(--gradient-img_6329_1180); border:1px solid var(--border-img_6329_1180); color:var(--text-img_6329_1180); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1180 { background-image: var(--gradient-img_6329_1180); border:1px solid var(--border-img_6329_1180); color:var(--text-img_6329_1180); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1181: linear-gradient(180deg, #e9ebe9 0%, #e8eae8 100%); --border-img_6329_1181: #dfdfde; --text-img_6329_1181: #ebebeb; }
+.btn-img_6329_1181 { background-image: var(--gradient-img_6329_1181); border:1px solid var(--border-img_6329_1181); color:var(--text-img_6329_1181); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1181 { background-image: var(--gradient-img_6329_1181); border:1px solid var(--border-img_6329_1181); color:var(--text-img_6329_1181); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1182: linear-gradient(180deg, #ededed 0%, #eaeaea 100%); --border-img_6329_1182: #ececec; --text-img_6329_1182: #ececec; }
+.btn-img_6329_1182 { background-image: var(--gradient-img_6329_1182); border:1px solid var(--border-img_6329_1182); color:var(--text-img_6329_1182); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1182 { background-image: var(--gradient-img_6329_1182); border:1px solid var(--border-img_6329_1182); color:var(--text-img_6329_1182); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1183: linear-gradient(180deg, #ebebeb 0%, #eaeaeb 100%); --border-img_6329_1183: #efefef; --text-img_6329_1183: #dfdfdf; }
+.btn-img_6329_1183 { background-image: var(--gradient-img_6329_1183); border:1px solid var(--border-img_6329_1183); color:var(--text-img_6329_1183); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1183 { background-image: var(--gradient-img_6329_1183); border:1px solid var(--border-img_6329_1183); color:var(--text-img_6329_1183); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1184: linear-gradient(180deg, #ebeceb 0%, #e7e8e7 100%); --border-img_6329_1184: #e9eae9; --text-img_6329_1184: #eaeaea; }
+.btn-img_6329_1184 { background-image: var(--gradient-img_6329_1184); border:1px solid var(--border-img_6329_1184); color:var(--text-img_6329_1184); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1184 { background-image: var(--gradient-img_6329_1184); border:1px solid var(--border-img_6329_1184); color:var(--text-img_6329_1184); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1185: linear-gradient(180deg, #ececec 0%, #e9e9e9 100%); --border-img_6329_1185: #eaeaea; --text-img_6329_1185: #eaeaea; }
+.btn-img_6329_1185 { background-image: var(--gradient-img_6329_1185); border:1px solid var(--border-img_6329_1185); color:var(--text-img_6329_1185); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1185 { background-image: var(--gradient-img_6329_1185); border:1px solid var(--border-img_6329_1185); color:var(--text-img_6329_1185); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1186: linear-gradient(180deg, #f7f7f7 0%, #f7f7f7 100%); --border-img_6329_1186: #f1f1f1; --text-img_6329_1186: #f7f7f7; }
+.btn-img_6329_1186 { background-image: var(--gradient-img_6329_1186); border:1px solid var(--border-img_6329_1186); color:var(--text-img_6329_1186); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1186 { background-image: var(--gradient-img_6329_1186); border:1px solid var(--border-img_6329_1186); color:var(--text-img_6329_1186); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1187: linear-gradient(180deg, #ebebeb 0%, #e8e8e8 100%); --border-img_6329_1187: #e9e9e9; --text-img_6329_1187: #e9e9e9; }
+.btn-img_6329_1187 { background-image: var(--gradient-img_6329_1187); border:1px solid var(--border-img_6329_1187); color:var(--text-img_6329_1187); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1187 { background-image: var(--gradient-img_6329_1187); border:1px solid var(--border-img_6329_1187); color:var(--text-img_6329_1187); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1188: linear-gradient(180deg, #ebebeb 0%, #e8e8e8 100%); --border-img_6329_1188: #e9e9e9; --text-img_6329_1188: #e9e9e9; }
+.btn-img_6329_1188 { background-image: var(--gradient-img_6329_1188); border:1px solid var(--border-img_6329_1188); color:var(--text-img_6329_1188); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1188 { background-image: var(--gradient-img_6329_1188); border:1px solid var(--border-img_6329_1188); color:var(--text-img_6329_1188); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1189: linear-gradient(180deg, #e8eae8 0%, #e7e9e6 100%); --border-img_6329_1189: #dddddc; --text-img_6329_1189: #eaeaea; }
+.btn-img_6329_1189 { background-image: var(--gradient-img_6329_1189); border:1px solid var(--border-img_6329_1189); color:var(--text-img_6329_1189); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1189 { background-image: var(--gradient-img_6329_1189); border:1px solid var(--border-img_6329_1189); color:var(--text-img_6329_1189); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1190: linear-gradient(180deg, #e9e9e9 0%, #e6e6e6 100%); --border-img_6329_1190: #e7e7e7; --text-img_6329_1190: #e8e8e8; }
+.btn-img_6329_1190 { background-image: var(--gradient-img_6329_1190); border:1px solid var(--border-img_6329_1190); color:var(--text-img_6329_1190); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1190 { background-image: var(--gradient-img_6329_1190); border:1px solid var(--border-img_6329_1190); color:var(--text-img_6329_1190); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1191: linear-gradient(180deg, #f7f7f7 0%, #e9e9e9 100%); --border-img_6329_1191: #f1f1f1; --text-img_6329_1191: #f7f7f7; }
+.btn-img_6329_1191 { background-image: var(--gradient-img_6329_1191); border:1px solid var(--border-img_6329_1191); color:var(--text-img_6329_1191); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1191 { background-image: var(--gradient-img_6329_1191); border:1px solid var(--border-img_6329_1191); color:var(--text-img_6329_1191); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1192: linear-gradient(180deg, #eaeaea 0%, #e9e9e9 100%); --border-img_6329_1192: #ececec; --text-img_6329_1192: #dedede; }
+.btn-img_6329_1192 { background-image: var(--gradient-img_6329_1192); border:1px solid var(--border-img_6329_1192); color:var(--text-img_6329_1192); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1192 { background-image: var(--gradient-img_6329_1192); border:1px solid var(--border-img_6329_1192); color:var(--text-img_6329_1192); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1193: linear-gradient(180deg, #e6e7e6 0%, #e9e9e9 100%); --border-img_6329_1193: #e7e8e7; --text-img_6329_1193: #e5e5e5; }
+.btn-img_6329_1193 { background-image: var(--gradient-img_6329_1193); border:1px solid var(--border-img_6329_1193); color:var(--text-img_6329_1193); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1193 { background-image: var(--gradient-img_6329_1193); border:1px solid var(--border-img_6329_1193); color:var(--text-img_6329_1193); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1194: linear-gradient(180deg, #e7e7e7 0%, #e9e9e9 100%); --border-img_6329_1194: #e7e7e6; --text-img_6329_1194: #e5e5e5; }
+.btn-img_6329_1194 { background-image: var(--gradient-img_6329_1194); border:1px solid var(--border-img_6329_1194); color:var(--text-img_6329_1194); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1194 { background-image: var(--gradient-img_6329_1194); border:1px solid var(--border-img_6329_1194); color:var(--text-img_6329_1194); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1195: linear-gradient(180deg, #f7f7f7 0%, #e9e9e9 100%); --border-img_6329_1195: #f1f1f1; --text-img_6329_1195: #f7f7f7; }
+.btn-img_6329_1195 { background-image: var(--gradient-img_6329_1195); border:1px solid var(--border-img_6329_1195); color:var(--text-img_6329_1195); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1195 { background-image: var(--gradient-img_6329_1195); border:1px solid var(--border-img_6329_1195); color:var(--text-img_6329_1195); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1196: linear-gradient(180deg, #f7f7f7 0%, #e9e9e9 100%); --border-img_6329_1196: #ededed; --text-img_6329_1196: #f7f7f7; }
+.btn-img_6329_1196 { background-image: var(--gradient-img_6329_1196); border:1px solid var(--border-img_6329_1196); color:var(--text-img_6329_1196); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1196 { background-image: var(--gradient-img_6329_1196); border:1px solid var(--border-img_6329_1196); color:var(--text-img_6329_1196); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1197: linear-gradient(180deg, #e7e7e7 0%, #e9e9e9 100%); --border-img_6329_1197: #e6e7e6; --text-img_6329_1197: #e5e5e5; }
+.btn-img_6329_1197 { background-image: var(--gradient-img_6329_1197); border:1px solid var(--border-img_6329_1197); color:var(--text-img_6329_1197); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1197 { background-image: var(--gradient-img_6329_1197); border:1px solid var(--border-img_6329_1197); color:var(--text-img_6329_1197); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1198: linear-gradient(180deg, #e7e7e7 0%, #e9e9e9 100%); --border-img_6329_1198: #e6e7e6; --text-img_6329_1198: #e5e5e5; }
+.btn-img_6329_1198 { background-image: var(--gradient-img_6329_1198); border:1px solid var(--border-img_6329_1198); color:var(--text-img_6329_1198); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1198 { background-image: var(--gradient-img_6329_1198); border:1px solid var(--border-img_6329_1198); color:var(--text-img_6329_1198); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1199: linear-gradient(180deg, #f7f7f7 0%, #8fc783 100%); --border-img_6329_1199: #d8ecd4; --text-img_6329_1199: #e9e9e9; }
+.btn-img_6329_1199 { background-image: var(--gradient-img_6329_1199); border:1px solid var(--border-img_6329_1199); color:var(--text-img_6329_1199); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1199 { background-image: var(--gradient-img_6329_1199); border:1px solid var(--border-img_6329_1199); color:var(--text-img_6329_1199); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1200: linear-gradient(180deg, #e9e9e9 0%, #e5e5e5 100%); --border-img_6329_1200: #dbdbda; --text-img_6329_1200: #e9e9e9; }
+.btn-img_6329_1200 { background-image: var(--gradient-img_6329_1200); border:1px solid var(--border-img_6329_1200); color:var(--text-img_6329_1200); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1200 { background-image: var(--gradient-img_6329_1200); border:1px solid var(--border-img_6329_1200); color:var(--text-img_6329_1200); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1201: linear-gradient(180deg, #b9dab2 0%, #7b7b7b 100%); --border-img_6329_1201: #c0c1c0; --text-img_6329_1201: #e9e9e9; }
+.btn-img_6329_1201 { background-image: var(--gradient-img_6329_1201); border:1px solid var(--border-img_6329_1201); color:var(--text-img_6329_1201); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1201 { background-image: var(--gradient-img_6329_1201); border:1px solid var(--border-img_6329_1201); color:var(--text-img_6329_1201); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1202: linear-gradient(180deg, #e9e9e9 0%, #aee9a2 100%); --border-img_6329_1202: #c6e7bf; --text-img_6329_1202: #a2dc96; }
+.btn-img_6329_1202 { background-image: var(--gradient-img_6329_1202); border:1px solid var(--border-img_6329_1202); color:var(--text-img_6329_1202); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1202 { background-image: var(--gradient-img_6329_1202); border:1px solid var(--border-img_6329_1202); color:var(--text-img_6329_1202); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1203: linear-gradient(180deg, #e9e9e9 0%, #aee9a1 100%); --border-img_6329_1203: #d1e7cc; --text-img_6329_1203: #a0da94; }
+.btn-img_6329_1203 { background-image: var(--gradient-img_6329_1203); border:1px solid var(--border-img_6329_1203); color:var(--text-img_6329_1203); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1203 { background-image: var(--gradient-img_6329_1203); border:1px solid var(--border-img_6329_1203); color:var(--text-img_6329_1203); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1204: linear-gradient(180deg, #e9e9e9 0%, #e7e7e7 100%); --border-img_6329_1204: #d2d2d2; --text-img_6329_1204: #e8e8e8; }
+.btn-img_6329_1204 { background-image: var(--gradient-img_6329_1204); border:1px solid var(--border-img_6329_1204); color:var(--text-img_6329_1204); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1204 { background-image: var(--gradient-img_6329_1204); border:1px solid var(--border-img_6329_1204); color:var(--text-img_6329_1204); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1205: linear-gradient(180deg, #e9e9e9 0%, #7c7c7c 100%); --border-img_6329_1205: #aaaaaa; --text-img_6329_1205: #757575; }
+.btn-img_6329_1205 { background-image: var(--gradient-img_6329_1205); border:1px solid var(--border-img_6329_1205); color:var(--text-img_6329_1205); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1205 { background-image: var(--gradient-img_6329_1205); border:1px solid var(--border-img_6329_1205); color:var(--text-img_6329_1205); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1206: linear-gradient(180deg, #e9e9e9 0%, #7c7c7c 100%); --border-img_6329_1206: #aaaaaa; --text-img_6329_1206: #757575; }
+.btn-img_6329_1206 { background-image: var(--gradient-img_6329_1206); border:1px solid var(--border-img_6329_1206); color:var(--text-img_6329_1206); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1206 { background-image: var(--gradient-img_6329_1206); border:1px solid var(--border-img_6329_1206); color:var(--text-img_6329_1206); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1207: linear-gradient(180deg, #e8e8e8 0%, #ace89f 100%); --border-img_6329_1207: #bde7b5; --text-img_6329_1207: #aeeaa2; }
+.btn-img_6329_1207 { background-image: var(--gradient-img_6329_1207); border:1px solid var(--border-img_6329_1207); color:var(--text-img_6329_1207); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1207 { background-image: var(--gradient-img_6329_1207); border:1px solid var(--border-img_6329_1207); color:var(--text-img_6329_1207); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1208: linear-gradient(180deg, #e9e9e9 0%, #c8e2c2 100%); --border-img_6329_1208: #d3e7ce; --text-img_6329_1208: #c5d6c1; }
+.btn-img_6329_1208 { background-image: var(--gradient-img_6329_1208); border:1px solid var(--border-img_6329_1208); color:var(--text-img_6329_1208); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1208 { background-image: var(--gradient-img_6329_1208); border:1px solid var(--border-img_6329_1208); color:var(--text-img_6329_1208); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1209: linear-gradient(180deg, #e9e9e9 0%, #7a7a7a 100%); --border-img_6329_1209: #b8b8b8; --text-img_6329_1209: #7d7d7d; }
+.btn-img_6329_1209 { background-image: var(--gradient-img_6329_1209); border:1px solid var(--border-img_6329_1209); color:var(--text-img_6329_1209); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1209 { background-image: var(--gradient-img_6329_1209); border:1px solid var(--border-img_6329_1209); color:var(--text-img_6329_1209); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1210: linear-gradient(180deg, #e9e9e9 0%, #7a7a7a 100%); --border-img_6329_1210: #9c9c9b; --text-img_6329_1210: #7d7d7d; }
+.btn-img_6329_1210 { background-image: var(--gradient-img_6329_1210); border:1px solid var(--border-img_6329_1210); color:var(--text-img_6329_1210); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1210 { background-image: var(--gradient-img_6329_1210); border:1px solid var(--border-img_6329_1210); color:var(--text-img_6329_1210); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1211: linear-gradient(180deg, #aeeaa2 0%, #aae69d 100%); --border-img_6329_1211: #ace89f; --text-img_6329_1211: #ace89f; }
+.btn-img_6329_1211 { background-image: var(--gradient-img_6329_1211); border:1px solid var(--border-img_6329_1211); color:var(--text-img_6329_1211); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1211 { background-image: var(--gradient-img_6329_1211); border:1px solid var(--border-img_6329_1211); color:var(--text-img_6329_1211); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1212: linear-gradient(180deg, #cfcfcf 0%, #cecece 100%); --border-img_6329_1212: #a9b2a7; --text-img_6329_1212: #e8e8e8; }
+.btn-img_6329_1212 { background-image: var(--gradient-img_6329_1212); border:1px solid var(--border-img_6329_1212); color:var(--text-img_6329_1212); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1212 { background-image: var(--gradient-img_6329_1212); border:1px solid var(--border-img_6329_1212); color:var(--text-img_6329_1212); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1213: linear-gradient(180deg, #7d7d7d 0%, #787878 100%); --border-img_6329_1213: #7a7a7a; --text-img_6329_1213: #7a7a7a; }
+.btn-img_6329_1213 { background-image: var(--gradient-img_6329_1213); border:1px solid var(--border-img_6329_1213); color:var(--text-img_6329_1213); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1213 { background-image: var(--gradient-img_6329_1213); border:1px solid var(--border-img_6329_1213); color:var(--text-img_6329_1213); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1214: linear-gradient(180deg, #ace8a0 0%, #a8e49b 100%); --border-img_6329_1214: #aae69d; --text-img_6329_1214: #aae69d; }
+.btn-img_6329_1214 { background-image: var(--gradient-img_6329_1214); border:1px solid var(--border-img_6329_1214); color:var(--text-img_6329_1214); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1214 { background-image: var(--gradient-img_6329_1214); border:1px solid var(--border-img_6329_1214); color:var(--text-img_6329_1214); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1215: linear-gradient(180deg, #ace89f 0%, #a8e49b 100%); --border-img_6329_1215: #bce4b3; --text-img_6329_1215: #aae69d; }
+.btn-img_6329_1215 { background-image: var(--gradient-img_6329_1215); border:1px solid var(--border-img_6329_1215); color:var(--text-img_6329_1215); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1215 { background-image: var(--gradient-img_6329_1215); border:1px solid var(--border-img_6329_1215); color:var(--text-img_6329_1215); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1216: linear-gradient(180deg, #e6e6e6 0%, #e6e6e6 100%); --border-img_6329_1216: #bebebe; --text-img_6329_1216: #e7e7e7; }
+.btn-img_6329_1216 { background-image: var(--gradient-img_6329_1216); border:1px solid var(--border-img_6329_1216); color:var(--text-img_6329_1216); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1216 { background-image: var(--gradient-img_6329_1216); border:1px solid var(--border-img_6329_1216); color:var(--text-img_6329_1216); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1217: linear-gradient(180deg, #7b7b7b 0%, #777777 100%); --border-img_6329_1217: #797979; --text-img_6329_1217: #797979; }
+.btn-img_6329_1217 { background-image: var(--gradient-img_6329_1217); border:1px solid var(--border-img_6329_1217); color:var(--text-img_6329_1217); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1217 { background-image: var(--gradient-img_6329_1217); border:1px solid var(--border-img_6329_1217); color:var(--text-img_6329_1217); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1218: linear-gradient(180deg, #7b7b7b 0%, #777777 100%); --border-img_6329_1218: #797979; --text-img_6329_1218: #797979; }
+.btn-img_6329_1218 { background-image: var(--gradient-img_6329_1218); border:1px solid var(--border-img_6329_1218); color:var(--text-img_6329_1218); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1218 { background-image: var(--gradient-img_6329_1218); border:1px solid var(--border-img_6329_1218); color:var(--text-img_6329_1218); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1219: linear-gradient(180deg, #a9e69c 0%, #a4e196 100%); --border-img_6329_1219: #a7e399; --text-img_6329_1219: #a7e399; }
+.btn-img_6329_1219 { background-image: var(--gradient-img_6329_1219); border:1px solid var(--border-img_6329_1219); color:var(--text-img_6329_1219); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1219 { background-image: var(--gradient-img_6329_1219); border:1px solid var(--border-img_6329_1219); color:var(--text-img_6329_1219); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1220: linear-gradient(180deg, #c7e1c1 0%, #c4dfbe 100%); --border-img_6329_1220: #c6e4c0; --text-img_6329_1220: #c4d6c0; }
+.btn-img_6329_1220 { background-image: var(--gradient-img_6329_1220); border:1px solid var(--border-img_6329_1220); color:var(--text-img_6329_1220); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1220 { background-image: var(--gradient-img_6329_1220); border:1px solid var(--border-img_6329_1220); color:var(--text-img_6329_1220); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1221: linear-gradient(180deg, #787878 0%, #737373 100%); --border-img_6329_1221: #9b9a9a; --text-img_6329_1221: #767575; }
+.btn-img_6329_1221 { background-image: var(--gradient-img_6329_1221); border:1px solid var(--border-img_6329_1221); color:var(--text-img_6329_1221); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1221 { background-image: var(--gradient-img_6329_1221); border:1px solid var(--border-img_6329_1221); color:var(--text-img_6329_1221); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1222: linear-gradient(180deg, #787878 0%, #737373 100%); --border-img_6329_1222: #767575; --text-img_6329_1222: #767575; }
+.btn-img_6329_1222 { background-image: var(--gradient-img_6329_1222); border:1px solid var(--border-img_6329_1222); color:var(--text-img_6329_1222); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1222 { background-image: var(--gradient-img_6329_1222); border:1px solid var(--border-img_6329_1222); color:var(--text-img_6329_1222); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1223: linear-gradient(180deg, #a8e49a 0%, #a3e095 100%); --border-img_6329_1223: #a5e298; --text-img_6329_1223: #a5e298; }
+.btn-img_6329_1223 { background-image: var(--gradient-img_6329_1223); border:1px solid var(--border-img_6329_1223); color:var(--text-img_6329_1223); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1223 { background-image: var(--gradient-img_6329_1223); border:1px solid var(--border-img_6329_1223); color:var(--text-img_6329_1223); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1224: linear-gradient(180deg, #cdcdcd 0%, #cccccc 100%); --border-img_6329_1224: #a6afa4; --text-img_6329_1224: #e6e6e6; }
+.btn-img_6329_1224 { background-image: var(--gradient-img_6329_1224); border:1px solid var(--border-img_6329_1224); color:var(--text-img_6329_1224); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1224 { background-image: var(--gradient-img_6329_1224); border:1px solid var(--border-img_6329_1224); color:var(--text-img_6329_1224); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1225: linear-gradient(180deg, #767676 0%, #727272 100%); --border-img_6329_1225: #747474; --text-img_6329_1225: #747474; }
+.btn-img_6329_1225 { background-image: var(--gradient-img_6329_1225); border:1px solid var(--border-img_6329_1225); color:var(--text-img_6329_1225); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1225 { background-image: var(--gradient-img_6329_1225); border:1px solid var(--border-img_6329_1225); color:var(--text-img_6329_1225); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1226: linear-gradient(180deg, #a6e399 0%, #a2df94 100%); --border-img_6329_1226: #a4e196; --text-img_6329_1226: #a4e196; }
+.btn-img_6329_1226 { background-image: var(--gradient-img_6329_1226); border:1px solid var(--border-img_6329_1226); color:var(--text-img_6329_1226); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1226 { background-image: var(--gradient-img_6329_1226); border:1px solid var(--border-img_6329_1226); color:var(--text-img_6329_1226); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1227: linear-gradient(180deg, #a6e399 0%, #a2df94 100%); --border-img_6329_1227: #b7e1ae; --text-img_6329_1227: #a4e196; }
+.btn-img_6329_1227 { background-image: var(--gradient-img_6329_1227); border:1px solid var(--border-img_6329_1227); color:var(--text-img_6329_1227); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1227 { background-image: var(--gradient-img_6329_1227); border:1px solid var(--border-img_6329_1227); color:var(--text-img_6329_1227); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1228: linear-gradient(180deg, #e5e5e5 0%, #e4e5e5 100%); --border-img_6329_1228: #bbbbbb; --text-img_6329_1228: #e6e6e6; }
+.btn-img_6329_1228 { background-image: var(--gradient-img_6329_1228); border:1px solid var(--border-img_6329_1228); color:var(--text-img_6329_1228); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1228 { background-image: var(--gradient-img_6329_1228); border:1px solid var(--border-img_6329_1228); color:var(--text-img_6329_1228); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1229: linear-gradient(180deg, #757575 0%, #717171 100%); --border-img_6329_1229: #737373; --text-img_6329_1229: #737373; }
+.btn-img_6329_1229 { background-image: var(--gradient-img_6329_1229); border:1px solid var(--border-img_6329_1229); color:var(--text-img_6329_1229); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1229 { background-image: var(--gradient-img_6329_1229); border:1px solid var(--border-img_6329_1229); color:var(--text-img_6329_1229); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1230: linear-gradient(180deg, #757575 0%, #717171 100%); --border-img_6329_1230: #737373; --text-img_6329_1230: #737373; }
+.btn-img_6329_1230 { background-image: var(--gradient-img_6329_1230); border:1px solid var(--border-img_6329_1230); color:var(--text-img_6329_1230); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1230 { background-image: var(--gradient-img_6329_1230); border:1px solid var(--border-img_6329_1230); color:var(--text-img_6329_1230); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1231: linear-gradient(180deg, #a2df94 0%, #343739 100%); --border-img_6329_1231: #81ad78; --text-img_6329_1231: #9fdd91; }
+.btn-img_6329_1231 { background-image: var(--gradient-img_6329_1231); border:1px solid var(--border-img_6329_1231); color:var(--text-img_6329_1231); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1231 { background-image: var(--gradient-img_6329_1231); border:1px solid var(--border-img_6329_1231); color:var(--text-img_6329_1231); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1232: linear-gradient(180deg, #c3debe 0%, #343739 100%); --border-img_6329_1232: #9ab097; --text-img_6329_1232: #c2d4bf; }
+.btn-img_6329_1232 { background-image: var(--gradient-img_6329_1232); border:1px solid var(--border-img_6329_1232); color:var(--text-img_6329_1232); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1232 { background-image: var(--gradient-img_6329_1232); border:1px solid var(--border-img_6329_1232); color:var(--text-img_6329_1232); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1233: linear-gradient(180deg, #717171 0%, #343739 100%); --border-img_6329_1233: #818282; --text-img_6329_1233: #6f6e6e; }
+.btn-img_6329_1233 { background-image: var(--gradient-img_6329_1233); border:1px solid var(--border-img_6329_1233); color:var(--text-img_6329_1233); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1233 { background-image: var(--gradient-img_6329_1233); border:1px solid var(--border-img_6329_1233); color:var(--text-img_6329_1233); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1234: linear-gradient(180deg, #717171 0%, #343739 100%); --border-img_6329_1234: #696a6a; --text-img_6329_1234: #6f6e6e; }
+.btn-img_6329_1234 { background-image: var(--gradient-img_6329_1234); border:1px solid var(--border-img_6329_1234); color:var(--text-img_6329_1234); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1234 { background-image: var(--gradient-img_6329_1234); border:1px solid var(--border-img_6329_1234); color:var(--text-img_6329_1234); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1235: linear-gradient(180deg, #a1df93 0%, #343739 100%); --border-img_6329_1235: #7ba473; --text-img_6329_1235: #9fdd90; }
+.btn-img_6329_1235 { background-image: var(--gradient-img_6329_1235); border:1px solid var(--border-img_6329_1235); color:var(--text-img_6329_1235); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1235 { background-image: var(--gradient-img_6329_1235); border:1px solid var(--border-img_6329_1235); color:var(--text-img_6329_1235); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1236: linear-gradient(180deg, #cccccc 0%, #3c4042 100%); --border-img_6329_1236: #7c847c; --text-img_6329_1236: #e5e5e5; }
+.btn-img_6329_1236 { background-image: var(--gradient-img_6329_1236); border:1px solid var(--border-img_6329_1236); color:var(--text-img_6329_1236); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1236 { background-image: var(--gradient-img_6329_1236); border:1px solid var(--border-img_6329_1236); color:var(--text-img_6329_1236); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1237: linear-gradient(180deg, #707070 0%, #343739 100%); --border-img_6329_1237: #696a6a; --text-img_6329_1237: #6e6e6e; }
+.btn-img_6329_1237 { background-image: var(--gradient-img_6329_1237); border:1px solid var(--border-img_6329_1237); color:var(--text-img_6329_1237); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1237 { background-image: var(--gradient-img_6329_1237); border:1px solid var(--border-img_6329_1237); color:var(--text-img_6329_1237); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1238: linear-gradient(180deg, #a0de92 0%, #343739 100%); --border-img_6329_1238: #7ca774; --text-img_6329_1238: #9edc90; }
+.btn-img_6329_1238 { background-image: var(--gradient-img_6329_1238); border:1px solid var(--border-img_6329_1238); color:var(--text-img_6329_1238); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1238 { background-image: var(--gradient-img_6329_1238); border:1px solid var(--border-img_6329_1238); color:var(--text-img_6329_1238); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1239: linear-gradient(180deg, #a0de92 0%, #343739 100%); --border-img_6329_1239: #8da888; --text-img_6329_1239: #9edc90; }
+.btn-img_6329_1239 { background-image: var(--gradient-img_6329_1239); border:1px solid var(--border-img_6329_1239); color:var(--text-img_6329_1239); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1239 { background-image: var(--gradient-img_6329_1239); border:1px solid var(--border-img_6329_1239); color:var(--text-img_6329_1239); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1240: linear-gradient(180deg, #e4e4e4 0%, #494d50 100%); --border-img_6329_1240: #909192; --text-img_6329_1240: #e5e5e5; }
+.btn-img_6329_1240 { background-image: var(--gradient-img_6329_1240); border:1px solid var(--border-img_6329_1240); color:var(--text-img_6329_1240); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1240 { background-image: var(--gradient-img_6329_1240); border:1px solid var(--border-img_6329_1240); color:var(--text-img_6329_1240); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1241: linear-gradient(180deg, #706f6f 0%, #343739 100%); --border-img_6329_1241: #646565; --text-img_6329_1241: #6e6e6d; }
+.btn-img_6329_1241 { background-image: var(--gradient-img_6329_1241); border:1px solid var(--border-img_6329_1241); color:var(--text-img_6329_1241); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1241 { background-image: var(--gradient-img_6329_1241); border:1px solid var(--border-img_6329_1241); color:var(--text-img_6329_1241); border-radius:.6rem; padding:1rem; }
+:root { --gradient-img_6329_1242: linear-gradient(180deg, #706f6f 0%, #343739 100%); --border-img_6329_1242: #696a6b; --text-img_6329_1242: #838383; }
+.btn-img_6329_1242 { background-image: var(--gradient-img_6329_1242); border:1px solid var(--border-img_6329_1242); color:var(--text-img_6329_1242); border-radius:.4rem; padding:.55rem 1rem; display:inline-flex; gap:.5rem; align-items:center; }
+.container-img_6329_1242 { background-image: var(--gradient-img_6329_1242); border:1px solid var(--border-img_6329_1242); color:var(--text-img_6329_1242); border-radius:.6rem; padding:1rem; }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3,8 +3,8 @@
   --gray-50: #FDFDFD;
   --gray-100: #D5D5D5;
   --gray-200: #B8BAB7;
-  --gray-600: #2F2F2F;
-  --gray-700: #313132;
+  --gray-600: #313132;
+  --gray-700: #2F2F2F;
   --gray-800: #212121;
   --gray-900: #161616;
   --brand-green-700: #456F3A;
@@ -55,7 +55,7 @@ body {
   font-family: "Helvetica Neue", Arial, sans-serif;
   font-size: 16px;
   line-height: 1.6;
-  background: linear-gradient(var(--gray-700), var(--gray-600));
+  background-color: #666;
   color: var(--color-white);
 }
 
@@ -300,7 +300,7 @@ a:hover, a:focus {
 }
 
 body.theme-dark {
-  background: linear-gradient(var(--gray-700), var(--gray-600));
+  background-color: #666;
   color: var(--color-white);
 }
 body.theme-dark a {

--- a/docs/canva-swatches.generated.html
+++ b/docs/canva-swatches.generated.html
@@ -1,0 +1,16151 @@
+<!-- AUTO-GENERATED CANVA SWATCH CATALOG (ALL) -->
+<section id='canva-swatches-all'><h2>Canva Swatch Catalog – ALL</h2>
+<p>Every detected swatch from the provided screenshots. Each uses the exact two-stop gradient, exact border, and cloud/text colour.</p>
+<div class='swatch-grid'>
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_001"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_001</span></button>
+    <div class="container-img_6314_001" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_001: linear-gradient(180deg, #f7f7f7 0%, #dcdcdc 100%);<br/>
+    --border-img_6314_001: #cccdcf;<br/>
+    --text-img_6314_001: #b4b4b4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_002"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_002</span></button>
+    <div class="container-img_6314_002" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_002: linear-gradient(180deg, #f7f7f7 0%, #e6e6e6 100%);<br/>
+    --border-img_6314_002: #d3d3d3;<br/>
+    --text-img_6314_002: #b4b4b4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_003"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_003</span></button>
+    <div class="container-img_6314_003" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_003: linear-gradient(180deg, #f7f7f7 0%, #e6e6e6 100%);<br/>
+    --border-img_6314_003: #d1d1d1;<br/>
+    --text-img_6314_003: #b4b4b4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_004"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_004</span></button>
+    <div class="container-img_6314_004" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_004: linear-gradient(180deg, #f7f7f7 0%, #e6e6e6 100%);<br/>
+    --border-img_6314_004: #d5d5d5;<br/>
+    --text-img_6314_004: #b4b4b4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_005"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_005</span></button>
+    <div class="container-img_6314_005" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_005: linear-gradient(180deg, #f7f7f7 0%, #dfdfdf 100%);<br/>
+    --border-img_6314_005: #cacdcf;<br/>
+    --text-img_6314_005: #b3b3b3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_006"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_006</span></button>
+    <div class="container-img_6314_006" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_006: linear-gradient(180deg, #f7f7f7 0%, #e0e0e0 100%);<br/>
+    --border-img_6314_006: #cacbcc;<br/>
+    --text-img_6314_006: #838383;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_007"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_007</span></button>
+    <div class="container-img_6314_007" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_007: linear-gradient(180deg, #f7f7f7 0%, #e0e0e0 100%);<br/>
+    --border-img_6314_007: #d6d6d6;<br/>
+    --text-img_6314_007: #838383;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_008"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_008</span></button>
+    <div class="container-img_6314_008" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_008: linear-gradient(180deg, #dfebf8 0%, #e0e0e0 100%);<br/>
+    --border-img_6314_008: #cbcdce;<br/>
+    --text-img_6314_008: #838383;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_009"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_009</span></button>
+    <div class="container-img_6314_009" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_009: linear-gradient(180deg, #f7f7f7 0%, #6f6f6f 100%);<br/>
+    --border-img_6314_009: #c7c8c9;<br/>
+    --text-img_6314_009: #616161;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_010"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_010</span></button>
+    <div class="container-img_6314_010" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_010: linear-gradient(180deg, #f1f1f1 0%, #d7d7d7 100%);<br/>
+    --border-img_6314_010: #d0d0d0;<br/>
+    --text-img_6314_010: #616161;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_011"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_011</span></button>
+    <div class="container-img_6314_011" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_011: linear-gradient(180deg, #f7f7f7 0%, #d7d7d7 100%);<br/>
+    --border-img_6314_011: #cfcfcf;<br/>
+    --text-img_6314_011: #616161;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_012"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_012</span></button>
+    <div class="container-img_6314_012" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_012: linear-gradient(180deg, #e9f0f7 0%, #859582 100%);<br/>
+    --border-img_6314_012: #c3c5c6;<br/>
+    --text-img_6314_012: #616161;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_013"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_013</span></button>
+    <div class="container-img_6314_013" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_013: linear-gradient(180deg, #cccdcd 0%, #cccccc 100%);<br/>
+    --border-img_6314_013: #9e9e9e;<br/>
+    --text-img_6314_013: #dddddd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_014"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_014</span></button>
+    <div class="container-img_6314_014" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_014: linear-gradient(180deg, #d4d4d5 0%, #c6c6c5 100%);<br/>
+    --border-img_6314_014: #d4d4d4;<br/>
+    --text-img_6314_014: #dedede;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_015"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_015</span></button>
+    <div class="container-img_6314_015" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_015: linear-gradient(180deg, #d4d5d5 0%, #e0e0e0 100%);<br/>
+    --border-img_6314_015: #d9d9d9;<br/>
+    --text-img_6314_015: #dedfdf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_016"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_016</span></button>
+    <div class="container-img_6314_016" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_016: linear-gradient(180deg, #d4d4d5 0%, #e0e0e0 100%);<br/>
+    --border-img_6314_016: #dbdbdb;<br/>
+    --text-img_6314_016: #dedede;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_017"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_017</span></button>
+    <div class="container-img_6314_017" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_017: linear-gradient(180deg, #a3aca2 0%, #d8d8d8 100%);<br/>
+    --border-img_6314_017: #a5a8a4;<br/>
+    --text-img_6314_017: #dddddd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_018"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_018</span></button>
+    <div class="container-img_6314_018" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_018: linear-gradient(180deg, #cccccc 0%, #e0e0e0 100%);<br/>
+    --border-img_6314_018: #bababa;<br/>
+    --text-img_6314_018: #b6b6b6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_019"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_019</span></button>
+    <div class="container-img_6314_019" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_019: linear-gradient(180deg, #cccccc 0%, #aeaeae 100%);<br/>
+    --border-img_6314_019: #d8d8d8;<br/>
+    --text-img_6314_019: #b9b9b9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_020"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_020</span></button>
+    <div class="container-img_6314_020" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_020: linear-gradient(180deg, #cccccc 0%, #cbd4c8 100%);<br/>
+    --border-img_6314_020: #bcbdbc;<br/>
+    --text-img_6314_020: #dedede;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_021"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_021</span></button>
+    <div class="container-img_6314_021" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_021: linear-gradient(180deg, #dddddd 0%, #9e9e9e 100%);<br/>
+    --border-img_6314_021: #a3a3a3;<br/>
+    --text-img_6314_021: #dadada;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_022"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_022</span></button>
+    <div class="container-img_6314_022" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_022: linear-gradient(180deg, #dedede 0%, #4f4f4f 100%);<br/>
+    --border-img_6314_022: #b2b5b2;<br/>
+    --text-img_6314_022: #e0e0e0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_023"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_023</span></button>
+    <div class="container-img_6314_023" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_023: linear-gradient(180deg, #dedede 0%, #8aba7d 100%);<br/>
+    --border-img_6314_023: #b8cbb3;<br/>
+    --text-img_6314_023: #cecece;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_024"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_024</span></button>
+    <div class="container-img_6314_024" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_024: linear-gradient(180deg, #dddddd 0%, #adc4a7 100%);<br/>
+    --border-img_6314_024: #a3ada1;<br/>
+    --text-img_6314_024: #dfdfdf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_025"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_025</span></button>
+    <div class="container-img_6314_025" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_025: linear-gradient(180deg, #d5d5d5 0%, #d7d7d7 100%);<br/>
+    --border-img_6314_025: #a5a5a5;<br/>
+    --text-img_6314_025: #e1e1e1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_026"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_026</span></button>
+    <div class="container-img_6314_026" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_026: linear-gradient(180deg, #e1e1e1 0%, #e5e5e5 100%);<br/>
+    --border-img_6314_026: #aeaeae;<br/>
+    --text-img_6314_026: #4b4b4b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_027"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_027</span></button>
+    <div class="container-img_6314_027" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_027: linear-gradient(180deg, #e2e2e2 0%, #94b78b 100%);<br/>
+    --border-img_6314_027: #aab5a7;<br/>
+    --text-img_6314_027: #8bc37c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_028"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_028</span></button>
+    <div class="container-img_6314_028" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_028: linear-gradient(180deg, #e1e1e1 0%, #587451 100%);<br/>
+    --border-img_6314_028: #b5c5b0;<br/>
+    --text-img_6314_028: #638f57;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_029"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_029</span></button>
+    <div class="container-img_6314_029" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_029: linear-gradient(180deg, #d9d9d9 0%, #d2d4d2 100%);<br/>
+    --border-img_6314_029: #9ea69b;<br/>
+    --text-img_6314_029: #e1e1e1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_030"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_030</span></button>
+    <div class="container-img_6314_030" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_030: linear-gradient(180deg, #777777 0%, #d6d6d6 100%);<br/>
+    --border-img_6314_030: #969696;<br/>
+    --text-img_6314_030: #838383;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_031"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_031</span></button>
+    <div class="container-img_6314_031" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_031: linear-gradient(180deg, #83b078 0%, #e5e6e5 100%);<br/>
+    --border-img_6314_031: #b1bbae;<br/>
+    --text-img_6314_031: #8eba84;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_032"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_032</span></button>
+    <div class="container-img_6314_032" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_032: linear-gradient(180deg, #89ae81 0%, #cecdcd 100%);<br/>
+    --border-img_6314_032: #9aa896;<br/>
+    --text-img_6314_032: #6a7b66;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_033"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_033</span></button>
+    <div class="container-img_6314_033" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_033: linear-gradient(180deg, #9a9a9a 0%, #d5d5d5 100%);<br/>
+    --border-img_6314_033: #a4a3a4;<br/>
+    --text-img_6314_033: #d8d8d8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_034"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_034</span></button>
+    <div class="container-img_6314_034" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_034: linear-gradient(180deg, #444444 0%, #eaeae9 100%);<br/>
+    --border-img_6314_034: #b3b8b1;<br/>
+    --text-img_6314_034: #d3d1d1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_035"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_035</span></button>
+    <div class="container-img_6314_035" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_035: linear-gradient(180deg, #789d6f 0%, #e5e4e3 100%);<br/>
+    --border-img_6314_035: #b2c2ae;<br/>
+    --text-img_6314_035: #cccaca;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_036"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_036</span></button>
+    <div class="container-img_6314_036" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_036: linear-gradient(180deg, #9fa99d 0%, #d3d2d2 100%);<br/>
+    --border-img_6314_036: #a4a8a2;<br/>
+    --text-img_6314_036: #d5d4d4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_037"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_037</span></button>
+    <div class="container-img_6314_037" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_037: linear-gradient(180deg, #d2d2d2 0%, #d4d4d4 100%);<br/>
+    --border-img_6314_037: #adacac;<br/>
+    --text-img_6314_037: #e6e6e6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_038"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_038</span></button>
+    <div class="container-img_6314_038" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_038: linear-gradient(180deg, #cccbcb 0%, #fefefe 100%);<br/>
+    --border-img_6314_038: #d5d4d4;<br/>
+    --text-img_6314_038: #9a9999;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_039"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_039</span></button>
+    <div class="container-img_6314_039" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_039: linear-gradient(180deg, #d6d3d3 0%, #fefefe 100%);<br/>
+    --border-img_6314_039: #d9d9d7;<br/>
+    --text-img_6314_039: #85b679;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_040"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_040</span></button>
+    <div class="container-img_6314_040" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_040: linear-gradient(180deg, #bbb9b9 0%, #fefefe 100%);<br/>
+    --border-img_6314_040: #cecccc;<br/>
+    --text-img_6314_040: #5f5f5f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_041"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_041</span></button>
+    <div class="container-img_6314_041" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_041: linear-gradient(180deg, #d4d4d4 0%, #d9d9d9 100%);<br/>
+    --border-img_6314_041: #a9a8a8;<br/>
+    --text-img_6314_041: #e6e6e6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_042"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_042</span></button>
+    <div class="container-img_6314_042" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_042: linear-gradient(180deg, #c9c9c9 0%, #a4cf98 100%);<br/>
+    --border-img_6314_042: #aeb6ac;<br/>
+    --text-img_6314_042: #c0c0c0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_043"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_043</span></button>
+    <div class="container-img_6314_043" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_043: linear-gradient(180deg, #95bf8b 0%, #e9e9e9 100%);<br/>
+    --border-img_6314_043: #dce0da;<br/>
+    --text-img_6314_043: #dddcdb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_044"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_044</span></button>
+    <div class="container-img_6314_044" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_044: linear-gradient(180deg, #c2c1c1 0%, #e9e9e9 100%);<br/>
+    --border-img_6314_044: #b9b8b8;<br/>
+    --text-img_6314_044: #c2c0c0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_045"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_045</span></button>
+    <div class="container-img_6314_045" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_045: linear-gradient(180deg, #d7d7d7 0%, #949494 100%);<br/>
+    --border-img_6314_045: #939b91;<br/>
+    --text-img_6314_045: #b3d1ac;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_046"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_046</span></button>
+    <div class="container-img_6314_046" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_046: linear-gradient(180deg, #cecccc 0%, #b7cdb1 100%);<br/>
+    --border-img_6314_046: #cbd4c8;<br/>
+    --text-img_6314_046: #cdcdcd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_047"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_047</span></button>
+    <div class="container-img_6314_047" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_047: linear-gradient(180deg, #d4d1d1 0%, #d7dcd5 100%);<br/>
+    --border-img_6314_047: #cad4c6;<br/>
+    --text-img_6314_047: #cecece;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_048"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_048</span></button>
+    <div class="container-img_6314_048" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_048: linear-gradient(180deg, #dad9d9 0%, #ebebeb 100%);<br/>
+    --border-img_6314_048: #bdbcbc;<br/>
+    --text-img_6314_048: #eaeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_049"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_049</span></button>
+    <div class="container-img_6314_049" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_049: linear-gradient(180deg, #dcdcdc 0%, #c5c5c5 100%);<br/>
+    --border-img_6314_049: #a0a79f;<br/>
+    --text-img_6314_049: #e9e9e9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_050"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_050</span></button>
+    <div class="container-img_6314_050" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_050: linear-gradient(180deg, #ebebeb 0%, #e6e6e6 100%);<br/>
+    --border-img_6314_050: #ccd6ca;<br/>
+    --text-img_6314_050: #e7e7e7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_051"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_051</span></button>
+    <div class="container-img_6314_051" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_051: linear-gradient(180deg, #ececec 0%, #67a658 100%);<br/>
+    --border-img_6314_051: #cad6c7;<br/>
+    --text-img_6314_051: #bebebe;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_052"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_052</span></button>
+    <div class="container-img_6314_052" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_052: linear-gradient(180deg, #ebebeb 0%, #e4e3e3 100%);<br/>
+    --border-img_6314_052: #e5e5e5;<br/>
+    --text-img_6314_052: #cfcece;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_053"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_053</span></button>
+    <div class="container-img_6314_053" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_053: linear-gradient(180deg, #e1e1e1 0%, #e3e3e3 100%);<br/>
+    --border-img_6314_053: #bfbfbf;<br/>
+    --text-img_6314_053: #e9e9e9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_054"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_054</span></button>
+    <div class="container-img_6314_054" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_054: linear-gradient(180deg, #97c08e 0%, #c3e8bb 100%);<br/>
+    --border-img_6314_054: #b3c0b0;<br/>
+    --text-img_6314_054: #638959;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_055"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_055</span></button>
+    <div class="container-img_6314_055" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_055: linear-gradient(180deg, #e6e5e5 0%, #67a658 100%);<br/>
+    --border-img_6314_055: #cdd7c9;<br/>
+    --text-img_6314_055: #67a658;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_056"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_056</span></button>
+    <div class="container-img_6314_056" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_056: linear-gradient(180deg, #e9e8e8 0%, #e7e7e7 100%);<br/>
+    --border-img_6314_056: #c2c4c1;<br/>
+    --text-img_6314_056: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_057"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_057</span></button>
+    <div class="container-img_6314_057" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_057: linear-gradient(180deg, #b6b6b5 0%, #cfd9cc 100%);<br/>
+    --border-img_6314_057: #9ba798;<br/>
+    --text-img_6314_057: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_058"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_058</span></button>
+    <div class="container-img_6314_058" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_058: linear-gradient(180deg, #e2e2e1 0%, #e1dfdf 100%);<br/>
+    --border-img_6314_058: #b6c9b1;<br/>
+    --text-img_6314_058: #dedbdb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_059"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_059</span></button>
+    <div class="container-img_6314_059" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_059: linear-gradient(180deg, #67a658 0%, #dad7d7 100%);<br/>
+    --border-img_6314_059: #a8c5a0;<br/>
+    --text-img_6314_059: #b8cab2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_060"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_060</span></button>
+    <div class="container-img_6314_060" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_060: linear-gradient(180deg, #a7c49f 0%, #dad7d7 100%);<br/>
+    --border-img_6314_060: #c8d5c4;<br/>
+    --text-img_6314_060: #dcdbda;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_061"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_061</span></button>
+    <div class="container-img_6314_061" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_061: linear-gradient(180deg, #e3e3e3 0%, #e4e4e4 100%);<br/>
+    --border-img_6314_061: #c1c1c1;<br/>
+    --text-img_6314_061: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_062"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_062</span></button>
+    <div class="container-img_6314_062" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_062: linear-gradient(180deg, #ececec 0%, #ececec 100%);<br/>
+    --border-img_6314_062: #a3aaa2;<br/>
+    --text-img_6314_062: #cce2c7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_063"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_063</span></button>
+    <div class="container-img_6314_063" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_063: linear-gradient(180deg, #81b275 0%, #f2f2f2 100%);<br/>
+    --border-img_6314_063: #d0ddcc;<br/>
+    --text-img_6314_063: #d8d6d6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_064"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_064</span></button>
+    <div class="container-img_6314_064" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_064: linear-gradient(180deg, #67a658 0%, #f2f2f2 100%);<br/>
+    --border-img_6314_064: #c7d7c3;<br/>
+    --text-img_6314_064: #d9d7d7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_065"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_065</span></button>
+    <div class="container-img_6314_065" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_065: linear-gradient(180deg, #ececec 0%, #ececec 100%);<br/>
+    --border-img_6314_065: #c2c1c1;<br/>
+    --text-img_6314_065: #ededed;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_066"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_066</span></button>
+    <div class="container-img_6314_066" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_066: linear-gradient(180deg, #b2dba8 0%, #ededed 100%);<br/>
+    --border-img_6314_066: #c0c6bf;<br/>
+    --text-img_6314_066: #ededed;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_067"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_067</span></button>
+    <div class="container-img_6314_067" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_067: linear-gradient(180deg, #dbd8d8 0%, #f1f1f1 100%);<br/>
+    --border-img_6314_067: #e8e8e7;<br/>
+    --text-img_6314_067: #f3f3f3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_068"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_068</span></button>
+    <div class="container-img_6314_068" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_068: linear-gradient(180deg, #e7e6e6 0%, #ededed 100%);<br/>
+    --border-img_6314_068: #cacaca;<br/>
+    --text-img_6314_068: #ededed;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_069"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_069</span></button>
+    <div class="container-img_6314_069" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_069: linear-gradient(180deg, #e0e0e0 0%, #e2e2e2 100%);<br/>
+    --border-img_6314_069: #c2c2c2;<br/>
+    --text-img_6314_069: #ebebeb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_070"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_070</span></button>
+    <div class="container-img_6314_070" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_070: linear-gradient(180deg, #f0f0f0 0%, #b5b5b5 100%);<br/>
+    --border-img_6314_070: #e5e5e5;<br/>
+    --text-img_6314_070: #efefef;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_071"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_071</span></button>
+    <div class="container-img_6314_071" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_071: linear-gradient(180deg, #f3f4f3 0%, #f6f7f6 100%);<br/>
+    --border-img_6314_071: #eaeee9;<br/>
+    --text-img_6314_071: #f2f2f2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_072"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_072</span></button>
+    <div class="container-img_6314_072" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_072: linear-gradient(180deg, #f0f0f0 0%, #fbfbfb 100%);<br/>
+    --border-img_6314_072: #f4f4f4;<br/>
+    --text-img_6314_072: #efeff0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_073"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_073</span></button>
+    <div class="container-img_6314_073" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_073: linear-gradient(180deg, #e4e4e4 0%, #e7e8e7 100%);<br/>
+    --border-img_6314_073: #c4c4c4;<br/>
+    --text-img_6314_073: #ebebeb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_074"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_074</span></button>
+    <div class="container-img_6314_074" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_074: linear-gradient(180deg, #ececec 0%, #e9e9e9 100%);<br/>
+    --border-img_6314_074: #c3c3c3;<br/>
+    --text-img_6314_074: #f2f2f2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_075"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_075</span></button>
+    <div class="container-img_6314_075" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_075: linear-gradient(180deg, #f0f0f0 0%, #f7f7f7 100%);<br/>
+    --border-img_6314_075: #eeeeee;<br/>
+    --text-img_6314_075: #f7f7f7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_076"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_076</span></button>
+    <div class="container-img_6314_076" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_076: linear-gradient(180deg, #f0f0f0 0%, #f0f0f0 100%);<br/>
+    --border-img_6314_076: #f2f2f2;<br/>
+    --text-img_6314_076: #f6f7f6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_077"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_077</span></button>
+    <div class="container-img_6314_077" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_077: linear-gradient(180deg, #ececec 0%, #ececec 100%);<br/>
+    --border-img_6314_077: #c7c7c7;<br/>
+    --text-img_6314_077: #f1f3f1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_078"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_078</span></button>
+    <div class="container-img_6314_078" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_078: linear-gradient(180deg, #f2f2f2 0%, #f3f3f3 100%);<br/>
+    --border-img_6314_078: #c9c9c9;<br/>
+    --text-img_6314_078: #f6f6f6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_079"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_079</span></button>
+    <div class="container-img_6314_079" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_079: linear-gradient(180deg, #caddc6 0%, #ecedec 100%);<br/>
+    --border-img_6314_079: #f1f2f1;<br/>
+    --text-img_6314_079: #f0f1f0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_080"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_080</span></button>
+    <div class="container-img_6314_080" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_080: linear-gradient(180deg, #f6f7f6 0%, #ebebeb 100%);<br/>
+    --border-img_6314_080: #d1d1d1;<br/>
+    --text-img_6314_080: #f3f3f3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_081"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_081</span></button>
+    <div class="container-img_6314_081" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_081: linear-gradient(180deg, #e2e2e2 0%, #e1e0e0 100%);<br/>
+    --border-img_6314_081: #c3c2c2;<br/>
+    --text-img_6314_081: #e8e8e8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_082"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_082</span></button>
+    <div class="container-img_6314_082" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_082: linear-gradient(180deg, #f2f3f2 0%, #e9eae9 100%);<br/>
+    --border-img_6314_082: #f1f2f1;<br/>
+    --text-img_6314_082: #edefed;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_083"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_083</span></button>
+    <div class="container-img_6314_083" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_083: linear-gradient(180deg, #f6f6f6 0%, #eaeaea 100%);<br/>
+    --border-img_6314_083: #f0f0f0;<br/>
+    --text-img_6314_083: #f0f0f0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_084"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_084</span></button>
+    <div class="container-img_6314_084" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_084: linear-gradient(180deg, #e5e6e5 0%, #e0e0e0 100%);<br/>
+    --border-img_6314_084: #c2c3c2;<br/>
+    --text-img_6314_084: #e6e8e6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_085"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_085</span></button>
+    <div class="container-img_6314_085" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_085: linear-gradient(180deg, #f0f0f0 0%, #f6f6f6 100%);<br/>
+    --border-img_6314_085: #cbd2ca;<br/>
+    --text-img_6314_085: #c8e3c2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_086"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_086</span></button>
+    <div class="container-img_6314_086" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_086: linear-gradient(180deg, #f7f7f7 0%, #f6f6f6 100%);<br/>
+    --border-img_6314_086: #e6eae5;<br/>
+    --text-img_6314_086: #b9e6b0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_087"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_087</span></button>
+    <div class="container-img_6314_087" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_087: linear-gradient(180deg, #e9e9e9 0%, #f6f6f6 100%);<br/>
+    --border-img_6314_087: #d4d5d5;<br/>
+    --text-img_6314_087: #949494;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_088"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_088</span></button>
+    <div class="container-img_6314_088" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_088: linear-gradient(180deg, #e7e8e7 0%, #f6f6f6 100%);<br/>
+    --border-img_6314_088: #c4c4c4;<br/>
+    --text-img_6314_088: #aaaaaa;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_089"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_089</span></button>
+    <div class="container-img_6314_089" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_089: linear-gradient(180deg, #f4f4f4 0%, #f6f6f6 100%);<br/>
+    --border-img_6314_089: #d2d6d1;<br/>
+    --text-img_6314_089: #ade9a0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_090"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_090</span></button>
+    <div class="container-img_6314_090" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_090: linear-gradient(180deg, #e9e9e9 0%, #f6f6f6 100%);<br/>
+    --border-img_6314_090: #dee4dc;<br/>
+    --text-img_6314_090: #919191;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_091"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_091</span></button>
+    <div class="container-img_6314_091" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_091: linear-gradient(180deg, #e6e6e6 0%, #f6f6f6 100%);<br/>
+    --border-img_6314_091: #cacbcc;<br/>
+    --text-img_6314_091: #7b7b7b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_092"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_092</span></button>
+    <div class="container-img_6314_092" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_092: linear-gradient(180deg, #cfcfcf 0%, #f6f7f7 100%);<br/>
+    --border-img_6314_092: #c9d2c8;<br/>
+    --text-img_6314_092: #e5e5e5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_093"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_093</span></button>
+    <div class="container-img_6314_093" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_093: linear-gradient(180deg, #c0c0c0 0%, #f6f6f6 100%);<br/>
+    --border-img_6314_093: #e0f0dd;<br/>
+    --text-img_6314_093: #687e63;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_094"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_094</span></button>
+    <div class="container-img_6314_094" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_094: linear-gradient(180deg, #e9e9e9 0%, #f6f6f6 100%);<br/>
+    --border-img_6314_094: #d5ded4;<br/>
+    --text-img_6314_094: #797979;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_095"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_095</span></button>
+    <div class="container-img_6314_095" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_095: linear-gradient(180deg, #e9e8e9 0%, #f6f6f6 100%);<br/>
+    --border-img_6314_095: #cbccce;<br/>
+    --text-img_6314_095: #7a7a7a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6314_096"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6314_096</span></button>
+    <div class="container-img_6314_096" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6314_096: linear-gradient(180deg, #dfdfdf 0%, #f6f6f6 100%);<br/>
+    --border-img_6314_096: #bdbfc1;<br/>
+    --text-img_6314_096: #deddde;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_097"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_097</span></button>
+    <div class="container-img_6318_097" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_097: linear-gradient(180deg, #5e6367 0%, #9d9d9d 100%);<br/>
+    --border-img_6318_097: #6e7072;<br/>
+    --text-img_6318_097: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_098"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_098</span></button>
+    <div class="container-img_6318_098" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_098: linear-gradient(180deg, #5e6367 0%, #2e2e2e 100%);<br/>
+    --border-img_6318_098: #444748;<br/>
+    --text-img_6318_098: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_099"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_099</span></button>
+    <div class="container-img_6318_099" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_099: linear-gradient(180deg, #5e6367 0%, #2e2e2e 100%);<br/>
+    --border-img_6318_099: #46484a;<br/>
+    --text-img_6318_099: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_100"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_100</span></button>
+    <div class="container-img_6318_100" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_100: linear-gradient(180deg, #5e6367 0%, #2e2e2e 100%);<br/>
+    --border-img_6318_100: #424547;<br/>
+    --text-img_6318_100: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_101"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_101</span></button>
+    <div class="container-img_6318_101" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_101: linear-gradient(180deg, #5e6367 0%, #2e2e2e 100%);<br/>
+    --border-img_6318_101: #434647;<br/>
+    --text-img_6318_101: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_102"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_102</span></button>
+    <div class="container-img_6318_102" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_102: linear-gradient(180deg, #5e6367 0%, #747474 100%);<br/>
+    --border-img_6318_102: #696c6d;<br/>
+    --text-img_6318_102: #36383a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_103"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_103</span></button>
+    <div class="container-img_6318_103" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_103: linear-gradient(180deg, #5e6367 0%, #2c2c2c 100%);<br/>
+    --border-img_6318_103: #454749;<br/>
+    --text-img_6318_103: #36383a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_104"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_104</span></button>
+    <div class="container-img_6318_104" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_104: linear-gradient(180deg, #5e6367 0%, #2c2c2c 100%);<br/>
+    --border-img_6318_104: #454749;<br/>
+    --text-img_6318_104: #36383a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_105"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_105</span></button>
+    <div class="container-img_6318_105" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_105: linear-gradient(180deg, #5e6367 0%, #454545 100%);<br/>
+    --border-img_6318_105: #545658;<br/>
+    --text-img_6318_105: #313232;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_106"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_106</span></button>
+    <div class="container-img_6318_106" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_106: linear-gradient(180deg, #5e6367 0%, #292929 100%);<br/>
+    --border-img_6318_106: #434547;<br/>
+    --text-img_6318_106: #313232;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_107"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_107</span></button>
+    <div class="container-img_6318_107" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_107: linear-gradient(180deg, #5e6367 0%, #292929 100%);<br/>
+    --border-img_6318_107: #444748;<br/>
+    --text-img_6318_107: #313232;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_108"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_108</span></button>
+    <div class="container-img_6318_108" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_108: linear-gradient(180deg, #5e6367 0%, #292929 100%);<br/>
+    --border-img_6318_108: #434547;<br/>
+    --text-img_6318_108: #313232;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_109"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_109</span></button>
+    <div class="container-img_6318_109" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_109: linear-gradient(180deg, #282828 0%, #414141 100%);<br/>
+    --border-img_6318_109: #414141;<br/>
+    --text-img_6318_109: #292929;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_110"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_110</span></button>
+    <div class="container-img_6318_110" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_110: linear-gradient(180deg, #282828 0%, #414141 100%);<br/>
+    --border-img_6318_110: #333333;<br/>
+    --text-img_6318_110: #292929;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_111"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_111</span></button>
+    <div class="container-img_6318_111" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_111: linear-gradient(180deg, #282828 0%, #414141 100%);<br/>
+    --border-img_6318_111: #333333;<br/>
+    --text-img_6318_111: #292929;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_112"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_112</span></button>
+    <div class="container-img_6318_112" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_112: linear-gradient(180deg, #282828 0%, #414141 100%);<br/>
+    --border-img_6318_112: #333333;<br/>
+    --text-img_6318_112: #292929;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_113"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_113</span></button>
+    <div class="container-img_6318_113" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_113: linear-gradient(180deg, #282828 0%, #414141 100%);<br/>
+    --border-img_6318_113: #333333;<br/>
+    --text-img_6318_113: #292929;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_114"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_114</span></button>
+    <div class="container-img_6318_114" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_114: linear-gradient(180deg, #262626 0%, #414141 100%);<br/>
+    --border-img_6318_114: #353535;<br/>
+    --text-img_6318_114: #414141;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_115"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_115</span></button>
+    <div class="container-img_6318_115" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_115: linear-gradient(180deg, #262626 0%, #414141 100%);<br/>
+    --border-img_6318_115: #353535;<br/>
+    --text-img_6318_115: #414141;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_116"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_116</span></button>
+    <div class="container-img_6318_116" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_116: linear-gradient(180deg, #262626 0%, #414141 100%);<br/>
+    --border-img_6318_116: #353535;<br/>
+    --text-img_6318_116: #414141;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_117"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_117</span></button>
+    <div class="container-img_6318_117" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_117: linear-gradient(180deg, #222222 0%, #414141 100%);<br/>
+    --border-img_6318_117: #393b39;<br/>
+    --text-img_6318_117: #414141;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_118"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_118</span></button>
+    <div class="container-img_6318_118" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_118: linear-gradient(180deg, #222222 0%, #414141 100%);<br/>
+    --border-img_6318_118: #393b39;<br/>
+    --text-img_6318_118: #414141;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_119"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_119</span></button>
+    <div class="container-img_6318_119" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_119: linear-gradient(180deg, #222222 0%, #414141 100%);<br/>
+    --border-img_6318_119: #393b39;<br/>
+    --text-img_6318_119: #414141;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_120"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_120</span></button>
+    <div class="container-img_6318_120" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_120: linear-gradient(180deg, #222222 0%, #414141 100%);<br/>
+    --border-img_6318_120: #393b39;<br/>
+    --text-img_6318_120: #414141;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_121"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_121</span></button>
+    <div class="container-img_6318_121" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_121: linear-gradient(180deg, #414141 0%, #a6e398 100%);<br/>
+    --border-img_6318_121: #76956f;<br/>
+    --text-img_6318_121: #84ad7c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_122"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_122</span></button>
+    <div class="container-img_6318_122" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_122: linear-gradient(180deg, #414141 0%, #a6e398 100%);<br/>
+    --border-img_6318_122: #76956f;<br/>
+    --text-img_6318_122: #84ad7c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_123"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_123</span></button>
+    <div class="container-img_6318_123" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_123: linear-gradient(180deg, #414141 0%, #a6e398 100%);<br/>
+    --border-img_6318_123: #76956f;<br/>
+    --text-img_6318_123: #84ad7c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_124"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_124</span></button>
+    <div class="container-img_6318_124" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_124: linear-gradient(180deg, #414141 0%, #a6e398 100%);<br/>
+    --border-img_6318_124: #76956f;<br/>
+    --text-img_6318_124: #84ad7c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_125"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_125</span></button>
+    <div class="container-img_6318_125" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_125: linear-gradient(180deg, #414141 0%, #a6e398 100%);<br/>
+    --border-img_6318_125: #75946e;<br/>
+    --text-img_6318_125: #84ad7c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_126"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_126</span></button>
+    <div class="container-img_6318_126" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_126: linear-gradient(180deg, #414141 0%, #484d46 100%);<br/>
+    --border-img_6318_126: #6f8c68;<br/>
+    --text-img_6318_126: #a7e49a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_127"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_127</span></button>
+    <div class="container-img_6318_127" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_127: linear-gradient(180deg, #414141 0%, #789771 100%);<br/>
+    --border-img_6318_127: #73916d;<br/>
+    --text-img_6318_127: #a7e49a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_128"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_128</span></button>
+    <div class="container-img_6318_128" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_128: linear-gradient(180deg, #414141 0%, #7d9f74 100%);<br/>
+    --border-img_6318_128: #779970;<br/>
+    --text-img_6318_128: #a7e49a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_129"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_129</span></button>
+    <div class="container-img_6318_129" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_129: linear-gradient(180deg, #a8e59b 0%, #8fd07f 100%);<br/>
+    --border-img_6318_129: #96d188;<br/>
+    --text-img_6318_129: #4a5148;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_130"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_130</span></button>
+    <div class="container-img_6318_130" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_130: linear-gradient(180deg, #a8e59b 0%, #8fd07f 100%);<br/>
+    --border-img_6318_130: #96d089;<br/>
+    --text-img_6318_130: #85ae7b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_131"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_131</span></button>
+    <div class="container-img_6318_131" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_131: linear-gradient(180deg, #a8e59b 0%, #8fd07f 100%);<br/>
+    --border-img_6318_131: #95cf88;<br/>
+    --text-img_6318_131: #7da074;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_132"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_132</span></button>
+    <div class="container-img_6318_132" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_132: linear-gradient(180deg, #a8e59b 0%, #8fd07f 100%);<br/>
+    --border-img_6318_132: #99d58b;<br/>
+    --text-img_6318_132: #7ea276;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_133"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_133</span></button>
+    <div class="container-img_6318_133" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_133: linear-gradient(180deg, #81ab76 0%, #7ab16e 100%);<br/>
+    --border-img_6318_133: #709367;<br/>
+    --text-img_6318_133: #94d484;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_134"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_134</span></button>
+    <div class="container-img_6318_134" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_134: linear-gradient(180deg, #99d28b 0%, #7ab16e 100%);<br/>
+    --border-img_6318_134: #769c6d;<br/>
+    --text-img_6318_134: #94d484;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_135"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_135</span></button>
+    <div class="container-img_6318_135" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_135: linear-gradient(180deg, #748f6e 0%, #7ab16e 100%);<br/>
+    --border-img_6318_135: #779e6e;<br/>
+    --text-img_6318_135: #94d484;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_136"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_136</span></button>
+    <div class="container-img_6318_136" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_136: linear-gradient(180deg, #76916f 0%, #7ab16e 100%);<br/>
+    --border-img_6318_136: #72946a;<br/>
+    --text-img_6318_136: #94d484;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_137"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_137</span></button>
+    <div class="container-img_6318_137" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_137: linear-gradient(180deg, #8ebd82 0%, #7ab16e 100%);<br/>
+    --border-img_6318_137: #789e6e;<br/>
+    --text-img_6318_137: #94d484;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_138"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_138</span></button>
+    <div class="container-img_6318_138" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_138: linear-gradient(180deg, #93d383 0%, #404040 100%);<br/>
+    --border-img_6318_138: #63855b;<br/>
+    --text-img_6318_138: #474e46;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_139"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_139</span></button>
+    <div class="container-img_6318_139" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_139: linear-gradient(180deg, #93d383 0%, #404040 100%);<br/>
+    --border-img_6318_139: #6e8c66;<br/>
+    --text-img_6318_139: #474e46;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_140"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_140</span></button>
+    <div class="container-img_6318_140" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_140: linear-gradient(180deg, #93d383 0%, #404040 100%);<br/>
+    --border-img_6318_140: #6b8963;<br/>
+    --text-img_6318_140: #474e46;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_141"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_141</span></button>
+    <div class="container-img_6318_141" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_141: linear-gradient(180deg, #404040 0%, #7daa71 100%);<br/>
+    --border-img_6318_141: #5b6a57;<br/>
+    --text-img_6318_141: #569348;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_142"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_142</span></button>
+    <div class="container-img_6318_142" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_142: linear-gradient(180deg, #404040 0%, #4d6448 100%);<br/>
+    --border-img_6318_142: #496343;<br/>
+    --text-img_6318_142: #3f413e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_143"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_143</span></button>
+    <div class="container-img_6318_143" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_143: linear-gradient(180deg, #404040 0%, #8dab86 100%);<br/>
+    --border-img_6318_143: #5e7159;<br/>
+    --text-img_6318_143: #5b8152;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_144"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_144</span></button>
+    <div class="container-img_6318_144" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_144: linear-gradient(180deg, #404040 0%, #4e7644 100%);<br/>
+    --border-img_6318_144: #566053;<br/>
+    --text-img_6318_144: #537a49;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_145"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_145</span></button>
+    <div class="container-img_6318_145" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_145: linear-gradient(180deg, #404040 0%, #569647 100%);<br/>
+    --border-img_6318_145: #4b6145;<br/>
+    --text-img_6318_145: #5c9c4d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_146"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_146</span></button>
+    <div class="container-img_6318_146" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_146: linear-gradient(180deg, #404040 0%, #569647 100%);<br/>
+    --border-img_6318_146: #485e42;<br/>
+    --text-img_6318_146: #5c9c4d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_147"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_147</span></button>
+    <div class="container-img_6318_147" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_147: linear-gradient(180deg, #404040 0%, #4a793d 100%);<br/>
+    --border-img_6318_147: #495945;<br/>
+    --text-img_6318_147: #537c49;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_148"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_148</span></button>
+    <div class="container-img_6318_148" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_148: linear-gradient(180deg, #404040 0%, #4f7d43 100%);<br/>
+    --border-img_6318_148: #465642;<br/>
+    --text-img_6318_148: #547c49;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_149"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_149</span></button>
+    <div class="container-img_6318_149" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_149: linear-gradient(180deg, #404040 0%, #4a793d 100%);<br/>
+    --border-img_6318_149: #485843;<br/>
+    --text-img_6318_149: #4e7843;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_150"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_150</span></button>
+    <div class="container-img_6318_150" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_150: linear-gradient(180deg, #5b9c4c 0%, #468237 100%);<br/>
+    --border-img_6318_150: #4e7e42;<br/>
+    --text-img_6318_150: #eae8e7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_151"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_151</span></button>
+    <div class="container-img_6318_151" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_151: linear-gradient(180deg, #4e7643 0%, #558548 100%);<br/>
+    --border-img_6318_151: #55714e;<br/>
+    --text-img_6318_151: #89a981;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_152"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_152</span></button>
+    <div class="container-img_6318_152" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_152: linear-gradient(180deg, #4c6246 0%, #4f6a49 100%);<br/>
+    --border-img_6318_152: #5f8356;<br/>
+    --text-img_6318_152: #51694b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_153"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_153</span></button>
+    <div class="container-img_6318_153" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_153: linear-gradient(180deg, #aac2a1 0%, #403f3f 100%);<br/>
+    --border-img_6318_153: #626f5d;<br/>
+    --text-img_6318_153: #458136;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_154"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_154</span></button>
+    <div class="container-img_6318_154" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_154: linear-gradient(180deg, #a3be9a 0%, #403f3f 100%);<br/>
+    --border-img_6318_154: #616e5c;<br/>
+    --text-img_6318_154: #458136;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_155"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_155</span></button>
+    <div class="container-img_6318_155" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_155: linear-gradient(180deg, #b8cbb4 0%, #403f3f 100%);<br/>
+    --border-img_6318_155: #6a7667;<br/>
+    --text-img_6318_155: #508842;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_156"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_156</span></button>
+    <div class="container-img_6318_156" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_156: linear-gradient(180deg, #a2bb9b 0%, #403f3f 100%);<br/>
+    --border-img_6318_156: #667262;<br/>
+    --text-img_6318_156: #508842;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_157"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_157</span></button>
+    <div class="container-img_6318_157" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_157: linear-gradient(180deg, #b6c9b1 0%, #403f3f 100%);<br/>
+    --border-img_6318_157: #697565;<br/>
+    --text-img_6318_157: #508842;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_158"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_158</span></button>
+    <div class="container-img_6318_158" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_158: linear-gradient(180deg, #4a863a 0%, #436b38 100%);<br/>
+    --border-img_6318_158: #5d7257;<br/>
+    --text-img_6318_158: #3b5634;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_159"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_159</span></button>
+    <div class="container-img_6318_159" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_159: linear-gradient(180deg, #4a6045 0%, #44593f 100%);<br/>
+    --border-img_6318_159: #506f47;<br/>
+    --text-img_6318_159: #403f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_160"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_160</span></button>
+    <div class="container-img_6318_160" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_160: linear-gradient(180deg, #4f8441 0%, #436b38 100%);<br/>
+    --border-img_6318_160: #6f8d67;<br/>
+    --text-img_6318_160: #5e7858;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_161"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_161</span></button>
+    <div class="container-img_6318_161" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_161: linear-gradient(180deg, #517d46 0%, #4a6942 100%);<br/>
+    --border-img_6318_161: #5c6d57;<br/>
+    --text-img_6318_161: #56704f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_162"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_162</span></button>
+    <div class="container-img_6318_162" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_162: linear-gradient(180deg, #40403f 0%, #3f6335 100%);<br/>
+    --border-img_6318_162: #486540;<br/>
+    --text-img_6318_162: #426838;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_163"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_163</span></button>
+    <div class="container-img_6318_163" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_163: linear-gradient(180deg, #a8b0a6 0%, #42653a 100%);<br/>
+    --border-img_6318_163: #4f6a48;<br/>
+    --text-img_6318_163: #4f7c43;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_164"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_164</span></button>
+    <div class="container-img_6318_164" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_164: linear-gradient(180deg, #5c6459 0%, #475a42 100%);<br/>
+    --border-img_6318_164: #506c49;<br/>
+    --text-img_6318_164: #545d51;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_165"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_165</span></button>
+    <div class="container-img_6318_165" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_165: linear-gradient(180deg, #436b39 0%, #97a693 100%);<br/>
+    --border-img_6318_165: #646f61;<br/>
+    --text-img_6318_165: #406536;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_166"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_166</span></button>
+    <div class="container-img_6318_166" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_166: linear-gradient(180deg, #446d39 0%, #9caa98 100%);<br/>
+    --border-img_6318_166: #616d5e;<br/>
+    --text-img_6318_166: #406536;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_167"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_167</span></button>
+    <div class="container-img_6318_167" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_167: linear-gradient(180deg, #46703b 0%, #9ec694 100%);<br/>
+    --border-img_6318_167: #6f8d67;<br/>
+    --text-img_6318_167: #406536;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_168"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_168</span></button>
+    <div class="container-img_6318_168" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_168: linear-gradient(180deg, #4c7641 0%, #88b07e 100%);<br/>
+    --border-img_6318_168: #65805e;<br/>
+    --text-img_6318_168: #406536;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_169"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_169</span></button>
+    <div class="container-img_6318_169" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_169: linear-gradient(180deg, #48703e 0%, #acb6a7 100%);<br/>
+    --border-img_6318_169: #7d847a;<br/>
+    --text-img_6318_169: #406536;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_170"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_170</span></button>
+    <div class="container-img_6318_170" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_170: linear-gradient(180deg, #5d7a55 0%, #3f3f3f 100%);<br/>
+    --border-img_6318_170: #4c5849;<br/>
+    --text-img_6318_170: #536d4d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_171"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_171</span></button>
+    <div class="container-img_6318_171" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_171: linear-gradient(180deg, #43563e 0%, #3f3f3f 100%);<br/>
+    --border-img_6318_171: #485b43;<br/>
+    --text-img_6318_171: #3c443a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_172"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_172</span></button>
+    <div class="container-img_6318_172" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_172: linear-gradient(180deg, #6e9464 0%, #3f3f3f 100%);<br/>
+    --border-img_6318_172: #4b6445;<br/>
+    --text-img_6318_172: #5c7e54;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_173"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_173</span></button>
+    <div class="container-img_6318_173" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_173: linear-gradient(180deg, #47633f 0%, #3f3f3f 100%);<br/>
+    --border-img_6318_173: #525b4f;<br/>
+    --text-img_6318_173: #3b5a33;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_174"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_174</span></button>
+    <div class="container-img_6318_174" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_174: linear-gradient(180deg, #d7d9d6 0%, #3f3f3f 100%);<br/>
+    --border-img_6318_174: #677164;<br/>
+    --text-img_6318_174: #37522f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_175"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_175</span></button>
+    <div class="container-img_6318_175" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_175: linear-gradient(180deg, #9ac191 0%, #3f3f3f 100%);<br/>
+    --border-img_6318_175: #5c6b58;<br/>
+    --text-img_6318_175: #37532f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_176"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_176</span></button>
+    <div class="container-img_6318_176" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_176: linear-gradient(180deg, #687264 0%, #3f3f3f 100%);<br/>
+    --border-img_6318_176: #596455;<br/>
+    --text-img_6318_176: #4e594c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_177"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_177</span></button>
+    <div class="container-img_6318_177" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_177: linear-gradient(180deg, #385631 0%, #78b967 100%);<br/>
+    --border-img_6318_177: #4b6444;<br/>
+    --text-img_6318_177: #3c423a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_178"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_178</span></button>
+    <div class="container-img_6318_178" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_178: linear-gradient(180deg, #385631 0%, #7dc46a 100%);<br/>
+    --border-img_6318_178: #4c6745;<br/>
+    --text-img_6318_178: #3c423a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_179"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_179</span></button>
+    <div class="container-img_6318_179" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_179: linear-gradient(180deg, #395631 0%, #88ca77 100%);<br/>
+    --border-img_6318_179: #506b49;<br/>
+    --text-img_6318_179: #4c6047;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_180"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_180</span></button>
+    <div class="container-img_6318_180" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_180: linear-gradient(180deg, #3c5b34 0%, #87c975 100%);<br/>
+    --border-img_6318_180: #506a49;<br/>
+    --text-img_6318_180: #4c6047;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_181"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_181</span></button>
+    <div class="container-img_6318_181" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_181: linear-gradient(180deg, #395631 0%, #84c972 100%);<br/>
+    --border-img_6318_181: #4f6948;<br/>
+    --text-img_6318_181: #565c54;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_182"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_182</span></button>
+    <div class="container-img_6318_182" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_182: linear-gradient(180deg, #7cc26a 0%, #343739 100%);<br/>
+    --border-img_6318_182: #62795d;<br/>
+    --text-img_6318_182: #83c074;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_183"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_183</span></button>
+    <div class="container-img_6318_183" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_183: linear-gradient(180deg, #597751 0%, #343739 100%);<br/>
+    --border-img_6318_183: #698f61;<br/>
+    --text-img_6318_183: #516a4b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_184"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_184</span></button>
+    <div class="container-img_6318_184" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_184: linear-gradient(180deg, #7dc36a 0%, #343739 100%);<br/>
+    --border-img_6318_184: #719c67;<br/>
+    --text-img_6318_184: #9fb699;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_185"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_185</span></button>
+    <div class="container-img_6318_185" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_185: linear-gradient(180deg, #71a663 0%, #343739 100%);<br/>
+    --border-img_6318_185: #647961;<br/>
+    --text-img_6318_185: #74b863;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_186"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_186</span></button>
+    <div class="container-img_6318_186" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_186: linear-gradient(180deg, #79bf67 0%, #343739 100%);<br/>
+    --border-img_6318_186: #5c7856;<br/>
+    --text-img_6318_186: #f6faf5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_187"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_187</span></button>
+    <div class="container-img_6318_187" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_187: linear-gradient(180deg, #78b168 0%, #3c4042 100%);<br/>
+    --border-img_6318_187: #64855e;<br/>
+    --text-img_6318_187: #6e9e62;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_188"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_188</span></button>
+    <div class="container-img_6318_188" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_188: linear-gradient(180deg, #688b5e 0%, #343739 100%);<br/>
+    --border-img_6318_188: #72906c;<br/>
+    --text-img_6318_188: #5d7956;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_189"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_189</span></button>
+    <div class="container-img_6318_189" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_189: linear-gradient(180deg, #76bb65 0%, #343739 100%);<br/>
+    --border-img_6318_189: #63775f;<br/>
+    --text-img_6318_189: #84be76;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_190"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_190</span></button>
+    <div class="container-img_6318_190" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_190: linear-gradient(180deg, #77bd66 0%, #343739 100%);<br/>
+    --border-img_6318_190: #647a61;<br/>
+    --text-img_6318_190: #d0e6ca;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_191"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_191</span></button>
+    <div class="container-img_6318_191" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_191: linear-gradient(180deg, #77bd66 0%, #494d50 100%);<br/>
+    --border-img_6318_191: #667a63;<br/>
+    --text-img_6318_191: #73926b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_192"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_192</span></button>
+    <div class="container-img_6318_192" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_192: linear-gradient(180deg, #77bd66 0%, #343739 100%);<br/>
+    --border-img_6318_192: #697d65;<br/>
+    --text-img_6318_192: #95ad90;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6318_193"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6318_193</span></button>
+    <div class="container-img_6318_193" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6318_193: linear-gradient(180deg, #78bd66 0%, #343739 100%);<br/>
+    --border-img_6318_193: #657b62;<br/>
+    --text-img_6318_193: #8cc37f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_194"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_194</span></button>
+    <div class="container-img_6319_194" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_194: linear-gradient(180deg, #343739 0%, #3f463e 100%);<br/>
+    --border-img_6319_194: #404d3f;<br/>
+    --text-img_6319_194: #404040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_195"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_195</span></button>
+    <div class="container-img_6319_195" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_195: linear-gradient(180deg, #4a4d4e 0%, #5a9a4b 100%);<br/>
+    --border-img_6319_195: #4e6e48;<br/>
+    --text-img_6319_195: #3f503b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_196"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_196</span></button>
+    <div class="container-img_6319_196" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_196: linear-gradient(180deg, #626466 0%, #4c574a 100%);<br/>
+    --border-img_6319_196: #53674f;<br/>
+    --text-img_6319_196: #404040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_197"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_197</span></button>
+    <div class="container-img_6319_197" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_197: linear-gradient(180deg, #46484a 0%, #48763c 100%);<br/>
+    --border-img_6319_197: #495f45;<br/>
+    --text-img_6319_197: #5f655d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_198"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_198</span></button>
+    <div class="container-img_6319_198" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_198: linear-gradient(180deg, #343739 0%, #4d574b 100%);<br/>
+    --border-img_6319_198: #435441;<br/>
+    --text-img_6319_198: #404040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_199"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_199</span></button>
+    <div class="container-img_6319_199" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_199: linear-gradient(180deg, #343739 0%, #4e7843 100%);<br/>
+    --border-img_6319_199: #42553f;<br/>
+    --text-img_6319_199: #46663f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_200"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_200</span></button>
+    <div class="container-img_6319_200" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_200: linear-gradient(180deg, #898b8c 0%, #4e6b47 100%);<br/>
+    --border-img_6319_200: #597154;<br/>
+    --text-img_6319_200: #404040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_201"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_201</span></button>
+    <div class="container-img_6319_201" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_201: linear-gradient(180deg, #343739 0%, #4d6f45 100%);<br/>
+    --border-img_6319_201: #445841;<br/>
+    --text-img_6319_201: #5e7359;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_202"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_202</span></button>
+    <div class="container-img_6319_202" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_202: linear-gradient(180deg, #343739 0%, #455d3f 100%);<br/>
+    --border-img_6319_202: #435441;<br/>
+    --text-img_6319_202: #3d433c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_203"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_203</span></button>
+    <div class="container-img_6319_203" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_203: linear-gradient(180deg, #343739 0%, #619a52 100%);<br/>
+    --border-img_6319_203: #61735e;<br/>
+    --text-img_6319_203: #589649;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_204"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_204</span></button>
+    <div class="container-img_6319_204" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_204: linear-gradient(180deg, #343739 0%, #638d58 100%);<br/>
+    --border-img_6319_204: #667164;<br/>
+    --text-img_6319_204: #5b8251;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_205"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_205</span></button>
+    <div class="container-img_6319_205" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_205: linear-gradient(180deg, #343739 0%, #4e6548 100%);<br/>
+    --border-img_6319_205: #445a41;<br/>
+    --text-img_6319_205: #5b6659;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_206"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_206</span></button>
+    <div class="container-img_6319_206" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_206: linear-gradient(180deg, #3f453d 0%, #3d413c 100%);<br/>
+    --border-img_6319_206: #435a3d;<br/>
+    --text-img_6319_206: #404040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_207"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_207</span></button>
+    <div class="container-img_6319_207" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_207: linear-gradient(180deg, #d1dacc 0%, #417b32 100%);<br/>
+    --border-img_6319_207: #709d64;<br/>
+    --text-img_6319_207: #84aa79;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_208"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_208</span></button>
+    <div class="container-img_6319_208" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_208: linear-gradient(180deg, #4b5649 0%, #454d43 100%);<br/>
+    --border-img_6319_208: #4c7641;<br/>
+    --text-img_6319_208: #404040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_209"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_209</span></button>
+    <div class="container-img_6319_209" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_209: linear-gradient(180deg, #dde4db 0%, #528c44 100%);<br/>
+    --border-img_6319_209: #769f6b;<br/>
+    --text-img_6319_209: #93b28a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_210"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_210</span></button>
+    <div class="container-img_6319_210" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_210: linear-gradient(180deg, #4e584b 0%, #4f584d 100%);<br/>
+    --border-img_6319_210: #537849;<br/>
+    --text-img_6319_210: #404040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_211"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_211</span></button>
+    <div class="container-img_6319_211" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_211: linear-gradient(180deg, #7c9076 0%, #403f3f 100%);<br/>
+    --border-img_6319_211: #5c6659;<br/>
+    --text-img_6319_211: #427c34;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_212"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_212</span></button>
+    <div class="container-img_6319_212" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_212: linear-gradient(180deg, #4c6945 0%, #403f3f 100%);<br/>
+    --border-img_6319_212: #64795f;<br/>
+    --text-img_6319_212: #404040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_213"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_213</span></button>
+    <div class="container-img_6319_213" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_213: linear-gradient(180deg, #94a48f 0%, #403f3f 100%);<br/>
+    --border-img_6319_213: #677a62;<br/>
+    --text-img_6319_213: #518842;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_214"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_214</span></button>
+    <div class="container-img_6319_214" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_214: linear-gradient(180deg, #42593c 0%, #404e3c 100%);<br/>
+    --border-img_6319_214: #4b5b46;<br/>
+    --text-img_6319_214: #3e403d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_215"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_215</span></button>
+    <div class="container-img_6319_215" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_215: linear-gradient(180deg, #4a873b 0%, #436c39 100%);<br/>
+    --border-img_6319_215: #5f7458;<br/>
+    --text-img_6319_215: #3b6032;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_216"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_216</span></button>
+    <div class="container-img_6319_216" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_216: linear-gradient(180deg, #a7c0a1 0%, #436c39 100%);<br/>
+    --border-img_6319_216: #657960;<br/>
+    --text-img_6319_216: #628459;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_217"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_217</span></button>
+    <div class="container-img_6319_217" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_217: linear-gradient(180deg, #50684a 0%, #465c41 100%);<br/>
+    --border-img_6319_217: #5b7654;<br/>
+    --text-img_6319_217: #535a52;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_218"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_218</span></button>
+    <div class="container-img_6319_218" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_218: linear-gradient(180deg, #403f3f 0%, #3f423e 100%);<br/>
+    --border-img_6319_218: #3f493d;<br/>
+    --text-img_6319_218: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_219"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_219</span></button>
+    <div class="container-img_6319_219" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_219: linear-gradient(180deg, #403f3f 0%, #b1bcae 100%);<br/>
+    --border-img_6319_219: #596b54;<br/>
+    --text-img_6319_219: #426938;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_220"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_220</span></button>
+    <div class="container-img_6319_220" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_220: linear-gradient(180deg, #403f3f 0%, #445240 100%);<br/>
+    --border-img_6319_220: #41563c;<br/>
+    --text-img_6319_220: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_221"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_221</span></button>
+    <div class="container-img_6319_221" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_221: linear-gradient(180deg, #403f3f 0%, #9fc895 100%);<br/>
+    --border-img_6319_221: #577150;<br/>
+    --text-img_6319_221: #426a38;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_222"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_222</span></button>
+    <div class="container-img_6319_222" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_222: linear-gradient(180deg, #403f3f 0%, #455142 100%);<br/>
+    --border-img_6319_222: #44583f;<br/>
+    --text-img_6319_222: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_223"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_223</span></button>
+    <div class="container-img_6319_223" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_223: linear-gradient(180deg, #415c3a 0%, #5d6c59 100%);<br/>
+    --border-img_6319_223: #4f5f4a;<br/>
+    --text-img_6319_223: #3e6035;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_224"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_224</span></button>
+    <div class="container-img_6319_224" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_224: linear-gradient(180deg, #445e3e 0%, #40553a 100%);<br/>
+    --border-img_6319_224: #56744f;<br/>
+    --text-img_6319_224: #3e403d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_225"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_225</span></button>
+    <div class="container-img_6319_225" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_225: linear-gradient(180deg, #46663d 0%, #73916c 100%);<br/>
+    --border-img_6319_225: #54724d;<br/>
+    --text-img_6319_225: #3f6335;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_226"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_226</span></button>
+    <div class="container-img_6319_226" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_226: linear-gradient(180deg, #3f4d3b 0%, #3d413b 100%);<br/>
+    --border-img_6319_226: #495347;<br/>
+    --text-img_6319_226: #3d433c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_227"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_227</span></button>
+    <div class="container-img_6319_227" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_227: linear-gradient(180deg, #3f6436 0%, #364d2f 100%);<br/>
+    --border-img_6319_227: #4d5e49;<br/>
+    --text-img_6319_227: #8e9d89;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_228"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_228</span></button>
+    <div class="container-img_6319_228" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_228: linear-gradient(180deg, #3f6436 0%, #3a5833 100%);<br/>
+    --border-img_6319_228: #51654b;<br/>
+    --text-img_6319_228: #8aaf80;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_229"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_229</span></button>
+    <div class="container-img_6319_229" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_229: linear-gradient(180deg, #44593f 0%, #445440 100%);<br/>
+    --border-img_6319_229: #4c6345;<br/>
+    --text-img_6319_229: #4b6445;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_230"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_230</span></button>
+    <div class="container-img_6319_230" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_230: linear-gradient(180deg, #3e423d 0%, #3f3f3f 100%);<br/>
+    --border-img_6319_230: #3d453b;<br/>
+    --text-img_6319_230: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_231"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_231</span></button>
+    <div class="container-img_6319_231" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_231: linear-gradient(180deg, #e1e1e1 0%, #3f3f3f 100%);<br/>
+    --border-img_6319_231: #70786e;<br/>
+    --text-img_6319_231: #375330;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_232"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_232</span></button>
+    <div class="container-img_6319_232" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_232: linear-gradient(180deg, #435140 0%, #3f3f3f 100%);<br/>
+    --border-img_6319_232: #3e4f39;<br/>
+    --text-img_6319_232: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_233"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_233</span></button>
+    <div class="container-img_6319_233" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_233: linear-gradient(180deg, #d3ffc9 0%, #3f3f3f 100%);<br/>
+    --border-img_6319_233: #6e8768;<br/>
+    --text-img_6319_233: #375430;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_234"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_234</span></button>
+    <div class="container-img_6319_234" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_234: linear-gradient(180deg, #445041 0%, #3f3f3f 100%);<br/>
+    --border-img_6319_234: #43533e;<br/>
+    --text-img_6319_234: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_235"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_235</span></button>
+    <div class="container-img_6319_235" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_235: linear-gradient(180deg, #394c34 0%, #628b57 100%);<br/>
+    --border-img_6319_235: #4b6345;<br/>
+    --text-img_6319_235: #40413f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_236"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_236</span></button>
+    <div class="container-img_6319_236" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_236: linear-gradient(180deg, #3e5039 0%, #668a5c 100%);<br/>
+    --border-img_6319_236: #567a4d;<br/>
+    --text-img_6319_236: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_237"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_237</span></button>
+    <div class="container-img_6319_237" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_237: linear-gradient(180deg, #3d5436 0%, #74a966 100%);<br/>
+    --border-img_6319_237: #5a7a52;<br/>
+    --text-img_6319_237: #424141;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_238"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_238</span></button>
+    <div class="container-img_6319_238" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_238: linear-gradient(180deg, #464f43 0%, #4d6148 100%);<br/>
+    --border-img_6319_238: #596c54;<br/>
+    --text-img_6319_238: #3f3e3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_239"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_239</span></button>
+    <div class="container-img_6319_239" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_239: linear-gradient(180deg, #6ba45c 0%, #e1efde 100%);<br/>
+    --border-img_6319_239: #6e9664;<br/>
+    --text-img_6319_239: #75ba64;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_240"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_240</span></button>
+    <div class="container-img_6319_240" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_240: linear-gradient(180deg, #ddebd9 0%, #263d20 100%);<br/>
+    --border-img_6319_240: #63785d;<br/>
+    --text-img_6319_240: #588c4b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_241"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_241</span></button>
+    <div class="container-img_6319_241" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_241: linear-gradient(180deg, #858b83 0%, #4c6347 100%);<br/>
+    --border-img_6319_241: #6d9164;<br/>
+    --text-img_6319_241: #7fa874;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_242"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_242</span></button>
+    <div class="container-img_6319_242" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_242: linear-gradient(180deg, #3f3f3e 0%, #3f403f 100%);<br/>
+    --border-img_6319_242: #526a4b;<br/>
+    --text-img_6319_242: #3f3e3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_243"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_243</span></button>
+    <div class="container-img_6319_243" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_243: linear-gradient(180deg, #7cc26a 0%, #ffffff 100%);<br/>
+    --border-img_6319_243: #aad69e;<br/>
+    --text-img_6319_243: #93c985;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_244"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_244</span></button>
+    <div class="container-img_6319_244" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_244: linear-gradient(180deg, #4f6149 0%, #4d6048 100%);<br/>
+    --border-img_6319_244: #76a569;<br/>
+    --text-img_6319_244: #3f3e3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_245"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_245</span></button>
+    <div class="container-img_6319_245" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_245: linear-gradient(180deg, #7cc36a 0%, #ffffff 100%);<br/>
+    --border-img_6319_245: #a5d09a;<br/>
+    --text-img_6319_245: #66915c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_246"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_246</span></button>
+    <div class="container-img_6319_246" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_246: linear-gradient(180deg, #5d6f58 0%, #5a6d55 100%);<br/>
+    --border-img_6319_246: #74a069;<br/>
+    --text-img_6319_246: #494948;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_247"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_247</span></button>
+    <div class="container-img_6319_247" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_247: linear-gradient(180deg, #688c5f 0%, #485444 100%);<br/>
+    --border-img_6319_247: #63725f;<br/>
+    --text-img_6319_247: #649a57;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_248"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_248</span></button>
+    <div class="container-img_6319_248" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_248: linear-gradient(180deg, #628659 0%, #474c45 100%);<br/>
+    --border-img_6319_248: #6d8c65;<br/>
+    --text-img_6319_248: #454e42;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_249"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_249</span></button>
+    <div class="container-img_6319_249" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_249: linear-gradient(180deg, #6e9d62 0%, #b1bbae 100%);<br/>
+    --border-img_6319_249: #789571;<br/>
+    --text-img_6319_249: #6aac5b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_250"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_250</span></button>
+    <div class="container-img_6319_250" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_250: linear-gradient(180deg, #3f403f 0%, #3e3e3e 100%);<br/>
+    --border-img_6319_250: #444f42;<br/>
+    --text-img_6319_250: #3e3e3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_251"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_251</span></button>
+    <div class="container-img_6319_251" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_251: linear-gradient(180deg, #69aa5a 0%, #393939 100%);<br/>
+    --border-img_6319_251: #506f49;<br/>
+    --text-img_6319_251: #495745;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_252"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_252</span></button>
+    <div class="container-img_6319_252" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_252: linear-gradient(180deg, #4b5e47 0%, #3c3c3c 100%);<br/>
+    --border-img_6319_252: #536a4d;<br/>
+    --text-img_6319_252: #3e3e3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_253"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_253</span></button>
+    <div class="container-img_6319_253" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_253: linear-gradient(180deg, #69aa5a 0%, #393939 100%);<br/>
+    --border-img_6319_253: #56744f;<br/>
+    --text-img_6319_253: #687265;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_254"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_254</span></button>
+    <div class="container-img_6319_254" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_254: linear-gradient(180deg, #586b54 0%, #4d4d4d 100%);<br/>
+    --border-img_6319_254: #566f50;<br/>
+    --text-img_6319_254: #3e3e3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_255"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_255</span></button>
+    <div class="container-img_6319_255" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_255: linear-gradient(180deg, #4a5d46 0%, #3b3b3b 100%);<br/>
+    --border-img_6319_255: #424b40;<br/>
+    --text-img_6319_255: #3e3e3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_256"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_256</span></button>
+    <div class="container-img_6319_256" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_256: linear-gradient(180deg, #65a657 0%, #363636 100%);<br/>
+    --border-img_6319_256: #475b42;<br/>
+    --text-img_6319_256: #3a3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_257"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_257</span></button>
+    <div class="container-img_6319_257" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_257: linear-gradient(180deg, #65a657 0%, #373737 100%);<br/>
+    --border-img_6319_257: #495845;<br/>
+    --text-img_6319_257: #4b4b4b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_258"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_258</span></button>
+    <div class="container-img_6319_258" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_258: linear-gradient(180deg, #5e8056 0%, #3e3e3e 100%);<br/>
+    --border-img_6319_258: #4e6149;<br/>
+    --text-img_6319_258: #4b4b4b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_259"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_259</span></button>
+    <div class="container-img_6319_259" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_259: linear-gradient(180deg, #3a3a3a 0%, #50634a 100%);<br/>
+    --border-img_6319_259: #4b5847;<br/>
+    --text-img_6319_259: #373737;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_260"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_260</span></button>
+    <div class="container-img_6319_260" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_260: linear-gradient(180deg, #3c3c3c 0%, #424540 100%);<br/>
+    --border-img_6319_260: #4a5647;<br/>
+    --text-img_6319_260: #3c3c3c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_261"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_261</span></button>
+    <div class="container-img_6319_261" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_261: linear-gradient(180deg, #3e3e3e 0%, #6f8f67 100%);<br/>
+    --border-img_6319_261: #586f52;<br/>
+    --text-img_6319_261: #333333;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_262"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_262</span></button>
+    <div class="container-img_6319_262" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_262: linear-gradient(180deg, #3e3d3e 0%, #3e3d3d 100%);<br/>
+    --border-img_6319_262: #3a3a3a;<br/>
+    --text-img_6319_262: #3e3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_263"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_263</span></button>
+    <div class="container-img_6319_263" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_263: linear-gradient(180deg, #373737 0%, #323232 100%);<br/>
+    --border-img_6319_263: #424d3f;<br/>
+    --text-img_6319_263: #8cd579;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_264"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_264</span></button>
+    <div class="container-img_6319_264" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_264: linear-gradient(180deg, #333333 0%, #272727 100%);<br/>
+    --border-img_6319_264: #3d463b;<br/>
+    --text-img_6319_264: #9ddc8e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_265"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_265</span></button>
+    <div class="container-img_6319_265" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_265: linear-gradient(180deg, #434343 0%, #3f3e3e 100%);<br/>
+    --border-img_6319_265: #3f453d;<br/>
+    --text-img_6319_265: #585757;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_266"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_266</span></button>
+    <div class="container-img_6319_266" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_266: linear-gradient(180deg, #3a3a3a 0%, #3d3d3d 100%);<br/>
+    --border-img_6319_266: #464f44;<br/>
+    --text-img_6319_266: #3e3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_267"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_267</span></button>
+    <div class="container-img_6319_267" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_267: linear-gradient(180deg, #83c572 0%, #3d3d3d 100%);<br/>
+    --border-img_6319_267: #5c7855;<br/>
+    --text-img_6319_267: #303030;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_268"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_268</span></button>
+    <div class="container-img_6319_268" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_268: linear-gradient(180deg, #73986a 0%, #3d3d3d 100%);<br/>
+    --border-img_6319_268: #586555;<br/>
+    --text-img_6319_268: #232323;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_269"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_269</span></button>
+    <div class="container-img_6319_269" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_269: linear-gradient(180deg, #515d4d 0%, #3d3d3d 100%);<br/>
+    --border-img_6319_269: #52604e;<br/>
+    --text-img_6319_269: #424242;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_270"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_270</span></button>
+    <div class="container-img_6319_270" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_270: linear-gradient(180deg, #363636 0%, #799b72 100%);<br/>
+    --border-img_6319_270: #505c4d;<br/>
+    --text-img_6319_270: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_271"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_271</span></button>
+    <div class="container-img_6319_271" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_271: linear-gradient(180deg, #3c3b3b 0%, #6f8969 100%);<br/>
+    --border-img_6319_271: #4d584b;<br/>
+    --text-img_6319_271: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_272"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_272</span></button>
+    <div class="container-img_6319_272" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_272: linear-gradient(180deg, #2f2f2f 0%, #424241 100%);<br/>
+    --border-img_6319_272: #3f453e;<br/>
+    --text-img_6319_272: #474747;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_273"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_273</span></button>
+    <div class="container-img_6319_273" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_273: linear-gradient(180deg, #3e3d3d 0%, #3d3d3d 100%);<br/>
+    --border-img_6319_273: #4b5449;<br/>
+    --text-img_6319_273: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_274"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_274</span></button>
+    <div class="container-img_6319_274" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_274: linear-gradient(180deg, #2f2f2f 0%, #a9e59c 100%);<br/>
+    --border-img_6319_274: #6a8564;<br/>
+    --text-img_6319_274: #444a43;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_275"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_275</span></button>
+    <div class="container-img_6319_275" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_275: linear-gradient(180deg, #3b3a3a 0%, #637b5e 100%);<br/>
+    --border-img_6319_275: #566353;<br/>
+    --text-img_6319_275: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_276"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_276</span></button>
+    <div class="container-img_6319_276" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_276: linear-gradient(180deg, #212121 0%, #3b3b3b 100%);<br/>
+    --border-img_6319_276: #383938;<br/>
+    --text-img_6319_276: #474946;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_277"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_277</span></button>
+    <div class="container-img_6319_277" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_277: linear-gradient(180deg, #414141 0%, #444544 100%);<br/>
+    --border-img_6319_277: #40443f;<br/>
+    --text-img_6319_277: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_278"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_278</span></button>
+    <div class="container-img_6319_278" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_278: linear-gradient(180deg, #556552 0%, #51604c 100%);<br/>
+    --border-img_6319_278: #61785b;<br/>
+    --text-img_6319_278: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_279"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_279</span></button>
+    <div class="container-img_6319_279" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_279: linear-gradient(180deg, #a8e49a 0%, #8fd07f 100%);<br/>
+    --border-img_6319_279: #93cc86;<br/>
+    --text-img_6319_279: #484c45;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_280"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_280</span></button>
+    <div class="container-img_6319_280" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_280: linear-gradient(180deg, #3e3f3e 0%, #333433 100%);<br/>
+    --border-img_6319_280: #464d45;<br/>
+    --text-img_6319_280: #799972;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_281"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_281</span></button>
+    <div class="container-img_6319_281" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_281: linear-gradient(180deg, #414241 0%, #3a3b3a 100%);<br/>
+    --border-img_6319_281: #464e44;<br/>
+    --text-img_6319_281: #484c48;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_282"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_282</span></button>
+    <div class="container-img_6319_282" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_282: linear-gradient(180deg, #75986e 0%, #6a8e61 100%);<br/>
+    --border-img_6319_282: #637e5d;<br/>
+    --text-img_6319_282: #7aa56f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_283"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_283</span></button>
+    <div class="container-img_6319_283" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_283: linear-gradient(180deg, #6c8766 0%, #637f5b 100%);<br/>
+    --border-img_6319_283: #678460;<br/>
+    --text-img_6319_283: #556851;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_284"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_284</span></button>
+    <div class="container-img_6319_284" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_284: linear-gradient(180deg, #3e3e3d 0%, #353635 100%);<br/>
+    --border-img_6319_284: #566753;<br/>
+    --text-img_6319_284: #6e8a68;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_285"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_285</span></button>
+    <div class="container-img_6319_285" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_285: linear-gradient(180deg, #3d3d3d 0%, #3d3c3c 100%);<br/>
+    --border-img_6319_285: #5b7056;<br/>
+    --text-img_6319_285: #3d3c3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_286"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_286</span></button>
+    <div class="container-img_6319_286" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_286: linear-gradient(180deg, #72916a 0%, #8ecf7e 100%);<br/>
+    --border-img_6319_286: #8ac07d;<br/>
+    --text-img_6319_286: #515d4d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_287"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_287</span></button>
+    <div class="container-img_6319_287" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_287: linear-gradient(180deg, #61795c 0%, #5a7254 100%);<br/>
+    --border-img_6319_287: #5f7959;<br/>
+    --text-img_6319_287: #485145;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_288"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_288</span></button>
+    <div class="container-img_6319_288" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_288: linear-gradient(180deg, #87ad7e 0%, #2e2e2e 100%);<br/>
+    --border-img_6319_288: #475045;<br/>
+    --text-img_6319_288: #81a579;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6319_289"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6319_289</span></button>
+    <div class="container-img_6319_289" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6319_289: linear-gradient(180deg, #424442 0%, #3f403f 100%);<br/>
+    --border-img_6319_289: #424840;<br/>
+    --text-img_6319_289: #535752;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_290"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_290</span></button>
+    <div class="container-img_6320_290" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_290: linear-gradient(180deg, #343739 0%, #4c6745 100%);<br/>
+    --border-img_6320_290: #3f4c3e;<br/>
+    --text-img_6320_290: #464846;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_291"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_291</span></button>
+    <div class="container-img_6320_291" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_291: linear-gradient(180deg, #4a4d4e 0%, #48763c 100%);<br/>
+    --border-img_6320_291: #485e44;<br/>
+    --text-img_6320_291: #535d51;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_292"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_292</span></button>
+    <div class="container-img_6320_292" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_292: linear-gradient(180deg, #626466 0%, #455e3e 100%);<br/>
+    --border-img_6320_292: #505e4e;<br/>
+    --text-img_6320_292: #404140;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_293"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_293</span></button>
+    <div class="container-img_6320_293" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_293: linear-gradient(180deg, #46484a 0%, #48763c 100%);<br/>
+    --border-img_6320_293: #465d42;<br/>
+    --text-img_6320_293: #43583f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_294"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_294</span></button>
+    <div class="container-img_6320_294" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_294: linear-gradient(180deg, #343739 0%, #4e6449 100%);<br/>
+    --border-img_6320_294: #465a43;<br/>
+    --text-img_6320_294: #404040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_295"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_295</span></button>
+    <div class="container-img_6320_295" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_295: linear-gradient(180deg, #343739 0%, #4d7a41 100%);<br/>
+    --border-img_6320_295: #40513e;<br/>
+    --text-img_6320_295: #536c4c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_296"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_296</span></button>
+    <div class="container-img_6320_296" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_296: linear-gradient(180deg, #898b8c 0%, #476141 100%);<br/>
+    --border-img_6320_296: #556a51;<br/>
+    --text-img_6320_296: #424e3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_297"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_297</span></button>
+    <div class="container-img_6320_297" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_297: linear-gradient(180deg, #343739 0%, #45603f 100%);<br/>
+    --border-img_6320_297: #455c41;<br/>
+    --text-img_6320_297: #424e3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_298"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_298</span></button>
+    <div class="container-img_6320_298" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_298: linear-gradient(180deg, #343739 0%, #4e7344 100%);<br/>
+    --border-img_6320_298: #4f5b4e;<br/>
+    --text-img_6320_298: #547b49;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_299"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_299</span></button>
+    <div class="container-img_6320_299" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_299: linear-gradient(180deg, #343739 0%, #4e7744 100%);<br/>
+    --border-img_6320_299: #546252;<br/>
+    --text-img_6320_299: #537b49;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_300"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_300</span></button>
+    <div class="container-img_6320_300" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_300: linear-gradient(180deg, #343739 0%, #9fb899 100%);<br/>
+    --border-img_6320_300: #647960;<br/>
+    --text-img_6320_300: #47763b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_301"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_301</span></button>
+    <div class="container-img_6320_301" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_301: linear-gradient(180deg, #343739 0%, #485b43 100%);<br/>
+    --border-img_6320_301: #475f42;<br/>
+    --text-img_6320_301: #404040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_302"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_302</span></button>
+    <div class="container-img_6320_302" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_302: linear-gradient(180deg, #4d6a46 0%, #517149 100%);<br/>
+    --border-img_6320_302: #5c7156;<br/>
+    --text-img_6320_302: #5f8855;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_303"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_303</span></button>
+    <div class="container-img_6320_303" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_303: linear-gradient(180deg, #82a47a 0%, #528c44 100%);<br/>
+    --border-img_6320_303: #719c66;<br/>
+    --text-img_6320_303: #93b28a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_304"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_304</span></button>
+    <div class="container-img_6320_304" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_304: linear-gradient(180deg, #46613f 0%, #486541 100%);<br/>
+    --border-img_6320_304: #5f7958;<br/>
+    --text-img_6320_304: #48693f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_305"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_305</span></button>
+    <div class="container-img_6320_305" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_305: linear-gradient(180deg, #9ab493 0%, #528c44 100%);<br/>
+    --border-img_6320_305: #719c66;<br/>
+    --text-img_6320_305: #8bae83;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_306"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_306</span></button>
+    <div class="container-img_6320_306" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_306: linear-gradient(180deg, #4a5c46 0%, #41493e 100%);<br/>
+    --border-img_6320_306: #55734e;<br/>
+    --text-img_6320_306: #434a41;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_307"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_307</span></button>
+    <div class="container-img_6320_307" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_307: linear-gradient(180deg, #b8c9b3 0%, #403f3f 100%);<br/>
+    --border-img_6320_307: #697366;<br/>
+    --text-img_6320_307: #518842;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_308"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_308</span></button>
+    <div class="container-img_6320_308" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_308: linear-gradient(180deg, #62765d 0%, #403f3f 100%);<br/>
+    --border-img_6320_308: #60765a;<br/>
+    --text-img_6320_308: #486740;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_309"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_309</span></button>
+    <div class="container-img_6320_309" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_309: linear-gradient(180deg, #60745b 0%, #403f3f 100%);<br/>
+    --border-img_6320_309: #5f715b;<br/>
+    --text-img_6320_309: #486640;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_310"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_310</span></button>
+    <div class="container-img_6320_310" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_310: linear-gradient(180deg, #6f8e67 0%, #4b6844 100%);<br/>
+    --border-img_6320_310: #5c6d57;<br/>
+    --text-img_6320_310: #597b50;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_311"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_311</span></button>
+    <div class="container-img_6320_311" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_311: linear-gradient(180deg, #7b9a73 0%, #4b6a43 100%);<br/>
+    --border-img_6320_311: #5d6f58;<br/>
+    --text-img_6320_311: #597d50;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_312"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_312</span></button>
+    <div class="container-img_6320_312" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_312: linear-gradient(180deg, #4f8441 0%, #436c39 100%);<br/>
+    --border-img_6320_312: #6c8a64;<br/>
+    --text-img_6320_312: #4c7641;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_313"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_313</span></button>
+    <div class="container-img_6320_313" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_313: linear-gradient(180deg, #465741 0%, #434d40 100%);<br/>
+    --border-img_6320_313: #4e6747;<br/>
+    --text-img_6320_313: #403f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_314"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_314</span></button>
+    <div class="container-img_6320_314" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_314: linear-gradient(180deg, #403f3f 0%, #495c44 100%);<br/>
+    --border-img_6320_314: #465143;<br/>
+    --text-img_6320_314: #607959;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_315"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_315</span></button>
+    <div class="container-img_6320_315" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_315: linear-gradient(180deg, #403f3f 0%, #698361 100%);<br/>
+    --border-img_6320_315: #586a53;<br/>
+    --text-img_6320_315: #426a38;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_316"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_316</span></button>
+    <div class="container-img_6320_316" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_316: linear-gradient(180deg, #403f3f 0%, #40543b 100%);<br/>
+    --border-img_6320_316: #495646;<br/>
+    --text-img_6320_316: #445d3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_317"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_317</span></button>
+    <div class="container-img_6320_317" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_317: linear-gradient(180deg, #403f3f 0%, #84987d 100%);<br/>
+    --border-img_6320_317: #586b52;<br/>
+    --text-img_6320_317: #426a38;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_318"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_318</span></button>
+    <div class="container-img_6320_318" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_318: linear-gradient(180deg, #403f3f 0%, #41493f 100%);<br/>
+    --border-img_6320_318: #42513e;<br/>
+    --text-img_6320_318: #414440;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_319"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_319</span></button>
+    <div class="container-img_6320_319" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_319: linear-gradient(180deg, #496e3f 0%, #a5afa0 100%);<br/>
+    --border-img_6320_319: #4d6248;<br/>
+    --text-img_6320_319: #47693d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_320"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_320</span></button>
+    <div class="container-img_6320_320" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_320: linear-gradient(180deg, #44593f 0%, #495845 100%);<br/>
+    --border-img_6320_320: #536d4c;<br/>
+    --text-img_6320_320: #42563c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_321"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_321</span></button>
+    <div class="container-img_6320_321" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_321: linear-gradient(180deg, #42573c 0%, #465642 100%);<br/>
+    --border-img_6320_321: #51674b;<br/>
+    --text-img_6320_321: #42563c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_322"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_322</span></button>
+    <div class="container-img_6320_322" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_322: linear-gradient(180deg, #476240 0%, #475743 100%);<br/>
+    --border-img_6320_322: #555f52;<br/>
+    --text-img_6320_322: #3f5e36;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_323"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_323</span></button>
+    <div class="container-img_6320_323" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_323: linear-gradient(180deg, #476540 0%, #475842 100%);<br/>
+    --border-img_6320_323: #545e50;<br/>
+    --text-img_6320_323: #486540;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_324"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_324</span></button>
+    <div class="container-img_6320_324" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_324: linear-gradient(180deg, #3f6436 0%, #35502e 100%);<br/>
+    --border-img_6320_324: #4a6144;<br/>
+    --text-img_6320_324: #93a18e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_325"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_325</span></button>
+    <div class="container-img_6320_325" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_325: linear-gradient(180deg, #414d3f 0%, #40433f 100%);<br/>
+    --border-img_6320_325: #4a5945;<br/>
+    --text-img_6320_325: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_326"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_326</span></button>
+    <div class="container-img_6320_326" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_326: linear-gradient(180deg, #52624e 0%, #3f3f3f 100%);<br/>
+    --border-img_6320_326: #535951;<br/>
+    --text-img_6320_326: #586b54;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_327"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_327</span></button>
+    <div class="container-img_6320_327" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_327: linear-gradient(180deg, #ece9e9 0%, #3f3f3f 100%);<br/>
+    --border-img_6320_327: #6b7567;<br/>
+    --text-img_6320_327: #375430;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_328"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_328</span></button>
+    <div class="container-img_6320_328" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_328: linear-gradient(180deg, #3f513a 0%, #3f3f3f 100%);<br/>
+    --border-img_6320_328: #565d53;<br/>
+    --text-img_6320_328: #41563c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_329"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_329</span></button>
+    <div class="container-img_6320_329" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_329: linear-gradient(180deg, #ece9e9 0%, #3f3f3f 100%);<br/>
+    --border-img_6320_329: #6b7567;<br/>
+    --text-img_6320_329: #375330;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_330"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_330</span></button>
+    <div class="container-img_6320_330" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_330: linear-gradient(180deg, #40463e 0%, #3f3f3f 100%);<br/>
+    --border-img_6320_330: #4a5447;<br/>
+    --text-img_6320_330: #40433f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_331"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_331</span></button>
+    <div class="container-img_6320_331" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_331: linear-gradient(180deg, #3e5736 0%, #78b967 100%);<br/>
+    --border-img_6320_331: #516d4a;<br/>
+    --text-img_6320_331: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_332"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_332</span></button>
+    <div class="container-img_6320_332" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_332: linear-gradient(180deg, #3f4e3b 0%, #648c5a 100%);<br/>
+    --border-img_6320_332: #56794d;<br/>
+    --text-img_6320_332: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_333"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_333</span></button>
+    <div class="container-img_6320_333" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_333: linear-gradient(180deg, #3c4c38 0%, #5f8455 100%);<br/>
+    --border-img_6320_333: #53744a;<br/>
+    --text-img_6320_333: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_334"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_334</span></button>
+    <div class="container-img_6320_334" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_334: linear-gradient(180deg, #495047 0%, #85a97d 100%);<br/>
+    --border-img_6320_334: #63775e;<br/>
+    --text-img_6320_334: #76bb65;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_335"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_335</span></button>
+    <div class="container-img_6320_335" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_335: linear-gradient(180deg, #4e574a 0%, #b2d1aa 100%);<br/>
+    --border-img_6320_335: #657a60;<br/>
+    --text-img_6320_335: #76bb65;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_336"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_336</span></button>
+    <div class="container-img_6320_336" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_336: linear-gradient(180deg, #4f5e4a 0%, #fcfdfc 100%);<br/>
+    --border-img_6320_336: #719c67;<br/>
+    --text-img_6320_336: #79bc68;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_337"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_337</span></button>
+    <div class="container-img_6320_337" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_337: linear-gradient(180deg, #3f3e3e 0%, #526b4c 100%);<br/>
+    --border-img_6320_337: #648d5a;<br/>
+    --text-img_6320_337: #3f3e3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_338"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_338</span></button>
+    <div class="container-img_6320_338" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_338: linear-gradient(180deg, #638659 0%, #5e8455 100%);<br/>
+    --border-img_6320_338: #6d8966;<br/>
+    --text-img_6320_338: #719e66;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_339"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_339</span></button>
+    <div class="container-img_6320_339" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_339: linear-gradient(180deg, #7dc36a 0%, #ffffff 100%);<br/>
+    --border-img_6320_339: #a5d599;<br/>
+    --text-img_6320_339: #76bb65;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_340"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_340</span></button>
+    <div class="container-img_6320_340" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_340: linear-gradient(180deg, #5c7c53 0%, #597b51 100%);<br/>
+    --border-img_6320_340: #7fae74;<br/>
+    --text-img_6320_340: #608557;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_341"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_341</span></button>
+    <div class="container-img_6320_341" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_341: linear-gradient(180deg, #7dc36a 0%, #ffffff 100%);<br/>
+    --border-img_6320_341: #a5d499;<br/>
+    --text-img_6320_341: #76bb65;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_342"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_342</span></button>
+    <div class="container-img_6320_342" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_342: linear-gradient(180deg, #536a4c 0%, #526c4b 100%);<br/>
+    --border-img_6320_342: #659658;<br/>
+    --text-img_6320_342: #485545;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_343"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_343</span></button>
+    <div class="container-img_6320_343" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_343: linear-gradient(180deg, #a4cb9a 0%, #7fb871 100%);<br/>
+    --border-img_6320_343: #677d62;<br/>
+    --text-img_6320_343: #77b469;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_344"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_344</span></button>
+    <div class="container-img_6320_344" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_344: linear-gradient(180deg, #618857 0%, #556f4e 100%);<br/>
+    --border-img_6320_344: #74956c;<br/>
+    --text-img_6320_344: #597b51;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_345"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_345</span></button>
+    <div class="container-img_6320_345" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_345: linear-gradient(180deg, #5c8052 0%, #546f4e 100%);<br/>
+    --border-img_6320_345: #688c5f;<br/>
+    --text-img_6320_345: #597a51;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_346"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_346</span></button>
+    <div class="container-img_6320_346" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_346: linear-gradient(180deg, #5c8053 0%, #445142 100%);<br/>
+    --border-img_6320_346: #4d6048;<br/>
+    --text-img_6320_346: #474c45;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_347"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_347</span></button>
+    <div class="container-img_6320_347" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_347: linear-gradient(180deg, #69ab5a 0%, #3a3b3a 100%);<br/>
+    --border-img_6320_347: #54774d;<br/>
+    --text-img_6320_347: #61825a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_348"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_348</span></button>
+    <div class="container-img_6320_348" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_348: linear-gradient(180deg, #57784f 0%, #3c3c3c 100%);<br/>
+    --border-img_6320_348: #546e4e;<br/>
+    --text-img_6320_348: #414440;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_349"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_349</span></button>
+    <div class="container-img_6320_349" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_349: linear-gradient(180deg, #69ab5a 0%, #393939 100%);<br/>
+    --border-img_6320_349: #52734b;<br/>
+    --text-img_6320_349: #577650;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_350"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_350</span></button>
+    <div class="container-img_6320_350" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_350: linear-gradient(180deg, #506a49 0%, #424e3f 100%);<br/>
+    --border-img_6320_350: #506f49;<br/>
+    --text-img_6320_350: #3e3e3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_351"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_351</span></button>
+    <div class="container-img_6320_351" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_351: linear-gradient(180deg, #619155 0%, #3c403b 100%);<br/>
+    --border-img_6320_351: #4b5a47;<br/>
+    --text-img_6320_351: #455142;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_352"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_352</span></button>
+    <div class="container-img_6320_352" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_352: linear-gradient(180deg, #68a45a 0%, #3a3f39 100%);<br/>
+    --border-img_6320_352: #485844;<br/>
+    --text-img_6320_352: #445041;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_353"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_353</span></button>
+    <div class="container-img_6320_353" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_353: linear-gradient(180deg, #66a757 0%, #363636 100%);<br/>
+    --border-img_6320_353: #496044;<br/>
+    --text-img_6320_353: #3a3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_354"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_354</span></button>
+    <div class="container-img_6320_354" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_354: linear-gradient(180deg, #4f684a 0%, #3f483c 100%);<br/>
+    --border-img_6320_354: #4b6745;<br/>
+    --text-img_6320_354: #3e3e3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_355"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_355</span></button>
+    <div class="container-img_6320_355" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_355: linear-gradient(180deg, #3e3e3e 0%, #6b995f 100%);<br/>
+    --border-img_6320_355: #4d5d49;<br/>
+    --text-img_6320_355: #373737;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_356"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_356</span></button>
+    <div class="container-img_6320_356" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_356: linear-gradient(180deg, #3c3c3c 0%, #3e433c 100%);<br/>
+    --border-img_6320_356: #40483e;<br/>
+    --text-img_6320_356: #3b3b3b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_357"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_357</span></button>
+    <div class="container-img_6320_357" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_357: linear-gradient(180deg, #3a3a3a 0%, #3e453c 100%);<br/>
+    --border-img_6320_357: #455541;<br/>
+    --text-img_6320_357: #383838;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_358"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_358</span></button>
+    <div class="container-img_6320_358" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_358: linear-gradient(180deg, #3e443d 0%, #3c423a 100%);<br/>
+    --border-img_6320_358: #60675d;<br/>
+    --text-img_6320_358: #455641;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_359"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_359</span></button>
+    <div class="container-img_6320_359" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_359: linear-gradient(180deg, #373737 0%, #323232 100%);<br/>
+    --border-img_6320_359: #3f483d;<br/>
+    --text-img_6320_359: #7bb56b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_360"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_360</span></button>
+    <div class="container-img_6320_360" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_360: linear-gradient(180deg, #3b3b3b 0%, #393939 100%);<br/>
+    --border-img_6320_360: #445540;<br/>
+    --text-img_6320_360: #3c3b3b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_361"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_361</span></button>
+    <div class="container-img_6320_361" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_361: linear-gradient(180deg, #373737 0%, #323232 100%);<br/>
+    --border-img_6320_361: #383d37;<br/>
+    --text-img_6320_361: #4a6444;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_362"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_362</span></button>
+    <div class="container-img_6320_362" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_362: linear-gradient(180deg, #44563f 0%, #44523f 100%);<br/>
+    --border-img_6320_362: #485d42;<br/>
+    --text-img_6320_362: #3f433e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_363"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_363</span></button>
+    <div class="container-img_6320_363" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_363: linear-gradient(180deg, #546e4d 0%, #3d3d3d 100%);<br/>
+    --border-img_6320_363: #566752;<br/>
+    --text-img_6320_363: #353a34;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_364"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_364</span></button>
+    <div class="container-img_6320_364" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_364: linear-gradient(180deg, #638a58 0%, #3d3d3d 100%);<br/>
+    --border-img_6320_364: #556950;<br/>
+    --text-img_6320_364: #303030;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_365"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_365</span></button>
+    <div class="container-img_6320_365" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_365: linear-gradient(180deg, #4a6444 0%, #3d3d3d 100%);<br/>
+    --border-img_6320_365: #3a4039;<br/>
+    --text-img_6320_365: #303030;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_366"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_366</span></button>
+    <div class="container-img_6320_366" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_366: linear-gradient(180deg, #3e463c 0%, #3d3d3d 100%);<br/>
+    --border-img_6320_366: #434f40;<br/>
+    --text-img_6320_366: #3e3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_367"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_367</span></button>
+    <div class="container-img_6320_367" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_367: linear-gradient(180deg, #353834 0%, #363935 100%);<br/>
+    --border-img_6320_367: #393b38;<br/>
+    --text-img_6320_367: #424a40;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_368"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_368</span></button>
+    <div class="container-img_6320_368" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_368: linear-gradient(180deg, #3a3d39 0%, #3d3f3d 100%);<br/>
+    --border-img_6320_368: #383a38;<br/>
+    --text-img_6320_368: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_369"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_369</span></button>
+    <div class="container-img_6320_369" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_369: linear-gradient(180deg, #373736 0%, #3a3a3a 100%);<br/>
+    --border-img_6320_369: #3b4039;<br/>
+    --text-img_6320_369: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_370"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_370</span></button>
+    <div class="container-img_6320_370" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_370: linear-gradient(180deg, #3d443b 0%, #3e433d 100%);<br/>
+    --border-img_6320_370: #464a44;<br/>
+    --text-img_6320_370: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_371"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_371</span></button>
+    <div class="container-img_6320_371" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_371: linear-gradient(180deg, #2f3030 0%, #2f2f2f 100%);<br/>
+    --border-img_6320_371: #363936;<br/>
+    --text-img_6320_371: #494f47;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_372"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_372</span></button>
+    <div class="container-img_6320_372" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_372: linear-gradient(180deg, #2f2f2f 0%, #383838 100%);<br/>
+    --border-img_6320_372: #363636;<br/>
+    --text-img_6320_372: #3c3c3c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_373"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_373</span></button>
+    <div class="container-img_6320_373" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_373: linear-gradient(180deg, #424c3f 0%, #3b3b3b 100%);<br/>
+    --border-img_6320_373: #3c413b;<br/>
+    --text-img_6320_373: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_374"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_374</span></button>
+    <div class="container-img_6320_374" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_374: linear-gradient(180deg, #3a3d39 0%, #3a3d39 100%);<br/>
+    --border-img_6320_374: #4f514e;<br/>
+    --text-img_6320_374: #2f2f2f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_375"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_375</span></button>
+    <div class="container-img_6320_375" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_375: linear-gradient(180deg, #343633 0%, #343633 100%);<br/>
+    --border-img_6320_375: #474746;<br/>
+    --text-img_6320_375: #848484;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_376"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_376</span></button>
+    <div class="container-img_6320_376" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_376: linear-gradient(180deg, #373737 0%, #303030 100%);<br/>
+    --border-img_6320_376: #414341;<br/>
+    --text-img_6320_376: #e5ffdf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_377"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_377</span></button>
+    <div class="container-img_6320_377" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_377: linear-gradient(180deg, #3a3a3a 0%, #383737 100%);<br/>
+    --border-img_6320_377: #3f413f;<br/>
+    --text-img_6320_377: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_378"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_378</span></button>
+    <div class="container-img_6320_378" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_378: linear-gradient(180deg, #353835 0%, #353835 100%);<br/>
+    --border-img_6320_378: #424342;<br/>
+    --text-img_6320_378: #828282;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_379"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_379</span></button>
+    <div class="container-img_6320_379" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_379: linear-gradient(180deg, #3b3d3b 0%, #393a38 100%);<br/>
+    --border-img_6320_379: #4d504c;<br/>
+    --text-img_6320_379: #3a3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_380"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_380</span></button>
+    <div class="container-img_6320_380" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_380: linear-gradient(180deg, #393939 0%, #363535 100%);<br/>
+    --border-img_6320_380: #444644;<br/>
+    --text-img_6320_380: #363636;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_381"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_381</span></button>
+    <div class="container-img_6320_381" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_381: linear-gradient(180deg, #3e433d 0%, #3f433e 100%);<br/>
+    --border-img_6320_381: #5d635b;<br/>
+    --text-img_6320_381: #4f5c4c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_382"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_382</span></button>
+    <div class="container-img_6320_382" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_382: linear-gradient(180deg, #767676 0%, #2f2f2f 100%);<br/>
+    --border-img_6320_382: #4a4a4a;<br/>
+    --text-img_6320_382: #959595;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_383"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_383</span></button>
+    <div class="container-img_6320_383" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_383: linear-gradient(180deg, #3a3a3a 0%, #383838 100%);<br/>
+    --border-img_6320_383: #424441;<br/>
+    --text-img_6320_383: #3b3b3b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_384"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_384</span></button>
+    <div class="container-img_6320_384" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_384: linear-gradient(180deg, #8e9b8b 0%, #303030 100%);<br/>
+    --border-img_6320_384: #565b55;<br/>
+    --text-img_6320_384: #a1b19d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6320_385"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6320_385</span></button>
+    <div class="container-img_6320_385" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6320_385: linear-gradient(180deg, #3a3a3a 0%, #393838 100%);<br/>
+    --border-img_6320_385: #373736;<br/>
+    --text-img_6320_385: #3d3c3c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_386"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_386</span></button>
+    <div class="container-img_6321_386" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_386: linear-gradient(180deg, #343739 0%, #495546 100%);<br/>
+    --border-img_6321_386: #40523e;<br/>
+    --text-img_6321_386: #404040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_387"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_387</span></button>
+    <div class="container-img_6321_387" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_387: linear-gradient(180deg, #4a4d4e 0%, #48763c 100%);<br/>
+    --border-img_6321_387: #465e42;<br/>
+    --text-img_6321_387: #44583f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_388"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_388</span></button>
+    <div class="container-img_6321_388" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_388: linear-gradient(180deg, #626466 0%, #44593e 100%);<br/>
+    --border-img_6321_388: #50624d;<br/>
+    --text-img_6321_388: #404040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_389"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_389</span></button>
+    <div class="container-img_6321_389" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_389: linear-gradient(180deg, #46484a 0%, #69a25b 100%);<br/>
+    --border-img_6321_389: #557150;<br/>
+    --text-img_6321_389: #434a41;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_390"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_390</span></button>
+    <div class="container-img_6321_390" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_390: linear-gradient(180deg, #343739 0%, #536e4c 100%);<br/>
+    --border-img_6321_390: #455343;<br/>
+    --text-img_6321_390: #404040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_391"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_391</span></button>
+    <div class="container-img_6321_391" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_391: linear-gradient(180deg, #343739 0%, #45613e 100%);<br/>
+    --border-img_6321_391: #41563d;<br/>
+    --text-img_6321_391: #43543f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_392"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_392</span></button>
+    <div class="container-img_6321_392" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_392: linear-gradient(180deg, #898b8c 0%, #476140 100%);<br/>
+    --border-img_6321_392: #597055;<br/>
+    --text-img_6321_392: #414840;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_393"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_393</span></button>
+    <div class="container-img_6321_393" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_393: linear-gradient(180deg, #343739 0%, #609054 100%);<br/>
+    --border-img_6321_393: #475945;<br/>
+    --text-img_6321_393: #56774e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_394"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_394</span></button>
+    <div class="container-img_6321_394" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_394: linear-gradient(180deg, #343739 0%, #495b44 100%);<br/>
+    --border-img_6321_394: #42593e;<br/>
+    --text-img_6321_394: #404040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_395"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_395</span></button>
+    <div class="container-img_6321_395" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_395: linear-gradient(180deg, #343739 0%, #779b6d 100%);<br/>
+    --border-img_6321_395: #62785e;<br/>
+    --text-img_6321_395: #47763b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_396"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_396</span></button>
+    <div class="container-img_6321_396" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_396: linear-gradient(180deg, #343739 0%, #5c8951 100%);<br/>
+    --border-img_6321_396: #636f60;<br/>
+    --text-img_6321_396: #689f5a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_397"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_397</span></button>
+    <div class="container-img_6321_397" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_397: linear-gradient(180deg, #343739 0%, #55764c 100%);<br/>
+    --border-img_6321_397: #465644;<br/>
+    --text-img_6321_397: #608d54;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_398"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_398</span></button>
+    <div class="container-img_6321_398" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_398: linear-gradient(180deg, #495646 0%, #4b5848 100%);<br/>
+    --border-img_6321_398: #527948;<br/>
+    --text-img_6321_398: #404040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_399"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_399</span></button>
+    <div class="container-img_6321_399" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_399: linear-gradient(180deg, #f5f5f5 0%, #528c44 100%);<br/>
+    --border-img_6321_399: #769f6b;<br/>
+    --text-img_6321_399: #8bae83;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_400"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_400</span></button>
+    <div class="container-img_6321_400" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_400: linear-gradient(180deg, #455b3f 0%, #465d40 100%);<br/>
+    --border-img_6321_400: #57774f;<br/>
+    --text-img_6321_400: #43543f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_401"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_401</span></button>
+    <div class="container-img_6321_401" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_401: linear-gradient(180deg, #c3cebd 0%, #3f543a 100%);<br/>
+    --border-img_6321_401: #65805e;<br/>
+    --text-img_6321_401: #9dac98;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_402"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_402</span></button>
+    <div class="container-img_6321_402" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_402: linear-gradient(180deg, #4d6448 0%, #414c3e 100%);<br/>
+    --border-img_6321_402: #53604f;<br/>
+    --text-img_6321_402: #475942;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_403"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_403</span></button>
+    <div class="container-img_6321_403" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_403: linear-gradient(180deg, #697c64 0%, #403f3f 100%);<br/>
+    --border-img_6321_403: #60765a;<br/>
+    --text-img_6321_403: #4b7241;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_404"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_404</span></button>
+    <div class="container-img_6321_404" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_404: linear-gradient(180deg, #586e52 0%, #403f3f 100%);<br/>
+    --border-img_6321_404: #62735d;<br/>
+    --text-img_6321_404: #455b40;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_405"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_405</span></button>
+    <div class="container-img_6321_405" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_405: linear-gradient(180deg, #a5b29f 0%, #403f3f 100%);<br/>
+    --border-img_6321_405: #61685f;<br/>
+    --text-img_6321_405: #466140;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_406"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_406</span></button>
+    <div class="container-img_6321_406" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_406: linear-gradient(180deg, #4a5d45 0%, #4a5548 100%);<br/>
+    --border-img_6321_406: #506f48;<br/>
+    --text-img_6321_406: #403f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_407"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_407</span></button>
+    <div class="container-img_6321_407" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_407: linear-gradient(180deg, #4f8441 0%, #436c39 100%);<br/>
+    --border-img_6321_407: #6a8862;<br/>
+    --text-img_6321_407: #4c7641;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_408"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_408</span></button>
+    <div class="container-img_6321_408" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_408: linear-gradient(180deg, #8e9f88 0%, #485f43 100%);<br/>
+    --border-img_6321_408: #5c6659;<br/>
+    --text-img_6321_408: #40523c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_409"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_409</span></button>
+    <div class="container-img_6321_409" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_409: linear-gradient(180deg, #65775f 0%, #465642 100%);<br/>
+    --border-img_6321_409: #565f53;<br/>
+    --text-img_6321_409: #42513d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_410"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_410</span></button>
+    <div class="container-img_6321_410" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_410: linear-gradient(180deg, #403f3f 0%, #495047 100%);<br/>
+    --border-img_6321_410: #43563e;<br/>
+    --text-img_6321_410: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_411"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_411</span></button>
+    <div class="container-img_6321_411" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_411: linear-gradient(180deg, #403f3f 0%, #b9c1b4 100%);<br/>
+    --border-img_6321_411: #5b6d55;<br/>
+    --text-img_6321_411: #426a38;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_412"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_412</span></button>
+    <div class="container-img_6321_412" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_412: linear-gradient(180deg, #403f3f 0%, #40503c 100%);<br/>
+    --border-img_6321_412: #41513d;<br/>
+    --text-img_6321_412: #434f40;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_413"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_413</span></button>
+    <div class="container-img_6321_413" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_413: linear-gradient(180deg, #403f3f 0%, #a7aea3 100%);<br/>
+    --border-img_6321_413: #5c6658;<br/>
+    --text-img_6321_413: #486042;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_414"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_414</span></button>
+    <div class="container-img_6321_414" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_414: linear-gradient(180deg, #403f3f 0%, #414b3f 100%);<br/>
+    --border-img_6321_414: #41483f;<br/>
+    --text-img_6321_414: #434e41;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_415"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_415</span></button>
+    <div class="container-img_6321_415" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_415: linear-gradient(180deg, #42593c 0%, #4e5d4a 100%);<br/>
+    --border-img_6321_415: #526c4b;<br/>
+    --text-img_6321_415: #425c3b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_416"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_416</span></button>
+    <div class="container-img_6321_416" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_416: linear-gradient(180deg, #42563d 0%, #3f4f3a 100%);<br/>
+    --border-img_6321_416: #546a4e;<br/>
+    --text-img_6321_416: #42513e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_417"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_417</span></button>
+    <div class="container-img_6321_417" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_417: linear-gradient(180deg, #485e43 0%, #949991 100%);<br/>
+    --border-img_6321_417: #515d4e;<br/>
+    --text-img_6321_417: #43593e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_418"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_418</span></button>
+    <div class="container-img_6321_418" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_418: linear-gradient(180deg, #485445 0%, #444942 100%);<br/>
+    --border-img_6321_418: #495d44;<br/>
+    --text-img_6321_418: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_419"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_419</span></button>
+    <div class="container-img_6321_419" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_419: linear-gradient(180deg, #3f6436 0%, #35502e 100%);<br/>
+    --border-img_6321_419: #4d6347;<br/>
+    --text-img_6321_419: #93a18e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_420"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_420</span></button>
+    <div class="container-img_6321_420" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_420: linear-gradient(180deg, #44583f 0%, #3a4537 100%);<br/>
+    --border-img_6321_420: #525950;<br/>
+    --text-img_6321_420: #657160;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_421"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_421</span></button>
+    <div class="container-img_6321_421" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_421: linear-gradient(180deg, #43523f 0%, #3c4439 100%);<br/>
+    --border-img_6321_421: #4c534a;<br/>
+    --text-img_6321_421: #3e4f3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_422"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_422</span></button>
+    <div class="container-img_6321_422" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_422: linear-gradient(180deg, #484f46 0%, #3f3f3f 100%);<br/>
+    --border-img_6321_422: #455341;<br/>
+    --text-img_6321_422: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_423"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_423</span></button>
+    <div class="container-img_6321_423" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_423: linear-gradient(180deg, #ece9e9 0%, #3f3f3f 100%);<br/>
+    --border-img_6321_423: #727b6e;<br/>
+    --text-img_6321_423: #375330;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_424"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_424</span></button>
+    <div class="container-img_6321_424" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_424: linear-gradient(180deg, #3f4e3b 0%, #3f3f3f 100%);<br/>
+    --border-img_6321_424: #495345;<br/>
+    --text-img_6321_424: #434f40;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_425"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_425</span></button>
+    <div class="container-img_6321_425" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_425: linear-gradient(180deg, #ece9e9 0%, #3f3f3f 100%);<br/>
+    --border-img_6321_425: #6d726a;<br/>
+    --text-img_6321_425: #3a4836;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_426"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_426</span></button>
+    <div class="container-img_6321_426" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_426: linear-gradient(180deg, #40483d 0%, #3f3f3f 100%);<br/>
+    --border-img_6321_426: #4d514c;<br/>
+    --text-img_6321_426: #3f473d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_427"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_427</span></button>
+    <div class="container-img_6321_427" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_427: linear-gradient(180deg, #3c4c37 0%, #628b58 100%);<br/>
+    --border-img_6321_427: #56794d;<br/>
+    --text-img_6321_427: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_428"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_428</span></button>
+    <div class="container-img_6321_428" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_428: linear-gradient(180deg, #3d4b38 0%, #5e8455 100%);<br/>
+    --border-img_6321_428: #53744a;<br/>
+    --text-img_6321_428: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_429"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_429</span></button>
+    <div class="container-img_6321_429" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_429: linear-gradient(180deg, #3a4737 0%, #73b263 100%);<br/>
+    --border-img_6321_429: #4e6648;<br/>
+    --text-img_6321_429: #3f3f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_430"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_430</span></button>
+    <div class="container-img_6321_430" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_430: linear-gradient(180deg, #3f3e3e 0%, #597652 100%);<br/>
+    --border-img_6321_430: #6f9565;<br/>
+    --text-img_6321_430: #3f3e3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_431"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_431</span></button>
+    <div class="container-img_6321_431" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_431: linear-gradient(180deg, #4f5e4a 0%, #fafcf9 100%);<br/>
+    --border-img_6321_431: #729c68;<br/>
+    --text-img_6321_431: #76bb65;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_432"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_432</span></button>
+    <div class="container-img_6321_432" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_432: linear-gradient(180deg, #464e43 0%, #5d974f 100%);<br/>
+    --border-img_6321_432: #506b49;<br/>
+    --text-img_6321_432: #76bb65;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_433"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_433</span></button>
+    <div class="container-img_6321_433" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_433: linear-gradient(180deg, #434841 0%, #59854e 100%);<br/>
+    --border-img_6321_433: #506949;<br/>
+    --text-img_6321_433: #75b964;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_434"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_434</span></button>
+    <div class="container-img_6321_434" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_434: linear-gradient(180deg, #586e52 0%, #567050 100%);<br/>
+    --border-img_6321_434: #76a66a;<br/>
+    --text-img_6321_434: #4d554a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_435"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_435</span></button>
+    <div class="container-img_6321_435" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_435: linear-gradient(180deg, #7dc36a 0%, #ffffff 100%);<br/>
+    --border-img_6321_435: #a6d49a;<br/>
+    --text-img_6321_435: #78bc66;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_436"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_436</span></button>
+    <div class="container-img_6321_436" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_436: linear-gradient(180deg, #566e4f 0%, #54704d 100%);<br/>
+    --border-img_6321_436: #739f68;<br/>
+    --text-img_6321_436: #4f5f4b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_437"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_437</span></button>
+    <div class="container-img_6321_437" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_437: linear-gradient(180deg, #7dc36a 0%, #508842 100%);<br/>
+    --border-img_6321_437: #6cad5b;<br/>
+    --text-img_6321_437: #76bb64;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_438"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_438</span></button>
+    <div class="container-img_6321_438" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_438: linear-gradient(180deg, #597851 0%, #57784f 100%);<br/>
+    --border-img_6321_438: #55744d;<br/>
+    --text-img_6321_438: #597b50;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_439"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_439</span></button>
+    <div class="container-img_6321_439" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_439: linear-gradient(180deg, #5f8755 0%, #577550 100%);<br/>
+    --border-img_6321_439: #729469;<br/>
+    --text-img_6321_439: #608c55;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_440"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_440</span></button>
+    <div class="container-img_6321_440" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_440: linear-gradient(180deg, #5c8052 0%, #52694c 100%);<br/>
+    --border-img_6321_440: #658a5c;<br/>
+    --text-img_6321_440: #52694c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_441"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_441</span></button>
+    <div class="container-img_6321_441" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_441: linear-gradient(180deg, #6aa65b 0%, #5d8c52 100%);<br/>
+    --border-img_6321_441: #4e6948;<br/>
+    --text-img_6321_441: #69aa59;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_442"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_442</span></button>
+    <div class="container-img_6321_442" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_442: linear-gradient(180deg, #546d4e 0%, #455142 100%);<br/>
+    --border-img_6321_442: #516d4b;<br/>
+    --text-img_6321_442: #3e3e3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_443"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_443</span></button>
+    <div class="container-img_6321_443" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_443: linear-gradient(180deg, #69ab5a 0%, #393939 100%);<br/>
+    --border-img_6321_443: #52734b;<br/>
+    --text-img_6321_443: #577650;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_444"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_444</span></button>
+    <div class="container-img_6321_444" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_444: linear-gradient(180deg, #526d4c 0%, #3b3b3b 100%);<br/>
+    --border-img_6321_444: #4e6748;<br/>
+    --text-img_6321_444: #3e3e3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_445"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_445</span></button>
+    <div class="container-img_6321_445" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_445: linear-gradient(180deg, #69ab5a 0%, #4f8742 100%);<br/>
+    --border-img_6321_445: #58894d;<br/>
+    --text-img_6321_445: #516d4a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_446"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_446</span></button>
+    <div class="container-img_6321_446" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_446: linear-gradient(180deg, #54754c 0%, #44563f 100%);<br/>
+    --border-img_6321_446: #4b6345;<br/>
+    --text-img_6321_446: #40423f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_447"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_447</span></button>
+    <div class="container-img_6321_447" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_447: linear-gradient(180deg, #567350 0%, #3f433d 100%);<br/>
+    --border-img_6321_447: #495d45;<br/>
+    --text-img_6321_447: #3e3e3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_448"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_448</span></button>
+    <div class="container-img_6321_448" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_448: linear-gradient(180deg, #66a757 0%, #363636 100%);<br/>
+    --border-img_6321_448: #495f44;<br/>
+    --text-img_6321_448: #3a3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_449"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_449</span></button>
+    <div class="container-img_6321_449" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_449: linear-gradient(180deg, #64a156 0%, #4e7a42 100%);<br/>
+    --border-img_6321_449: #4d6b45;<br/>
+    --text-img_6321_449: #44583f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_450"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_450</span></button>
+    <div class="container-img_6321_450" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_450: linear-gradient(180deg, #5a8850 0%, #496a41 100%);<br/>
+    --border-img_6321_450: #4b6544;<br/>
+    --text-img_6321_450: #424f3f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_451"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_451</span></button>
+    <div class="container-img_6321_451" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_451: linear-gradient(180deg, #3b3b3b 0%, #3d423c 100%);<br/>
+    --border-img_6321_451: #3e443d;<br/>
+    --text-img_6321_451: #3a3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_452"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_452</span></button>
+    <div class="container-img_6321_452" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_452: linear-gradient(180deg, #3b3b3b 0%, #3e463c 100%);<br/>
+    --border-img_6321_452: #465742;<br/>
+    --text-img_6321_452: #393939;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_453"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_453</span></button>
+    <div class="container-img_6321_453" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_453: linear-gradient(180deg, #42503f 0%, #79a170 100%);<br/>
+    --border-img_6321_453: #566952;<br/>
+    --text-img_6321_453: #4f8142;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_454"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_454</span></button>
+    <div class="container-img_6321_454" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_454: linear-gradient(180deg, #373737 0%, #323232 100%);<br/>
+    --border-img_6321_454: #363936;<br/>
+    --text-img_6321_454: #4b6645;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_455"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_455</span></button>
+    <div class="container-img_6321_455" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_455: linear-gradient(180deg, #3a3a3a 0%, #383737 100%);<br/>
+    --border-img_6321_455: #404f3c;<br/>
+    --text-img_6321_455: #383838;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_456"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_456</span></button>
+    <div class="container-img_6321_456" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_456: linear-gradient(180deg, #4f8142 0%, #4e7543 100%);<br/>
+    --border-img_6321_456: #56834b;<br/>
+    --text-img_6321_456: #9fcc95;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_457"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_457</span></button>
+    <div class="container-img_6321_457" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_457: linear-gradient(180deg, #465d40 0%, #455740 100%);<br/>
+    --border-img_6321_457: #4c6246;<br/>
+    --text-img_6321_457: #44563f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_458"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_458</span></button>
+    <div class="container-img_6321_458" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_458: linear-gradient(180deg, #3e423c 0%, #3d3d3d 100%);<br/>
+    --border-img_6321_458: #424940;<br/>
+    --text-img_6321_458: #3e3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_459"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_459</span></button>
+    <div class="container-img_6321_459" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_459: linear-gradient(180deg, #4b6645 0%, #3d3d3d 100%);<br/>
+    --border-img_6321_459: #3a4139;<br/>
+    --text-img_6321_459: #303030;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_460"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_460</span></button>
+    <div class="container-img_6321_460" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_460: linear-gradient(180deg, #769e6c 0%, #3d3d3d 100%);<br/>
+    --border-img_6321_460: #4f5d4b;<br/>
+    --text-img_6321_460: #4d7243;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_461"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_461</span></button>
+    <div class="container-img_6321_461" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_461: linear-gradient(180deg, #5e7c57 0%, #3d3d3d 100%);<br/>
+    --border-img_6321_461: #4c5948;<br/>
+    --text-img_6321_461: #4c6e43;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_462"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_462</span></button>
+    <div class="container-img_6321_462" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_462: linear-gradient(180deg, #383938 0%, #3e403d 100%);<br/>
+    --border-img_6321_462: #383a38;<br/>
+    --text-img_6321_462: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_463"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_463</span></button>
+    <div class="container-img_6321_463" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_463: linear-gradient(180deg, #383b37 0%, #3a3a3a 100%);<br/>
+    --border-img_6321_463: #3b4139;<br/>
+    --text-img_6321_463: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_464"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_464</span></button>
+    <div class="container-img_6321_464" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_464: linear-gradient(180deg, #4b6e42 0%, #393939 100%);<br/>
+    --border-img_6321_464: #414c3d;<br/>
+    --text-img_6321_464: #3e3f3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_465"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_465</span></button>
+    <div class="container-img_6321_465" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_465: linear-gradient(180deg, #3f463d 0%, #3c3e3b 100%);<br/>
+    --border-img_6321_465: #3a3d39;<br/>
+    --text-img_6321_465: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_466"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_466</span></button>
+    <div class="container-img_6321_466" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_466: linear-gradient(180deg, #2f2f2f 0%, #383838 100%);<br/>
+    --border-img_6321_466: #363636;<br/>
+    --text-img_6321_466: #3c3c3c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_467"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_467</span></button>
+    <div class="container-img_6321_467" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_467: linear-gradient(180deg, #383737 0%, #3a3a3a 100%);<br/>
+    --border-img_6321_467: #393a39;<br/>
+    --text-img_6321_467: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_468"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_468</span></button>
+    <div class="container-img_6321_468" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_468: linear-gradient(180deg, #4d7044 0%, #383838 100%);<br/>
+    --border-img_6321_468: #404b3c;<br/>
+    --text-img_6321_468: #3c3c3c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_469"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_469</span></button>
+    <div class="container-img_6321_469" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_469: linear-gradient(180deg, #43513f 0%, #393939 100%);<br/>
+    --border-img_6321_469: #3e433d;<br/>
+    --text-img_6321_469: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_470"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_470</span></button>
+    <div class="container-img_6321_470" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_470: linear-gradient(180deg, #3c3e3c 0%, #3c3d3b 100%);<br/>
+    --border-img_6321_470: #404140;<br/>
+    --text-img_6321_470: #3d3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_471"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_471</span></button>
+    <div class="container-img_6321_471" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_471: linear-gradient(180deg, #373737 0%, #303030 100%);<br/>
+    --border-img_6321_471: #434643;<br/>
+    --text-img_6321_471: #e5ffdf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_472"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_472</span></button>
+    <div class="container-img_6321_472" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_472: linear-gradient(180deg, #373737 0%, #323131 100%);<br/>
+    --border-img_6321_472: #3b3b3a;<br/>
+    --text-img_6321_472: #3c3e3b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_473"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_473</span></button>
+    <div class="container-img_6321_473" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_473: linear-gradient(180deg, #383838 0%, #333333 100%);<br/>
+    --border-img_6321_473: #3a3a3a;<br/>
+    --text-img_6321_473: #343434;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_474"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_474</span></button>
+    <div class="container-img_6321_474" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_474: linear-gradient(180deg, #3b3d3b 0%, #393a38 100%);<br/>
+    --border-img_6321_474: #4c4f4b;<br/>
+    --text-img_6321_474: #393838;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_475"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_475</span></button>
+    <div class="container-img_6321_475" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_475: linear-gradient(180deg, #393839 0%, #363535 100%);<br/>
+    --border-img_6321_475: #434543;<br/>
+    --text-img_6321_475: #373737;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_476"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_476</span></button>
+    <div class="container-img_6321_476" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_476: linear-gradient(180deg, #363636 0%, #313131 100%);<br/>
+    --border-img_6321_476: #393a39;<br/>
+    --text-img_6321_476: #494f48;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_477"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_477</span></button>
+    <div class="container-img_6321_477" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_477: linear-gradient(180deg, #3c3e3b 0%, #3d3f3c 100%);<br/>
+    --border-img_6321_477: #424342;<br/>
+    --text-img_6321_477: #474f45;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_478"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_478</span></button>
+    <div class="container-img_6321_478" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_478: linear-gradient(180deg, #9bab98 0%, #303030 100%);<br/>
+    --border-img_6321_478: #494c48;<br/>
+    --text-img_6321_478: #a1b29e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_479"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_479</span></button>
+    <div class="container-img_6321_479" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_479: linear-gradient(180deg, #393839 0%, #363636 100%);<br/>
+    --border-img_6321_479: #434543;<br/>
+    --text-img_6321_479: #373737;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_480"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_480</span></button>
+    <div class="container-img_6321_480" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_480: linear-gradient(180deg, #444944 0%, #303030 100%);<br/>
+    --border-img_6321_480: #363736;<br/>
+    --text-img_6321_480: #464b45;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6321_481"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6321_481</span></button>
+    <div class="container-img_6321_481" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6321_481: linear-gradient(180deg, #383838 0%, #363636 100%);<br/>
+    --border-img_6321_481: #3a3b3a;<br/>
+    --text-img_6321_481: #363636;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_482"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_482</span></button>
+    <div class="container-img_6322_482" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_482: linear-gradient(180deg, #5e6367 0%, #3c3c3c 100%);<br/>
+    --border-img_6322_482: #494b4d;<br/>
+    --text-img_6322_482: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_483"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_483</span></button>
+    <div class="container-img_6322_483" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_483: linear-gradient(180deg, #5e6367 0%, #393939 100%);<br/>
+    --border-img_6322_483: #494b4d;<br/>
+    --text-img_6322_483: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_484"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_484</span></button>
+    <div class="container-img_6322_484" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_484: linear-gradient(180deg, #5e6367 0%, #3f3f3f 100%);<br/>
+    --border-img_6322_484: #4c4e50;<br/>
+    --text-img_6322_484: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_485"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_485</span></button>
+    <div class="container-img_6322_485" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_485: linear-gradient(180deg, #5e6367 0%, #3d3d3d 100%);<br/>
+    --border-img_6322_485: #494b4d;<br/>
+    --text-img_6322_485: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_486"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_486</span></button>
+    <div class="container-img_6322_486" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_486: linear-gradient(180deg, #5e6367 0%, #2f2f2f 100%);<br/>
+    --border-img_6322_486: #46494a;<br/>
+    --text-img_6322_486: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_487"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_487</span></button>
+    <div class="container-img_6322_487" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_487: linear-gradient(180deg, #5e6367 0%, #3a3a3a 100%);<br/>
+    --border-img_6322_487: #4d4f51;<br/>
+    --text-img_6322_487: #3a3c3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_488"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_488</span></button>
+    <div class="container-img_6322_488" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_488: linear-gradient(180deg, #5e6367 0%, #3a3a3a 100%);<br/>
+    --border-img_6322_488: #4b4d4f;<br/>
+    --text-img_6322_488: #3a3c3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_489"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_489</span></button>
+    <div class="container-img_6322_489" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_489: linear-gradient(180deg, #5e6367 0%, #373936 100%);<br/>
+    --border-img_6322_489: #4a4d4e;<br/>
+    --text-img_6322_489: #3a3c3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_490"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_490</span></button>
+    <div class="container-img_6322_490" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_490: linear-gradient(180deg, #5e6367 0%, #3b3a3a 100%);<br/>
+    --border-img_6322_490: #4a4c4e;<br/>
+    --text-img_6322_490: #393a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_491"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_491</span></button>
+    <div class="container-img_6322_491" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_491: linear-gradient(180deg, #5e6367 0%, #363636 100%);<br/>
+    --border-img_6322_491: #4c4e50;<br/>
+    --text-img_6322_491: #393a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_492"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_492</span></button>
+    <div class="container-img_6322_492" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_492: linear-gradient(180deg, #5e6367 0%, #323232 100%);<br/>
+    --border-img_6322_492: #4b4d4f;<br/>
+    --text-img_6322_492: #393a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_493"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_493</span></button>
+    <div class="container-img_6322_493" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_493: linear-gradient(180deg, #5e6367 0%, #2f2f2f 100%);<br/>
+    --border-img_6322_493: #4b4e4f;<br/>
+    --text-img_6322_493: #3a3b3b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_494"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_494</span></button>
+    <div class="container-img_6322_494" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_494: linear-gradient(180deg, #3c3b3c 0%, #3c3b3b 100%);<br/>
+    --border-img_6322_494: #393939;<br/>
+    --text-img_6322_494: #3c3b3b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_495"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_495</span></button>
+    <div class="container-img_6322_495" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_495: linear-gradient(180deg, #363636 0%, #2f2f2f 100%);<br/>
+    --border-img_6322_495: #464646;<br/>
+    --text-img_6322_495: #9c9c9c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_496"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_496</span></button>
+    <div class="container-img_6322_496" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_496: linear-gradient(180deg, #3a3a3a 0%, #363535 100%);<br/>
+    --border-img_6322_496: #494848;<br/>
+    --text-img_6322_496: #3c3c3c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_497"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_497</span></button>
+    <div class="container-img_6322_497" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_497: linear-gradient(180deg, #343434 0%, #2b2b2b 100%);<br/>
+    --border-img_6322_497: #515050;<br/>
+    --text-img_6322_497: #676767;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_498"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_498</span></button>
+    <div class="container-img_6322_498" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_498: linear-gradient(180deg, #2f2f2f 0%, #2f2f2f 100%);<br/>
+    --border-img_6322_498: #464b44;<br/>
+    --text-img_6322_498: #9f9f9f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_499"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_499</span></button>
+    <div class="container-img_6322_499" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_499: linear-gradient(180deg, #4a4a49 0%, #3c3b3b 100%);<br/>
+    --border-img_6322_499: #525252;<br/>
+    --text-img_6322_499: #363636;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_500"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_500</span></button>
+    <div class="container-img_6322_500" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_500: linear-gradient(180deg, #525252 0%, #3c3b3b 100%);<br/>
+    --border-img_6322_500: #585757;<br/>
+    --text-img_6322_500: #363535;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_501"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_501</span></button>
+    <div class="container-img_6322_501" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_501: linear-gradient(180deg, #747673 0%, #3c3b3b 100%);<br/>
+    --border-img_6322_501: #585857;<br/>
+    --text-img_6322_501: #2f2f2f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_502"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_502</span></button>
+    <div class="container-img_6322_502" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_502: linear-gradient(180deg, #3a3a3a 0%, #414040 100%);<br/>
+    --border-img_6322_502: #484848;<br/>
+    --text-img_6322_502: #3c3b3b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_503"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_503</span></button>
+    <div class="container-img_6322_503" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_503: linear-gradient(180deg, #989898 0%, #5a5959 100%);<br/>
+    --border-img_6322_503: #5e5e5e;<br/>
+    --text-img_6322_503: #383737;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_504"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_504</span></button>
+    <div class="container-img_6322_504" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_504: linear-gradient(180deg, #d7d7d7 0%, #4f4f4f 100%);<br/>
+    --border-img_6322_504: #5d5d5d;<br/>
+    --text-img_6322_504: #3e3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_505"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_505</span></button>
+    <div class="container-img_6322_505" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_505: linear-gradient(180deg, #c1c1c1 0%, #424242 100%);<br/>
+    --border-img_6322_505: #60605f;<br/>
+    --text-img_6322_505: #40463e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_506"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_506</span></button>
+    <div class="container-img_6322_506" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_506: linear-gradient(180deg, #3c3b3b 0%, #3b3b3b 100%);<br/>
+    --border-img_6322_506: #444343;<br/>
+    --text-img_6322_506: #3b3b3b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_507"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_507</span></button>
+    <div class="container-img_6322_507" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_507: linear-gradient(180deg, #4a4a4a 0%, #e3e3e3 100%);<br/>
+    --border-img_6322_507: #5f5e5e;<br/>
+    --text-img_6322_507: #6b6a6a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_508"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_508</span></button>
+    <div class="container-img_6322_508" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_508: linear-gradient(180deg, #3c3b3b 0%, #626262 100%);<br/>
+    --border-img_6322_508: #5e5d5d;<br/>
+    --text-img_6322_508: #5a5a5a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_509"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_509</span></button>
+    <div class="container-img_6322_509" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_509: linear-gradient(180deg, #3c3b3b 0%, #b6b6b6 100%);<br/>
+    --border-img_6322_509: #626262;<br/>
+    --text-img_6322_509: #4e4e4e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_510"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_510</span></button>
+    <div class="container-img_6322_510" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_510: linear-gradient(180deg, #3c3b3b 0%, #b8b8b8 100%);<br/>
+    --border-img_6322_510: #585757;<br/>
+    --text-img_6322_510: #434343;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_511"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_511</span></button>
+    <div class="container-img_6322_511" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_511: linear-gradient(180deg, #4c4b4b 0%, #464545 100%);<br/>
+    --border-img_6322_511: #525252;<br/>
+    --text-img_6322_511: #494949;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_512"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_512</span></button>
+    <div class="container-img_6322_512" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_512: linear-gradient(180deg, #4b4b4b 0%, #444444 100%);<br/>
+    --border-img_6322_512: #656464;<br/>
+    --text-img_6322_512: #4e4e4e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_513"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_513</span></button>
+    <div class="container-img_6322_513" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_513: linear-gradient(180deg, #434343 0%, #414141 100%);<br/>
+    --border-img_6322_513: #565656;<br/>
+    --text-img_6322_513: #5f5f5f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_514"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_514</span></button>
+    <div class="container-img_6322_514" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_514: linear-gradient(180deg, #404040 0%, #424242 100%);<br/>
+    --border-img_6322_514: #504f4f;<br/>
+    --text-img_6322_514: #3b3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_515"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_515</span></button>
+    <div class="container-img_6322_515" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_515: linear-gradient(180deg, #a4a4a4 0%, #767676 100%);<br/>
+    --border-img_6322_515: #686767;<br/>
+    --text-img_6322_515: #4c4c4c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_516"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_516</span></button>
+    <div class="container-img_6322_516" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_516: linear-gradient(180deg, #ffffff 0%, #7a7a7a 100%);<br/>
+    --border-img_6322_516: #717171;<br/>
+    --text-img_6322_516: #4e4e4e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_517"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_517</span></button>
+    <div class="container-img_6322_517" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_517: linear-gradient(180deg, #989898 0%, #7a7a7a 100%);<br/>
+    --border-img_6322_517: #646363;<br/>
+    --text-img_6322_517: #444444;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_518"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_518</span></button>
+    <div class="container-img_6322_518" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_518: linear-gradient(180deg, #3b3a3a 0%, #3b3a3a 100%);<br/>
+    --border-img_6322_518: #444343;<br/>
+    --text-img_6322_518: #3b3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_519"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_519</span></button>
+    <div class="container-img_6322_519" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_519: linear-gradient(180deg, #525252 0%, #747474 100%);<br/>
+    --border-img_6322_519: #5f5f5f;<br/>
+    --text-img_6322_519: #4c4b4b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_520"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_520</span></button>
+    <div class="container-img_6322_520" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_520: linear-gradient(180deg, #464646 0%, #626161 100%);<br/>
+    --border-img_6322_520: #575757;<br/>
+    --text-img_6322_520: #484747;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_521"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_521</span></button>
+    <div class="container-img_6322_521" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_521: linear-gradient(180deg, #484848 0%, #767676 100%);<br/>
+    --border-img_6322_521: #525151;<br/>
+    --text-img_6322_521: #575656;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_522"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_522</span></button>
+    <div class="container-img_6322_522" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_522: linear-gradient(180deg, #424242 0%, #747474 100%);<br/>
+    --border-img_6322_522: #5a5a5a;<br/>
+    --text-img_6322_522: #515151;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_523"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_523</span></button>
+    <div class="container-img_6322_523" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_523: linear-gradient(180deg, #464646 0%, #4f4e4e 100%);<br/>
+    --border-img_6322_523: #535252;<br/>
+    --text-img_6322_523: #515050;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_524"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_524</span></button>
+    <div class="container-img_6322_524" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_524: linear-gradient(180deg, #696969 0%, #595959 100%);<br/>
+    --border-img_6322_524: #696868;<br/>
+    --text-img_6322_524: #686767;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_525"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_525</span></button>
+    <div class="container-img_6322_525" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_525: linear-gradient(180deg, #646464 0%, #5d5d5d 100%);<br/>
+    --border-img_6322_525: #636363;<br/>
+    --text-img_6322_525: #727171;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_526"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_526</span></button>
+    <div class="container-img_6322_526" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_526: linear-gradient(180deg, #414040 0%, #414040 100%);<br/>
+    --border-img_6322_526: #555555;<br/>
+    --text-img_6322_526: #3a3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_527"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_527</span></button>
+    <div class="container-img_6322_527" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_527: linear-gradient(180deg, #898989 0%, #adadad 100%);<br/>
+    --border-img_6322_527: #737373;<br/>
+    --text-img_6322_527: #605f5f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_528"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_528</span></button>
+    <div class="container-img_6322_528" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_528: linear-gradient(180deg, #e6e6e6 0%, #c1c0c0 100%);<br/>
+    --border-img_6322_528: #888787;<br/>
+    --text-img_6322_528: #626161;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_529"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_529</span></button>
+    <div class="container-img_6322_529" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_529: linear-gradient(180deg, #aaaaaa 0%, #bdbdbd 100%);<br/>
+    --border-img_6322_529: #767676;<br/>
+    --text-img_6322_529: #616060;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_530"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_530</span></button>
+    <div class="container-img_6322_530" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_530: linear-gradient(180deg, #3b3a3a 0%, #3a393a 100%);<br/>
+    --border-img_6322_530: #424141;<br/>
+    --text-img_6322_530: #3a3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_531"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_531</span></button>
+    <div class="container-img_6322_531" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_531: linear-gradient(180deg, #d5d5d5 0%, #3a393a 100%);<br/>
+    --border-img_6322_531: #868686;<br/>
+    --text-img_6322_531: #605f5f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_532"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_532</span></button>
+    <div class="container-img_6322_532" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_532: linear-gradient(180deg, #6f6f6f 0%, #3a3939 100%);<br/>
+    --border-img_6322_532: #717171;<br/>
+    --text-img_6322_532: #676666;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_533"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_533</span></button>
+    <div class="container-img_6322_533" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_533: linear-gradient(180deg, #b9b8b8 0%, #3a393a 100%);<br/>
+    --border-img_6322_533: #7c7b7b;<br/>
+    --text-img_6322_533: #605f5f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_534"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_534</span></button>
+    <div class="container-img_6322_534" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_534: linear-gradient(180deg, #d5d5d5 0%, #3a393a 100%);<br/>
+    --border-img_6322_534: #6f6f6f;<br/>
+    --text-img_6322_534: #605f5f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_535"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_535</span></button>
+    <div class="container-img_6322_535" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_535: linear-gradient(180deg, #3a3a3a 0%, #636262 100%);<br/>
+    --border-img_6322_535: #525252;<br/>
+    --text-img_6322_535: #686767;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_536"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_536</span></button>
+    <div class="container-img_6322_536" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_536: linear-gradient(180deg, #3a3a3a 0%, #929292 100%);<br/>
+    --border-img_6322_536: #8b8b8b;<br/>
+    --text-img_6322_536: #8d8c8c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_537"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_537</span></button>
+    <div class="container-img_6322_537" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_537: linear-gradient(180deg, #3a3a3a 0%, #656464 100%);<br/>
+    --border-img_6322_537: #757474;<br/>
+    --text-img_6322_537: #bdbdbd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_538"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_538</span></button>
+    <div class="container-img_6322_538" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_538: linear-gradient(180deg, #3a3939 0%, #3a3939 100%);<br/>
+    --border-img_6322_538: #5c5b5b;<br/>
+    --text-img_6322_538: #3a3939;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_539"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_539</span></button>
+    <div class="container-img_6322_539" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_539: linear-gradient(180deg, #bbbaba 0%, #a4a2a2 100%);<br/>
+    --border-img_6322_539: #a9a8a8;<br/>
+    --text-img_6322_539: #4f4f4f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_540"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_540</span></button>
+    <div class="container-img_6322_540" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_540: linear-gradient(180deg, #858484 0%, #797878 100%);<br/>
+    --border-img_6322_540: #9f9f9f;<br/>
+    --text-img_6322_540: #959494;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_541"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_541</span></button>
+    <div class="container-img_6322_541" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_541: linear-gradient(180deg, #b8b8b8 0%, #a3a2a2 100%);<br/>
+    --border-img_6322_541: #8b8b8a;<br/>
+    --text-img_6322_541: #d1d0d0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_542"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_542</span></button>
+    <div class="container-img_6322_542" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_542: linear-gradient(180deg, #bbbbbb 0%, #a4a3a3 100%);<br/>
+    --border-img_6322_542: #a9a8a8;<br/>
+    --text-img_6322_542: #333333;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_543"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_543</span></button>
+    <div class="container-img_6322_543" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_543: linear-gradient(180deg, #474646 0%, #3a3939 100%);<br/>
+    --border-img_6322_543: #5e5d5d;<br/>
+    --text-img_6322_543: #3a3939;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_544"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_544</span></button>
+    <div class="container-img_6322_544" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_544: linear-gradient(180deg, #aaa9a9 0%, #3a3939 100%);<br/>
+    --border-img_6322_544: #797878;<br/>
+    --text-img_6322_544: #a6a4a4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_545"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_545</span></button>
+    <div class="container-img_6322_545" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_545: linear-gradient(180deg, #c9c8c8 0%, #3a3939 100%);<br/>
+    --border-img_6322_545: #b0b0b0;<br/>
+    --text-img_6322_545: #a6a4a4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_546"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_546</span></button>
+    <div class="container-img_6322_546" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_546: linear-gradient(180deg, #b5b5b5 0%, #3a3939 100%);<br/>
+    --border-img_6322_546: #858484;<br/>
+    --text-img_6322_546: #a7a5a5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_547"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_547</span></button>
+    <div class="container-img_6322_547" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_547: linear-gradient(180deg, #6c6b6b 0%, #8f8e8e 100%);<br/>
+    --border-img_6322_547: #787878;<br/>
+    --text-img_6322_547: #3a3939;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_548"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_548</span></button>
+    <div class="container-img_6322_548" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_548: linear-gradient(180deg, #7d7c7c 0%, #aeaeae 100%);<br/>
+    --border-img_6322_548: #a9a8a8;<br/>
+    --text-img_6322_548: #414040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_549"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_549</span></button>
+    <div class="container-img_6322_549" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_549: linear-gradient(180deg, #868585 0%, #b3b3b3 100%);<br/>
+    --border-img_6322_549: #acacac;<br/>
+    --text-img_6322_549: #3e3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_550"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_550</span></button>
+    <div class="container-img_6322_550" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_550: linear-gradient(180deg, #3a3939 0%, #393838 100%);<br/>
+    --border-img_6322_550: #5f5e5e;<br/>
+    --text-img_6322_550: #393939;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_551"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_551</span></button>
+    <div class="container-img_6322_551" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_551: linear-gradient(180deg, #3a3939 0%, #4f4f4f 100%);<br/>
+    --border-img_6322_551: #818080;<br/>
+    --text-img_6322_551: #eaeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_552"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_552</span></button>
+    <div class="container-img_6322_552" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_552: linear-gradient(180deg, #3a3939 0%, #959595 100%);<br/>
+    --border-img_6322_552: #888888;<br/>
+    --text-img_6322_552: #cccccc;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_553"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_553</span></button>
+    <div class="container-img_6322_553" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_553: linear-gradient(180deg, #3a3939 0%, #9a9999 100%);<br/>
+    --border-img_6322_553: #616060;<br/>
+    --text-img_6322_553: #eaeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_554"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_554</span></button>
+    <div class="container-img_6322_554" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_554: linear-gradient(180deg, #3a3939 0%, #4c6746 100%);<br/>
+    --border-img_6322_554: #868d85;<br/>
+    --text-img_6322_554: #eaeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_555"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_555</span></button>
+    <div class="container-img_6322_555" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_555: linear-gradient(180deg, #515151 0%, #393838 100%);<br/>
+    --border-img_6322_555: #696969;<br/>
+    --text-img_6322_555: #393838;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_556"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_556</span></button>
+    <div class="container-img_6322_556" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_556: linear-gradient(180deg, #e3e3e3 0%, #393838 100%);<br/>
+    --border-img_6322_556: #7f7e7e;<br/>
+    --text-img_6322_556: #eaeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_557"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_557</span></button>
+    <div class="container-img_6322_557" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_557: linear-gradient(180deg, #ededed 0%, #393838 100%);<br/>
+    --border-img_6322_557: #c4c4c4;<br/>
+    --text-img_6322_557: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_558"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_558</span></button>
+    <div class="container-img_6322_558" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_558: linear-gradient(180deg, #ededed 0%, #393838 100%);<br/>
+    --border-img_6322_558: #8d908b;<br/>
+    --text-img_6322_558: #eff0ef;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_559"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_559</span></button>
+    <div class="container-img_6322_559" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_559: linear-gradient(180deg, #706f6f 0%, #858484 100%);<br/>
+    --border-img_6322_559: #747373;<br/>
+    --text-img_6322_559: #696868;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_560"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_560</span></button>
+    <div class="container-img_6322_560" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_560: linear-gradient(180deg, #858484 0%, #acacac 100%);<br/>
+    --border-img_6322_560: #a7a7a7;<br/>
+    --text-img_6322_560: #848383;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_561"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_561</span></button>
+    <div class="container-img_6322_561" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_561: linear-gradient(180deg, #758072 0%, #afb0af 100%);<br/>
+    --border-img_6322_561: #a8aca7;<br/>
+    --text-img_6322_561: #a2a1a1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_562"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_562</span></button>
+    <div class="container-img_6322_562" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_562: linear-gradient(180deg, #393838 0%, #393838 100%);<br/>
+    --border-img_6322_562: #575656;<br/>
+    --text-img_6322_562: #393838;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_563"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_563</span></button>
+    <div class="container-img_6322_563" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_563: linear-gradient(180deg, #fafaf9 0%, #ebebeb 100%);<br/>
+    --border-img_6322_563: #d7d7d7;<br/>
+    --text-img_6322_563: #3a3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_564"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_564</span></button>
+    <div class="container-img_6322_564" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_564: linear-gradient(180deg, #aeaeae 0%, #a1a1a1 100%);<br/>
+    --border-img_6322_564: #b4b4b4;<br/>
+    --text-img_6322_564: #393838;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_565"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_565</span></button>
+    <div class="container-img_6322_565" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_565: linear-gradient(180deg, #f9f9f9 0%, #e8e8e8 100%);<br/>
+    --border-img_6322_565: #a1a1a1;<br/>
+    --text-img_6322_565: #3b3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_566"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_566</span></button>
+    <div class="container-img_6322_566" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_566: linear-gradient(180deg, #fafafa 0%, #ebebeb 100%);<br/>
+    --border-img_6322_566: #d2d3d2;<br/>
+    --text-img_6322_566: #3d3d3c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_567"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_567</span></button>
+    <div class="container-img_6322_567" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_567: linear-gradient(180deg, #474646 0%, #343739 100%);<br/>
+    --border-img_6322_567: #656566;<br/>
+    --text-img_6322_567: #383838;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_568"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_568</span></button>
+    <div class="container-img_6322_568" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_568: linear-gradient(180deg, #e8e8e8 0%, #343739 100%);<br/>
+    --border-img_6322_568: #727273;<br/>
+    --text-img_6322_568: #d5d5d5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_569"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_569</span></button>
+    <div class="container-img_6322_569" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_569: linear-gradient(180deg, #ececec 0%, #343739 100%);<br/>
+    --border-img_6322_569: #b2b3b4;<br/>
+    --text-img_6322_569: #d5d5d5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_570"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_570</span></button>
+    <div class="container-img_6322_570" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_570: linear-gradient(180deg, #ececec 0%, #343739 100%);<br/>
+    --border-img_6322_570: #7a7e7a;<br/>
+    --text-img_6322_570: #d7e5d4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_571"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_571</span></button>
+    <div class="container-img_6322_571" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_571: linear-gradient(180deg, #888888 0%, #343739 100%);<br/>
+    --border-img_6322_571: #5c5c5d;<br/>
+    --text-img_6322_571: #727171;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_572"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_572</span></button>
+    <div class="container-img_6322_572" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_572: linear-gradient(180deg, #a7a7a7 0%, #3c4042 100%);<br/>
+    --border-img_6322_572: #8c8d8e;<br/>
+    --text-img_6322_572: #b4b4b4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_573"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_573</span></button>
+    <div class="container-img_6322_573" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_573: linear-gradient(180deg, #9ba797 0%, #343739 100%);<br/>
+    --border-img_6322_573: #949a94;<br/>
+    --text-img_6322_573: #f6f8f6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_574"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_574</span></button>
+    <div class="container-img_6322_574" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_574: linear-gradient(180deg, #383838 0%, #343739 100%);<br/>
+    --border-img_6322_574: #4f5050;<br/>
+    --text-img_6322_574: #383838;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_575"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_575</span></button>
+    <div class="container-img_6322_575" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_575: linear-gradient(180deg, #333333 0%, #343739 100%);<br/>
+    --border-img_6322_575: #818182;<br/>
+    --text-img_6322_575: #fbfbfb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_576"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_576</span></button>
+    <div class="container-img_6322_576" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_576: linear-gradient(180deg, #9a9a9a 0%, #494d50 100%);<br/>
+    --border-img_6322_576: #8f9091;<br/>
+    --text-img_6322_576: #cac9c9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_577"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_577</span></button>
+    <div class="container-img_6322_577" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_577: linear-gradient(180deg, #aeadad 0%, #343739 100%);<br/>
+    --border-img_6322_577: #727374;<br/>
+    --text-img_6322_577: #fbfbfb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6322_578"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6322_578</span></button>
+    <div class="container-img_6322_578" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6322_578: linear-gradient(180deg, #70ab62 0%, #343739 100%);<br/>
+    --border-img_6322_578: #8a9988;<br/>
+    --text-img_6322_578: #fbfbfb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_579"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_579</span></button>
+    <div class="container-img_6323_579" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_579: linear-gradient(180deg, #5e6367 0%, #383838 100%);<br/>
+    --border-img_6323_579: #494b4d;<br/>
+    --text-img_6323_579: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_580"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_580</span></button>
+    <div class="container-img_6323_580" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_580: linear-gradient(180deg, #5e6367 0%, #2f2f2f 100%);<br/>
+    --border-img_6323_580: #484b4c;<br/>
+    --text-img_6323_580: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_581"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_581</span></button>
+    <div class="container-img_6323_581" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_581: linear-gradient(180deg, #5e6367 0%, #393b38 100%);<br/>
+    --border-img_6323_581: #4b4d4e;<br/>
+    --text-img_6323_581: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_582"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_582</span></button>
+    <div class="container-img_6323_582" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_582: linear-gradient(180deg, #5e6367 0%, #373738 100%);<br/>
+    --border-img_6323_582: #47494b;<br/>
+    --text-img_6323_582: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_583"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_583</span></button>
+    <div class="container-img_6323_583" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_583: linear-gradient(180deg, #5e6367 0%, #3b3b3b 100%);<br/>
+    --border-img_6323_583: #494b4d;<br/>
+    --text-img_6323_583: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_584"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_584</span></button>
+    <div class="container-img_6323_584" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_584: linear-gradient(180deg, #5e6367 0%, #3b3d3b 100%);<br/>
+    --border-img_6323_584: #4c4f50;<br/>
+    --text-img_6323_584: #3a3c3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_585"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_585</span></button>
+    <div class="container-img_6323_585" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_585: linear-gradient(180deg, #5e6367 0%, #353635 100%);<br/>
+    --border-img_6323_585: #494c4d;<br/>
+    --text-img_6323_585: #3a3c3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_586"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_586</span></button>
+    <div class="container-img_6323_586" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_586: linear-gradient(180deg, #5e6367 0%, #383838 100%);<br/>
+    --border-img_6323_586: #4a4d4f;<br/>
+    --text-img_6323_586: #3a3c3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_587"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_587</span></button>
+    <div class="container-img_6323_587" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_587: linear-gradient(180deg, #5e6367 0%, #323232 100%);<br/>
+    --border-img_6323_587: #4a4c4e;<br/>
+    --text-img_6323_587: #393a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_588"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_588</span></button>
+    <div class="container-img_6323_588" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_588: linear-gradient(180deg, #5e6367 0%, #2f2f2f 100%);<br/>
+    --border-img_6323_588: #494c4d;<br/>
+    --text-img_6323_588: #3a3b3b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_589"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_589</span></button>
+    <div class="container-img_6323_589" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_589: linear-gradient(180deg, #5e6367 0%, #323232 100%);<br/>
+    --border-img_6323_589: #4c4e50;<br/>
+    --text-img_6323_589: #393a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_590"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_590</span></button>
+    <div class="container-img_6323_590" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_590: linear-gradient(180deg, #5e6367 0%, #383838 100%);<br/>
+    --border-img_6323_590: #494b4d;<br/>
+    --text-img_6323_590: #393a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_591"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_591</span></button>
+    <div class="container-img_6323_591" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_591: linear-gradient(180deg, #313131 0%, #212121 100%);<br/>
+    --border-img_6323_591: #4c4b4b;<br/>
+    --text-img_6323_591: #919191;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_592"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_592</span></button>
+    <div class="container-img_6323_592" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_592: linear-gradient(180deg, #2f2f2f 0%, #303030 100%);<br/>
+    --border-img_6323_592: #4f534e;<br/>
+    --text-img_6323_592: #8c8c8c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_593"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_593</span></button>
+    <div class="container-img_6323_593" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_593: linear-gradient(180deg, #373836 0%, #3d423b 100%);<br/>
+    --border-img_6323_593: #434542;<br/>
+    --text-img_6323_593: #3a3e38;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_594"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_594</span></button>
+    <div class="container-img_6323_594" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_594: linear-gradient(180deg, #313131 0%, #222222 100%);<br/>
+    --border-img_6323_594: #3a3939;<br/>
+    --text-img_6323_594: #777575;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_595"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_595</span></button>
+    <div class="container-img_6323_595" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_595: linear-gradient(180deg, #363635 0%, #2f2f2f 100%);<br/>
+    --border-img_6323_595: #3d3d3d;<br/>
+    --text-img_6323_595: #2a2a2a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_596"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_596</span></button>
+    <div class="container-img_6323_596" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_596: linear-gradient(180deg, #505250 0%, #3c3b3b 100%);<br/>
+    --border-img_6323_596: #565655;<br/>
+    --text-img_6323_596: #303030;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_597"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_597</span></button>
+    <div class="container-img_6323_597" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_597: linear-gradient(180deg, #3d3d3c 0%, #3c3b3b 100%);<br/>
+    --border-img_6323_597: #545453;<br/>
+    --text-img_6323_597: #383b37;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_598"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_598</span></button>
+    <div class="container-img_6323_598" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_598: linear-gradient(180deg, #343434 0%, #3c3b3b 100%);<br/>
+    --border-img_6323_598: #444444;<br/>
+    --text-img_6323_598: #363636;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_599"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_599</span></button>
+    <div class="container-img_6323_599" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_599: linear-gradient(180deg, #9a9a9a 0%, #505050 100%);<br/>
+    --border-img_6323_599: #5b5a5a;<br/>
+    --text-img_6323_599: #3e3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_600"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_600</span></button>
+    <div class="container-img_6323_600" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_600: linear-gradient(180deg, #ffffff 0%, #424242 100%);<br/>
+    --border-img_6323_600: #616261;<br/>
+    --text-img_6323_600: #40463e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_601"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_601</span></button>
+    <div class="container-img_6323_601" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_601: linear-gradient(180deg, #858383 0%, #454945 100%);<br/>
+    --border-img_6323_601: #515150;<br/>
+    --text-img_6323_601: #363636;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_602"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_602</span></button>
+    <div class="container-img_6323_602" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_602: linear-gradient(180deg, #373737 0%, #424442 100%);<br/>
+    --border-img_6323_602: #3f403f;<br/>
+    --text-img_6323_602: #3d3c3c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_603"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_603</span></button>
+    <div class="container-img_6323_603" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_603: linear-gradient(180deg, #3c3b3b 0%, #fefefe 100%);<br/>
+    --border-img_6323_603: #696969;<br/>
+    --text-img_6323_603: #4e4e4e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_604"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_604</span></button>
+    <div class="container-img_6323_604" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_604: linear-gradient(180deg, #3c3b3b 0%, #8e8e8e 100%);<br/>
+    --border-img_6323_604: #555555;<br/>
+    --text-img_6323_604: #424242;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_605"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_605</span></button>
+    <div class="container-img_6323_605" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_605: linear-gradient(180deg, #3c3b3b 0%, #494949 100%);<br/>
+    --border-img_6323_605: #4d4e4d;<br/>
+    --text-img_6323_605: #424242;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_606"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_606</span></button>
+    <div class="container-img_6323_606" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_606: linear-gradient(180deg, #3c3b3b 0%, #e3e1e1 100%);<br/>
+    --border-img_6323_606: #656664;<br/>
+    --text-img_6323_606: #464646;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_607"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_607</span></button>
+    <div class="container-img_6323_607" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_607: linear-gradient(180deg, #3c3b3b 0%, #474d46 100%);<br/>
+    --border-img_6323_607: #4a5248;<br/>
+    --text-img_6323_607: #434343;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_608"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_608</span></button>
+    <div class="container-img_6323_608" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_608: linear-gradient(180deg, #4d4d4d 0%, #464646 100%);<br/>
+    --border-img_6323_608: #5f5e5e;<br/>
+    --text-img_6323_608: #6e6e6e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_609"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_609</span></button>
+    <div class="container-img_6323_609" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_609: linear-gradient(180deg, #434542 0%, #434642 100%);<br/>
+    --border-img_6323_609: #555754;<br/>
+    --text-img_6323_609: #414141;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_610"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_610</span></button>
+    <div class="container-img_6323_610" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_610: linear-gradient(180deg, #424442 0%, #444643 100%);<br/>
+    --border-img_6323_610: #575e55;<br/>
+    --text-img_6323_610: #454944;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_611"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_611</span></button>
+    <div class="container-img_6323_611" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_611: linear-gradient(180deg, #c9c9c9 0%, #7a7a7a 100%);<br/>
+    --border-img_6323_611: #6f6e6e;<br/>
+    --text-img_6323_611: #4e4e4e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_612"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_612</span></button>
+    <div class="container-img_6323_612" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_612: linear-gradient(180deg, #b8b8b8 0%, #7a7a7a 100%);<br/>
+    --border-img_6323_612: #636363;<br/>
+    --text-img_6323_612: #444444;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_613"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_613</span></button>
+    <div class="container-img_6323_613" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_613: linear-gradient(180deg, #989a96 0%, #696a68 100%);<br/>
+    --border-img_6323_613: #646563;<br/>
+    --text-img_6323_613: #4b5449;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_614"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_614</span></button>
+    <div class="container-img_6323_614" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_614: linear-gradient(180deg, #424442 0%, #676967 100%);<br/>
+    --border-img_6323_614: #61675f;<br/>
+    --text-img_6323_614: #3d3c3c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_615"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_615</span></button>
+    <div class="container-img_6323_615" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_615: linear-gradient(180deg, #444444 0%, #747474 100%);<br/>
+    --border-img_6323_615: #5d5c5c;<br/>
+    --text-img_6323_615: #575656;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_616"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_616</span></button>
+    <div class="container-img_6323_616" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_616: linear-gradient(180deg, #424242 0%, #747474 100%);<br/>
+    --border-img_6323_616: #515151;<br/>
+    --text-img_6323_616: #515151;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_617"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_617</span></button>
+    <div class="container-img_6323_617" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_617: linear-gradient(180deg, #403f3f 0%, #565555 100%);<br/>
+    --border-img_6323_617: #4d4e4c;<br/>
+    --text-img_6323_617: #3c3b3b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_618"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_618</span></button>
+    <div class="container-img_6323_618" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_618: linear-gradient(180deg, #424242 0%, #757474 100%);<br/>
+    --border-img_6323_618: #5b5d5a;<br/>
+    --text-img_6323_618: #4f554d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_619"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_619</span></button>
+    <div class="container-img_6323_619" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_619: linear-gradient(180deg, #404040 0%, #60615f 100%);<br/>
+    --border-img_6323_619: #585957;<br/>
+    --text-img_6323_619: #3c3b3b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_620"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_620</span></button>
+    <div class="container-img_6323_620" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_620: linear-gradient(180deg, #717171 0%, #5e5e5e 100%);<br/>
+    --border-img_6323_620: #6b6a6a;<br/>
+    --text-img_6323_620: #757575;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_621"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_621</span></button>
+    <div class="container-img_6323_621" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_621: linear-gradient(180deg, #535252 0%, #504f4f 100%);<br/>
+    --border-img_6323_621: #606060;<br/>
+    --text-img_6323_621: #545353;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_622"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_622</span></button>
+    <div class="container-img_6323_622" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_622: linear-gradient(180deg, #63775f 0%, #5e5e5d 100%);<br/>
+    --border-img_6323_622: #676965;<br/>
+    --text-img_6323_622: #737673;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_623"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_623</span></button>
+    <div class="container-img_6323_623" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_623: linear-gradient(180deg, #a2a2a2 0%, #bdbcbc 100%);<br/>
+    --border-img_6323_623: #7d7c7c;<br/>
+    --text-img_6323_623: #626161;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_624"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_624</span></button>
+    <div class="container-img_6323_624" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_624: linear-gradient(180deg, #bfbfbf 0%, #c2c1c1 100%);<br/>
+    --border-img_6323_624: #818080;<br/>
+    --text-img_6323_624: #616060;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_625"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_625</span></button>
+    <div class="container-img_6323_625" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_625: linear-gradient(180deg, #737572 0%, #c1c1c1 100%);<br/>
+    --border-img_6323_625: #7b7b7a;<br/>
+    --text-img_6323_625: #636561;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_626"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_626</span></button>
+    <div class="container-img_6323_626" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_626: linear-gradient(180deg, #60625f 0%, #807f7f 100%);<br/>
+    --border-img_6323_626: #7b7f7a;<br/>
+    --text-img_6323_626: #464a44;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_627"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_627</span></button>
+    <div class="container-img_6323_627" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_627: linear-gradient(180deg, #f4f4f4 0%, #3a3939 100%);<br/>
+    --border-img_6323_627: #969595;<br/>
+    --text-img_6323_627: #605f5f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_628"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_628</span></button>
+    <div class="container-img_6323_628" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_628: linear-gradient(180deg, #b3b2b2 0%, #3a393a 100%);<br/>
+    --border-img_6323_628: #616060;<br/>
+    --text-img_6323_628: #605f5f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_629"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_629</span></button>
+    <div class="container-img_6323_629" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_629: linear-gradient(180deg, #525151 0%, #3a3939 100%);<br/>
+    --border-img_6323_629: #555455;<br/>
+    --text-img_6323_629: #4c4b4b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_630"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_630</span></button>
+    <div class="container-img_6323_630" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_630: linear-gradient(180deg, #ffffff 0%, #3a3939 100%);<br/>
+    --border-img_6323_630: #8f8f8e;<br/>
+    --text-img_6323_630: #605f5f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_631"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_631</span></button>
+    <div class="container-img_6323_631" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_631: linear-gradient(180deg, #5b5d5a 0%, #3a393a 100%);<br/>
+    --border-img_6323_631: #656c63;<br/>
+    --text-img_6323_631: #504f4f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_632"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_632</span></button>
+    <div class="container-img_6323_632" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_632: linear-gradient(180deg, #3a3a3a 0%, #a3a3a3 100%);<br/>
+    --border-img_6323_632: #8e8e8e;<br/>
+    --text-img_6323_632: #b0b0b0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_633"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_633</span></button>
+    <div class="container-img_6323_633" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_633: linear-gradient(180deg, #3a3a3a 0%, #8b8a8a 100%);<br/>
+    --border-img_6323_633: #656665;<br/>
+    --text-img_6323_633: #5b5a5a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_634"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_634</span></button>
+    <div class="container-img_6323_634" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_634: linear-gradient(180deg, #3a3a3a 0%, #7f7e7e 100%);<br/>
+    --border-img_6323_634: #70766e;<br/>
+    --text-img_6323_634: #3a3939;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_635"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_635</span></button>
+    <div class="container-img_6323_635" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_635: linear-gradient(180deg, #bababa 0%, #a3a2a2 100%);<br/>
+    --border-img_6323_635: #b8b7b7;<br/>
+    --text-img_6323_635: #f4f4f4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_636"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_636</span></button>
+    <div class="container-img_6323_636" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_636: linear-gradient(180deg, #bbbbbb 0%, #a4a3a3 100%);<br/>
+    --border-img_6323_636: #7d7c7c;<br/>
+    --text-img_6323_636: #565656;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_637"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_637</span></button>
+    <div class="container-img_6323_637" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_637: linear-gradient(180deg, #757474 0%, #6b6a6a 100%);<br/>
+    --border-img_6323_637: #979696;<br/>
+    --text-img_6323_637: #4a4949;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_638"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_638</span></button>
+    <div class="container-img_6323_638" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_638: linear-gradient(180deg, #bbbaba 0%, #a4a2a2 100%);<br/>
+    --border-img_6323_638: #a4a3a3;<br/>
+    --text-img_6323_638: #343434;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_639"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_639</span></button>
+    <div class="container-img_6323_639" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_639: linear-gradient(180deg, #a6a6a6 0%, #949292 100%);<br/>
+    --border-img_6323_639: #767774;<br/>
+    --text-img_6323_639: #a2a5a1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_640"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_640</span></button>
+    <div class="container-img_6323_640" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_640: linear-gradient(180deg, #bbbbbb 0%, #3a3939 100%);<br/>
+    --border-img_6323_640: #8e8d8d;<br/>
+    --text-img_6323_640: #a6a4a4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_641"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_641</span></button>
+    <div class="container-img_6323_641" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_641: linear-gradient(180deg, #b5b5b5 0%, #3a3939 100%);<br/>
+    --border-img_6323_641: #afafaf;<br/>
+    --text-img_6323_641: #a7a5a5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_642"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_642</span></button>
+    <div class="container-img_6323_642" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_642: linear-gradient(180deg, #908f8f 0%, #3a3939 100%);<br/>
+    --border-img_6323_642: #808080;<br/>
+    --text-img_6323_642: #a6a4a4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_643"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_643</span></button>
+    <div class="container-img_6323_643" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_643: linear-gradient(180deg, #807f7f 0%, #474646 100%);<br/>
+    --border-img_6323_643: #90928f;<br/>
+    --text-img_6323_643: #898787;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_644"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_644</span></button>
+    <div class="container-img_6323_644" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_644: linear-gradient(180deg, #868585 0%, #b3b3b3 100%);<br/>
+    --border-img_6323_644: #acabab;<br/>
+    --text-img_6323_644: #474646;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_645"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_645</span></button>
+    <div class="container-img_6323_645" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_645: linear-gradient(180deg, #838282 0%, #9d9d9c 100%);<br/>
+    --border-img_6323_645: #a7a7a6;<br/>
+    --text-img_6323_645: #3b3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_646"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_646</span></button>
+    <div class="container-img_6323_646" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_646: linear-gradient(180deg, #797878 0%, #a8a8a8 100%);<br/>
+    --border-img_6323_646: #aaa9a9;<br/>
+    --text-img_6323_646: #3a3a39;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_647"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_647</span></button>
+    <div class="container-img_6323_647" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_647: linear-gradient(180deg, #3a3939 0%, #565555 100%);<br/>
+    --border-img_6323_647: #878787;<br/>
+    --text-img_6323_647: #eaeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_648"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_648</span></button>
+    <div class="container-img_6323_648" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_648: linear-gradient(180deg, #3a3939 0%, #91a18e 100%);<br/>
+    --border-img_6323_648: #5f645d;<br/>
+    --text-img_6323_648: #eaeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_649"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_649</span></button>
+    <div class="container-img_6323_649" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_649: linear-gradient(180deg, #3a3939 0%, #8e908d 100%);<br/>
+    --border-img_6323_649: #7e837d;<br/>
+    --text-img_6323_649: #a0a0a0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_650"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_650</span></button>
+    <div class="container-img_6323_650" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_650: linear-gradient(180deg, #3a3939 0%, #518a43 100%);<br/>
+    --border-img_6323_650: #859482;<br/>
+    --text-img_6323_650: #eaeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_651"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_651</span></button>
+    <div class="container-img_6323_651" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_651: linear-gradient(180deg, #3a3939 0%, #919191 100%);<br/>
+    --border-img_6323_651: #989797;<br/>
+    --text-img_6323_651: #a3a2a2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_652"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_652</span></button>
+    <div class="container-img_6323_652" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_652: linear-gradient(180deg, #ededed 0%, #393838 100%);<br/>
+    --border-img_6323_652: #858484;<br/>
+    --text-img_6323_652: #f0f0f0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_653"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_653</span></button>
+    <div class="container-img_6323_653" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_653: linear-gradient(180deg, #ededed 0%, #393838 100%);<br/>
+    --border-img_6323_653: #cacec9;<br/>
+    --text-img_6323_653: #eceeec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_654"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_654</span></button>
+    <div class="container-img_6323_654" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_654: linear-gradient(180deg, #d7d8d6 0%, #393838 100%);<br/>
+    --border-img_6323_654: #7d817c;<br/>
+    --text-img_6323_654: #f2f4f1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_655"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_655</span></button>
+    <div class="container-img_6323_655" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_655: linear-gradient(180deg, #929291 0%, #393838 100%);<br/>
+    --border-img_6323_655: #9ea19d;<br/>
+    --text-img_6323_655: #393838;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_656"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_656</span></button>
+    <div class="container-img_6323_656" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_656: linear-gradient(180deg, #7c7b7b 0%, #aeafae 100%);<br/>
+    --border-img_6323_656: #a7a9a7;<br/>
+    --text-img_6323_656: #a9a9a9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_657"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_657</span></button>
+    <div class="container-img_6323_657" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_657: linear-gradient(180deg, #777f75 0%, #9a9a99 100%);<br/>
+    --border-img_6323_657: #a3a9a1;<br/>
+    --text-img_6323_657: #6b6a6a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_658"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_658</span></button>
+    <div class="container-img_6323_658" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_658: linear-gradient(180deg, #7f8e7a 0%, #9d9d9d 100%);<br/>
+    --border-img_6323_658: #979e94;<br/>
+    --text-img_6323_658: #636562;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_659"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_659</span></button>
+    <div class="container-img_6323_659" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_659: linear-gradient(180deg, #fafafa 0%, #ebebeb 100%);<br/>
+    --border-img_6323_659: #d1d1d1;<br/>
+    --text-img_6323_659: #3b3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_660"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_660</span></button>
+    <div class="container-img_6323_660" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_660: linear-gradient(180deg, #fafafa 0%, #ebebeb 100%);<br/>
+    --border-img_6323_660: #a3a3a2;<br/>
+    --text-img_6323_660: #3d3d3c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_661"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_661</span></button>
+    <div class="container-img_6323_661" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_661: linear-gradient(180deg, #9f9e9e 0%, #9e9e9d 100%);<br/>
+    --border-img_6323_661: #989897;<br/>
+    --text-img_6323_661: #393838;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_662"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_662</span></button>
+    <div class="container-img_6323_662" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_662: linear-gradient(180deg, #fafafa 0%, #ebebeb 100%);<br/>
+    --border-img_6323_662: #d3d4d3;<br/>
+    --text-img_6323_662: #3b3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_663"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_663</span></button>
+    <div class="container-img_6323_663" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_663: linear-gradient(180deg, #939191 0%, #464545 100%);<br/>
+    --border-img_6323_663: #8b8b8b;<br/>
+    --text-img_6323_663: #424141;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_664"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_664</span></button>
+    <div class="container-img_6323_664" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_664: linear-gradient(180deg, #ececec 0%, #343739 100%);<br/>
+    --border-img_6323_664: #777878;<br/>
+    --text-img_6323_664: #dbdbdb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_665"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_665</span></button>
+    <div class="container-img_6323_665" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_665: linear-gradient(180deg, #ececec 0%, #343739 100%);<br/>
+    --border-img_6323_665: #b1b2b3;<br/>
+    --text-img_6323_665: #d3e3cf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_666"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_666</span></button>
+    <div class="container-img_6323_666" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_666: linear-gradient(180deg, #d0d0d0 0%, #343739 100%);<br/>
+    --border-img_6323_666: #737374;<br/>
+    --text-img_6323_666: #eaeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_667"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_667</span></button>
+    <div class="container-img_6323_667" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_667: linear-gradient(180deg, #6a6a6a 0%, #343739 100%);<br/>
+    --border-img_6323_667: #767777;<br/>
+    --text-img_6323_667: #464646;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_668"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_668</span></button>
+    <div class="container-img_6323_668" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_668: linear-gradient(180deg, #b4b4b3 0%, #343739 100%);<br/>
+    --border-img_6323_668: #8d908e;<br/>
+    --text-img_6323_668: #edecec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_669"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_669</span></button>
+    <div class="container-img_6323_669" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_669: linear-gradient(180deg, #9e9f9e 0%, #3c4042 100%);<br/>
+    --border-img_6323_669: #8a918b;<br/>
+    --text-img_6323_669: #b1b2b0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_670"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_670</span></button>
+    <div class="container-img_6323_670" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_670: linear-gradient(180deg, #a2a2a2 0%, #343739 100%);<br/>
+    --border-img_6323_670: #737475;<br/>
+    --text-img_6323_670: #b1b1b1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_671"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_671</span></button>
+    <div class="container-img_6323_671" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_671: linear-gradient(180deg, #7c7b7b 0%, #343739 100%);<br/>
+    --border-img_6323_671: #8d8d8e;<br/>
+    --text-img_6323_671: #fbfbfb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_672"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_672</span></button>
+    <div class="container-img_6323_672" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_672: linear-gradient(180deg, #aacba2 0%, #343739 100%);<br/>
+    --border-img_6323_672: #677366;<br/>
+    --text-img_6323_672: #fbfbfb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_673"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_673</span></button>
+    <div class="container-img_6323_673" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_673: linear-gradient(180deg, #999d97 0%, #494d50 100%);<br/>
+    --border-img_6323_673: #747a74;<br/>
+    --text-img_6323_673: #bcbfbc;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_674"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_674</span></button>
+    <div class="container-img_6323_674" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_674: linear-gradient(180deg, #4a4a4a 0%, #343739 100%);<br/>
+    --border-img_6323_674: #8e8f90;<br/>
+    --text-img_6323_674: #fbfbfb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6323_675"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6323_675</span></button>
+    <div class="container-img_6323_675" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6323_675: linear-gradient(180deg, #525252 0%, #343739 100%);<br/>
+    --border-img_6323_675: #78797a;<br/>
+    --text-img_6323_675: #575757;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_676"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_676</span></button>
+    <div class="container-img_6324_676" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_676: linear-gradient(180deg, #5e6367 0%, #2f2f2f 100%);<br/>
+    --border-img_6324_676: #474a4b;<br/>
+    --text-img_6324_676: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_677"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_677</span></button>
+    <div class="container-img_6324_677" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_677: linear-gradient(180deg, #5e6367 0%, #383b37 100%);<br/>
+    --border-img_6324_677: #494b4c;<br/>
+    --text-img_6324_677: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_678"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_678</span></button>
+    <div class="container-img_6324_678" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_678: linear-gradient(180deg, #5e6367 0%, #373738 100%);<br/>
+    --border-img_6324_678: #4b4d4f;<br/>
+    --text-img_6324_678: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_679"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_679</span></button>
+    <div class="container-img_6324_679" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_679: linear-gradient(180deg, #5e6367 0%, #3b3b3b 100%);<br/>
+    --border-img_6324_679: #484a4c;<br/>
+    --text-img_6324_679: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_680"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_680</span></button>
+    <div class="container-img_6324_680" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_680: linear-gradient(180deg, #5e6367 0%, #393939 100%);<br/>
+    --border-img_6324_680: #494b4d;<br/>
+    --text-img_6324_680: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_681"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_681</span></button>
+    <div class="container-img_6324_681" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_681: linear-gradient(180deg, #5e6367 0%, #2f2f2f 100%);<br/>
+    --border-img_6324_681: #4c504f;<br/>
+    --text-img_6324_681: #3a3c3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_682"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_682</span></button>
+    <div class="container-img_6324_682" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_682: linear-gradient(180deg, #5e6367 0%, #353535 100%);<br/>
+    --border-img_6324_682: #4a4c4e;<br/>
+    --text-img_6324_682: #3a3c3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_683"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_683</span></button>
+    <div class="container-img_6324_683" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_683: linear-gradient(180deg, #5e6367 0%, #363636 100%);<br/>
+    --border-img_6324_683: #4b4d4f;<br/>
+    --text-img_6324_683: #3a3c3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_684"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_684</span></button>
+    <div class="container-img_6324_684" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_684: linear-gradient(180deg, #5e6367 0%, #2f2f2f 100%);<br/>
+    --border-img_6324_684: #4a4d4e;<br/>
+    --text-img_6324_684: #3a3b3b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_685"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_685</span></button>
+    <div class="container-img_6324_685" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_685: linear-gradient(180deg, #5e6367 0%, #363636 100%);<br/>
+    --border-img_6324_685: #494c4d;<br/>
+    --text-img_6324_685: #393a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_686"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_686</span></button>
+    <div class="container-img_6324_686" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_686: linear-gradient(180deg, #5e6367 0%, #383737 100%);<br/>
+    --border-img_6324_686: #4b4d4e;<br/>
+    --text-img_6324_686: #393a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_687"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_687</span></button>
+    <div class="container-img_6324_687" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_687: linear-gradient(180deg, #5e6367 0%, #323232 100%);<br/>
+    --border-img_6324_687: #494b4d;<br/>
+    --text-img_6324_687: #393a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_688"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_688</span></button>
+    <div class="container-img_6324_688" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_688: linear-gradient(180deg, #2f2f2f 0%, #343833 100%);<br/>
+    --border-img_6324_688: #50544f;<br/>
+    --text-img_6324_688: #7a7a7a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_689"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_689</span></button>
+    <div class="container-img_6324_689" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_689: linear-gradient(180deg, #363836 0%, #3c413a 100%);<br/>
+    --border-img_6324_689: #444643;<br/>
+    --text-img_6324_689: #383c36;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_690"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_690</span></button>
+    <div class="container-img_6324_690" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_690: linear-gradient(180deg, #313131 0%, #222222 100%);<br/>
+    --border-img_6324_690: #3d3c3c;<br/>
+    --text-img_6324_690: #777575;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_691"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_691</span></button>
+    <div class="container-img_6324_691" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_691: linear-gradient(180deg, #363636 0%, #313030 100%);<br/>
+    --border-img_6324_691: #393939;<br/>
+    --text-img_6324_691: #2f2f2f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_692"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_692</span></button>
+    <div class="container-img_6324_692" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_692: linear-gradient(180deg, #313131 0%, #272727 100%);<br/>
+    --border-img_6324_692: #3f3f3f;<br/>
+    --text-img_6324_692: #404040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_693"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_693</span></button>
+    <div class="container-img_6324_693" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_693: linear-gradient(180deg, #bcbcbc 0%, #3c3b3b 100%);<br/>
+    --border-img_6324_693: #4b4e4a;<br/>
+    --text-img_6324_693: #2f2f2f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_694"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_694</span></button>
+    <div class="container-img_6324_694" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_694: linear-gradient(180deg, #8d8b8b 0%, #3c3b3b 100%);<br/>
+    --border-img_6324_694: #424341;<br/>
+    --text-img_6324_694: #252525;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_695"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_695</span></button>
+    <div class="container-img_6324_695" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_695: linear-gradient(180deg, #525252 0%, #3c3b3b 100%);<br/>
+    --border-img_6324_695: #3a3a3a;<br/>
+    --text-img_6324_695: #262626;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_696"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_696</span></button>
+    <div class="container-img_6324_696" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_696: linear-gradient(180deg, #c7c7c7 0%, #424242 100%);<br/>
+    --border-img_6324_696: #616160;<br/>
+    --text-img_6324_696: #40463e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_697"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_697</span></button>
+    <div class="container-img_6324_697" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_697: linear-gradient(180deg, #4d4c4c 0%, #434642 100%);<br/>
+    --border-img_6324_697: #494a48;<br/>
+    --text-img_6324_697: #393939;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_698"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_698</span></button>
+    <div class="container-img_6324_698" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_698: linear-gradient(180deg, #434242 0%, #424442 100%);<br/>
+    --border-img_6324_698: #454545;<br/>
+    --text-img_6324_698: #3b3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_699"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_699</span></button>
+    <div class="container-img_6324_699" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_699: linear-gradient(180deg, #565656 0%, #424242 100%);<br/>
+    --border-img_6324_699: #434343;<br/>
+    --text-img_6324_699: #383737;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_700"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_700</span></button>
+    <div class="container-img_6324_700" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_700: linear-gradient(180deg, #3c3b3b 0%, #888888 100%);<br/>
+    --border-img_6324_700: #555454;<br/>
+    --text-img_6324_700: #424242;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_701"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_701</span></button>
+    <div class="container-img_6324_701" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_701: linear-gradient(180deg, #3c3b3b 0%, #4f4f4f 100%);<br/>
+    --border-img_6324_701: #535952;<br/>
+    --text-img_6324_701: #434343;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_702"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_702</span></button>
+    <div class="container-img_6324_702" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_702: linear-gradient(180deg, #3c3b3b 0%, #e3e1e1 100%);<br/>
+    --border-img_6324_702: #636462;<br/>
+    --text-img_6324_702: #464646;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_703"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_703</span></button>
+    <div class="container-img_6324_703" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_703: linear-gradient(180deg, #3c3b3b 0%, #434542 100%);<br/>
+    --border-img_6324_703: #4a5147;<br/>
+    --text-img_6324_703: #424242;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_704"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_704</span></button>
+    <div class="container-img_6324_704" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_704: linear-gradient(180deg, #3c3b3b 0%, #76a26b 100%);<br/>
+    --border-img_6324_704: #4c5749;<br/>
+    --text-img_6324_704: #424242;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_705"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_705</span></button>
+    <div class="container-img_6324_705" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_705: linear-gradient(180deg, #424242 0%, #424242 100%);<br/>
+    --border-img_6324_705: #454444;<br/>
+    --text-img_6324_705: #b8b8b8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_706"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_706</span></button>
+    <div class="container-img_6324_706" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_706: linear-gradient(180deg, #424242 0%, #424242 100%);<br/>
+    --border-img_6324_706: #484f46;<br/>
+    --text-img_6324_706: #e3e1e1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_707"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_707</span></button>
+    <div class="container-img_6324_707" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_707: linear-gradient(180deg, #424242 0%, #424242 100%);<br/>
+    --border-img_6324_707: #434343;<br/>
+    --text-img_6324_707: #8fd07f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_708"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_708</span></button>
+    <div class="container-img_6324_708" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_708: linear-gradient(180deg, #9c9c9c 0%, #7a7a7a 100%);<br/>
+    --border-img_6324_708: #646363;<br/>
+    --text-img_6324_708: #444444;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_709"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_709</span></button>
+    <div class="container-img_6324_709" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_709: linear-gradient(180deg, #4f524e 0%, #4d4e4c 100%);<br/>
+    --border-img_6324_709: #5d5e5d;<br/>
+    --text-img_6324_709: #495246;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_710"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_710</span></button>
+    <div class="container-img_6324_710" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_710: linear-gradient(180deg, #70716f 0%, #717370 100%);<br/>
+    --border-img_6324_710: #636462;<br/>
+    --text-img_6324_710: #4f5b4c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_711"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_711</span></button>
+    <div class="container-img_6324_711" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_711: linear-gradient(180deg, #83ba75 0%, #7b7a7a 100%);<br/>
+    --border-img_6324_711: #5d695a;<br/>
+    --text-img_6324_711: #434343;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_712"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_712</span></button>
+    <div class="container-img_6324_712" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_712: linear-gradient(180deg, #424242 0%, #747474 100%);<br/>
+    --border-img_6324_712: #505050;<br/>
+    --text-img_6324_712: #515151;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_713"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_713</span></button>
+    <div class="container-img_6324_713" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_713: linear-gradient(180deg, #404040 0%, #595858 100%);<br/>
+    --border-img_6324_713: #4e504d;<br/>
+    --text-img_6324_713: #3e3d3d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_714"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_714</span></button>
+    <div class="container-img_6324_714" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_714: linear-gradient(180deg, #424242 0%, #757474 100%);<br/>
+    --border-img_6324_714: #5b5d5a;<br/>
+    --text-img_6324_714: #4f554d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_715"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_715</span></button>
+    <div class="container-img_6324_715" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_715: linear-gradient(180deg, #403f3f 0%, #60625f 100%);<br/>
+    --border-img_6324_715: #585957;<br/>
+    --text-img_6324_715: #3b3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_716"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_716</span></button>
+    <div class="container-img_6324_716" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_716: linear-gradient(180deg, #424242 0%, #757474 100%);<br/>
+    --border-img_6324_716: #515050;<br/>
+    --text-img_6324_716: #4d4c4c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_717"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_717</span></button>
+    <div class="container-img_6324_717" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_717: linear-gradient(180deg, #7a7a7a 0%, #656565 100%);<br/>
+    --border-img_6324_717: #4c4b4b;<br/>
+    --text-img_6324_717: #9d9d9d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_718"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_718</span></button>
+    <div class="container-img_6324_718" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_718: linear-gradient(180deg, #81a479 0%, #666565 100%);<br/>
+    --border-img_6324_718: #50504f;<br/>
+    --text-img_6324_718: #989797;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_719"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_719</span></button>
+    <div class="container-img_6324_719" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_719: linear-gradient(180deg, #7a7a7a 0%, #666565 100%);<br/>
+    --border-img_6324_719: #4f4e4e;<br/>
+    --text-img_6324_719: #7e9878;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_720"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_720</span></button>
+    <div class="container-img_6324_720" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_720: linear-gradient(180deg, #aeaeae 0%, #c0c0c0 100%);<br/>
+    --border-img_6324_720: #777777;<br/>
+    --text-img_6324_720: #616060;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_721"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_721</span></button>
+    <div class="container-img_6324_721" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_721: linear-gradient(180deg, #4a4b49 0%, #939393 100%);<br/>
+    --border-img_6324_721: #767675;<br/>
+    --text-img_6324_721: #3a3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_722"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_722</span></button>
+    <div class="container-img_6324_722" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_722: linear-gradient(180deg, #797b78 0%, #666666 100%);<br/>
+    --border-img_6324_722: #828281;<br/>
+    --text-img_6324_722: #606060;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_723"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_723</span></button>
+    <div class="container-img_6324_723" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_723: linear-gradient(180deg, #80a477 0%, #aaaaaa 100%);<br/>
+    --border-img_6324_723: #6d746b;<br/>
+    --text-img_6324_723: #605f5f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_724"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_724</span></button>
+    <div class="container-img_6324_724" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_724: linear-gradient(180deg, #adadad 0%, #3a393a 100%);<br/>
+    --border-img_6324_724: #605f5f;<br/>
+    --text-img_6324_724: #605f5f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_725"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_725</span></button>
+    <div class="container-img_6324_725" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_725: linear-gradient(180deg, #555555 0%, #3a3939 100%);<br/>
+    --border-img_6324_725: #565555;<br/>
+    --text-img_6324_725: #525252;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_726"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_726</span></button>
+    <div class="container-img_6324_726" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_726: linear-gradient(180deg, #f9f9f9 0%, #3a393a 100%);<br/>
+    --border-img_6324_726: #8f8f8f;<br/>
+    --text-img_6324_726: #605f5f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_727"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_727</span></button>
+    <div class="container-img_6324_727" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_727: linear-gradient(180deg, #5b5d5a 0%, #3a393a 100%);<br/>
+    --border-img_6324_727: #646a62;<br/>
+    --text-img_6324_727: #494949;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_728"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_728</span></button>
+    <div class="container-img_6324_728" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_728: linear-gradient(180deg, #84b279 0%, #3a3939 100%);<br/>
+    --border-img_6324_728: #606d5d;<br/>
+    --text-img_6324_728: #605f5f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_729"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_729</span></button>
+    <div class="container-img_6324_729" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_729: linear-gradient(180deg, #3a393a 0%, #606060 100%);<br/>
+    --border-img_6324_729: #4e4e4e;<br/>
+    --text-img_6324_729: #bebebe;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_730"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_730</span></button>
+    <div class="container-img_6324_730" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_730: linear-gradient(180deg, #3a3a3a 0%, #4f4f4f 100%);<br/>
+    --border-img_6324_730: #616660;<br/>
+    --text-img_6324_730: #bdbdbd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_731"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_731</span></button>
+    <div class="container-img_6324_731" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_731: linear-gradient(180deg, #3a3a3a 0%, #6f806a 100%);<br/>
+    --border-img_6324_731: #646762;<br/>
+    --text-img_6324_731: #bdbdbd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_732"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_732</span></button>
+    <div class="container-img_6324_732" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_732: linear-gradient(180deg, #bbbbbb 0%, #a4a3a3 100%);<br/>
+    --border-img_6324_732: #7b7a7a;<br/>
+    --text-img_6324_732: #686767;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_733"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_733</span></button>
+    <div class="container-img_6324_733" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_733: linear-gradient(180deg, #757474 0%, #6b6a6a 100%);<br/>
+    --border-img_6324_733: #969696;<br/>
+    --text-img_6324_733: #5d5c5c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_734"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_734</span></button>
+    <div class="container-img_6324_734" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_734: linear-gradient(180deg, #bbbaba 0%, #a4a2a2 100%);<br/>
+    --border-img_6324_734: #a5a4a4;<br/>
+    --text-img_6324_734: #343434;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_735"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_735</span></button>
+    <div class="container-img_6324_735" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_735: linear-gradient(180deg, #9f9f9f 0%, #8e8d8d 100%);<br/>
+    --border-img_6324_735: #747672;<br/>
+    --text-img_6324_735: #ababaa;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_736"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_736</span></button>
+    <div class="container-img_6324_736" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_736: linear-gradient(180deg, #999898 0%, #898787 100%);<br/>
+    --border-img_6324_736: #747573;<br/>
+    --text-img_6324_736: #afaeae;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_737"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_737</span></button>
+    <div class="container-img_6324_737" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_737: linear-gradient(180deg, #b5b5b5 0%, #3a3939 100%);<br/>
+    --border-img_6324_737: #868585;<br/>
+    --text-img_6324_737: #a7a5a5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_738"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_738</span></button>
+    <div class="container-img_6324_738" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_738: linear-gradient(180deg, #929191 0%, #3a3939 100%);<br/>
+    --border-img_6324_738: #8b8a8a;<br/>
+    --text-img_6324_738: #a6a4a4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_739"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_739</span></button>
+    <div class="container-img_6324_739" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_739: linear-gradient(180deg, #707070 0%, #3a3939 100%);<br/>
+    --border-img_6324_739: #8d8e8c;<br/>
+    --text-img_6324_739: #3a3939;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_740"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_740</span></button>
+    <div class="container-img_6324_740" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_740: linear-gradient(180deg, #a7a7a7 0%, #b3b3b3 100%);<br/>
+    --border-img_6324_740: #878885;<br/>
+    --text-img_6324_740: #a6a4a4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_741"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_741</span></button>
+    <div class="container-img_6324_741" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_741: linear-gradient(180deg, #a6a5a5 0%, #ececec 100%);<br/>
+    --border-img_6324_741: #8f8e8e;<br/>
+    --text-img_6324_741: #414040;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_742"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_742</span></button>
+    <div class="container-img_6324_742" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_742: linear-gradient(180deg, #a5a4a4 0%, #ececec 100%);<br/>
+    --border-img_6324_742: #939392;<br/>
+    --text-img_6324_742: #3e413d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_743"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_743</span></button>
+    <div class="container-img_6324_743" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_743: linear-gradient(180deg, #a5a4a4 0%, #f3f3f3 100%);<br/>
+    --border-img_6324_743: #8b8a8a;<br/>
+    --text-img_6324_743: #616060;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_744"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_744</span></button>
+    <div class="container-img_6324_744" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_744: linear-gradient(180deg, #3a3939 0%, #96a492 100%);<br/>
+    --border-img_6324_744: #5e635c;<br/>
+    --text-img_6324_744: #eaebea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_745"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_745</span></button>
+    <div class="container-img_6324_745" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_745: linear-gradient(180deg, #3a3939 0%, #8f938e 100%);<br/>
+    --border-img_6324_745: #6a7068;<br/>
+    --text-img_6324_745: #bebdbd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_746"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_746</span></button>
+    <div class="container-img_6324_746" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_746: linear-gradient(180deg, #3a3939 0%, #518a43 100%);<br/>
+    --border-img_6324_746: #869583;<br/>
+    --text-img_6324_746: #eaeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_747"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_747</span></button>
+    <div class="container-img_6324_747" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_747: linear-gradient(180deg, #3a3939 0%, #8b8a8a 100%);<br/>
+    --border-img_6324_747: #999998;<br/>
+    --text-img_6324_747: #858484;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_748"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_748</span></button>
+    <div class="container-img_6324_748" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_748: linear-gradient(180deg, #3a3939 0%, #cac9c9 100%);<br/>
+    --border-img_6324_748: #777777;<br/>
+    --text-img_6324_748: #f6f5f5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_749"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_749</span></button>
+    <div class="container-img_6324_749" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_749: linear-gradient(180deg, #ededed 0%, #393838 100%);<br/>
+    --border-img_6324_749: #8e928d;<br/>
+    --text-img_6324_749: #eeefee;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_750"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_750</span></button>
+    <div class="container-img_6324_750" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_750: linear-gradient(180deg, #888887 0%, #393838 100%);<br/>
+    --border-img_6324_750: #a0a49f;<br/>
+    --text-img_6324_750: #757874;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_751"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_751</span></button>
+    <div class="container-img_6324_751" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_751: linear-gradient(180deg, #a6a6a6 0%, #393838 100%);<br/>
+    --border-img_6324_751: #a1a59f;<br/>
+    --text-img_6324_751: #d3d5d3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_752"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_752</span></button>
+    <div class="container-img_6324_752" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_752: linear-gradient(180deg, #f2f2f2 0%, #393838 100%);<br/>
+    --border-img_6324_752: #858484;<br/>
+    --text-img_6324_752: #e2e1e1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_753"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_753</span></button>
+    <div class="container-img_6324_753" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_753: linear-gradient(180deg, #587153 0%, #e8e8e8 100%);<br/>
+    --border-img_6324_753: #919690;<br/>
+    --text-img_6324_753: #b3b3b3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_754"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_754</span></button>
+    <div class="container-img_6324_754" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_754: linear-gradient(180deg, #5f9353 0%, #e8e8e8 100%);<br/>
+    --border-img_6324_754: #8e998b;<br/>
+    --text-img_6324_754: #b0b3af;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_755"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_755</span></button>
+    <div class="container-img_6324_755" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_755: linear-gradient(180deg, #b7b6b6 0%, #424242 100%);<br/>
+    --border-img_6324_755: #686767;<br/>
+    --text-img_6324_755: #c0bfbf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_756"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_756</span></button>
+    <div class="container-img_6324_756" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_756: linear-gradient(180deg, #f5f5f5 0%, #e8e9e8 100%);<br/>
+    --border-img_6324_756: #a0a09f;<br/>
+    --text-img_6324_756: #3d3d3c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_757"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_757</span></button>
+    <div class="container-img_6324_757" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_757: linear-gradient(180deg, #a9a9a9 0%, #a7a8a7 100%);<br/>
+    --border-img_6324_757: #8f908e;<br/>
+    --text-img_6324_757: #393838;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_758"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_758</span></button>
+    <div class="container-img_6324_758" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_758: linear-gradient(180deg, #fafafa 0%, #ebebeb 100%);<br/>
+    --border-img_6324_758: #d3d4d3;<br/>
+    --text-img_6324_758: #3b3a3a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_759"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_759</span></button>
+    <div class="container-img_6324_759" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_759: linear-gradient(180deg, #898888 0%, #454545 100%);<br/>
+    --border-img_6324_759: #8e8e8d;<br/>
+    --text-img_6324_759: #3e3e3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_760"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_760</span></button>
+    <div class="container-img_6324_760" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_760: linear-gradient(180deg, #e4e2e2 0%, #424242 100%);<br/>
+    --border-img_6324_760: #6e6d6d;<br/>
+    --text-img_6324_760: #505050;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_761"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_761</span></button>
+    <div class="container-img_6324_761" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_761: linear-gradient(180deg, #ecedec 0%, #343739 100%);<br/>
+    --border-img_6324_761: #7a7f7b;<br/>
+    --text-img_6324_761: #d5e4d1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_762"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_762</span></button>
+    <div class="container-img_6324_762" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_762: linear-gradient(180deg, #838282 0%, #343739 100%);<br/>
+    --border-img_6324_762: #979899;<br/>
+    --text-img_6324_762: #626262;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_763"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_763</span></button>
+    <div class="container-img_6324_763" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_763: linear-gradient(180deg, #afafae 0%, #343739 100%);<br/>
+    --border-img_6324_763: #717273;<br/>
+    --text-img_6324_763: #eeeeee;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_764"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_764</span></button>
+    <div class="container-img_6324_764" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_764: linear-gradient(180deg, #424242 0%, #343739 100%);<br/>
+    --border-img_6324_764: #49494a;<br/>
+    --text-img_6324_764: #656565;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_765"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_765</span></button>
+    <div class="container-img_6324_765" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_765: linear-gradient(180deg, #b5d0af 0%, #343739 100%);<br/>
+    --border-img_6324_765: #808281;<br/>
+    --text-img_6324_765: #f9f9f9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_766"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_766</span></button>
+    <div class="container-img_6324_766" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_766: linear-gradient(180deg, #a9a9a9 0%, #3c4042 100%);<br/>
+    --border-img_6324_766: #818283;<br/>
+    --text-img_6324_766: #f9f9f9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_767"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_767</span></button>
+    <div class="container-img_6324_767" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_767: linear-gradient(180deg, #a5a5a5 0%, #343739 100%);<br/>
+    --border-img_6324_767: #595a5a;<br/>
+    --text-img_6324_767: #424242;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_768"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_768</span></button>
+    <div class="container-img_6324_768" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_768: linear-gradient(180deg, #aecda7 0%, #343739 100%);<br/>
+    --border-img_6324_768: #677266;<br/>
+    --text-img_6324_768: #fbfbfb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_769"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_769</span></button>
+    <div class="container-img_6324_769" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_769: linear-gradient(180deg, #9ba399 0%, #343739 100%);<br/>
+    --border-img_6324_769: #686f68;<br/>
+    --text-img_6324_769: #dcdfdb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_770"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_770</span></button>
+    <div class="container-img_6324_770" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_770: linear-gradient(180deg, #4a4a4a 0%, #494d50 100%);<br/>
+    --border-img_6324_770: #8a8b8c;<br/>
+    --text-img_6324_770: #fbfbfb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_771"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_771</span></button>
+    <div class="container-img_6324_771" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_771: linear-gradient(180deg, #474747 0%, #343739 100%);<br/>
+    --border-img_6324_771: #818283;<br/>
+    --text-img_6324_771: #555555;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6324_772"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6324_772</span></button>
+    <div class="container-img_6324_772" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6324_772: linear-gradient(180deg, #c8c8c8 0%, #343739 100%);<br/>
+    --border-img_6324_772: #606161;<br/>
+    --text-img_6324_772: #424242;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_773"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_773</span></button>
+    <div class="container-img_6325_773" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_773: linear-gradient(180deg, #5e6367 0%, #cacaca 100%);<br/>
+    --border-img_6325_773: #787a7c;<br/>
+    --text-img_6325_773: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_774"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_774</span></button>
+    <div class="container-img_6325_774" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_774: linear-gradient(180deg, #5e6367 0%, #dddddd 100%);<br/>
+    --border-img_6325_774: #818385;<br/>
+    --text-img_6325_774: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_775"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_775</span></button>
+    <div class="container-img_6325_775" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_775: linear-gradient(180deg, #5e6367 0%, #dddddd 100%);<br/>
+    --border-img_6325_775: #828586;<br/>
+    --text-img_6325_775: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_776"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_776</span></button>
+    <div class="container-img_6325_776" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_776: linear-gradient(180deg, #5e6367 0%, #dddddd 100%);<br/>
+    --border-img_6325_776: #7f8183;<br/>
+    --text-img_6325_776: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_777"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_777</span></button>
+    <div class="container-img_6325_777" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_777: linear-gradient(180deg, #5e6367 0%, #cdcdcd 100%);<br/>
+    --border-img_6325_777: #787b7d;<br/>
+    --text-img_6325_777: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_778"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_778</span></button>
+    <div class="container-img_6325_778" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_778: linear-gradient(180deg, #5e6367 0%, #e3e3e3 100%);<br/>
+    --border-img_6325_778: #898b8d;<br/>
+    --text-img_6325_778: #36383a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_779"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_779</span></button>
+    <div class="container-img_6325_779" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_779: linear-gradient(180deg, #5e6367 0%, #e3e3e3 100%);<br/>
+    --border-img_6325_779: #8e9092;<br/>
+    --text-img_6325_779: #36383a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_780"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_780</span></button>
+    <div class="container-img_6325_780" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_780: linear-gradient(180deg, #5e6367 0%, #e3e3e3 100%);<br/>
+    --border-img_6325_780: #878a8c;<br/>
+    --text-img_6325_780: #36383a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_781"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_781</span></button>
+    <div class="container-img_6325_781" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_781: linear-gradient(180deg, #5e6367 0%, #9a9a9a 100%);<br/>
+    --border-img_6325_781: #76787a;<br/>
+    --text-img_6325_781: #4f4f50;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_782"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_782</span></button>
+    <div class="container-img_6325_782" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_782: linear-gradient(180deg, #5e6367 0%, #dbdbdb 100%);<br/>
+    --border-img_6325_782: #909294;<br/>
+    --text-img_6325_782: #4e4f50;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_783"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_783</span></button>
+    <div class="container-img_6325_783" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_783: linear-gradient(180deg, #5e6367 0%, #dbdbdb 100%);<br/>
+    --border-img_6325_783: #929496;<br/>
+    --text-img_6325_783: #4e4f50;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_784"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_784</span></button>
+    <div class="container-img_6325_784" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_784: linear-gradient(180deg, #5e6367 0%, #b0b8ae 100%);<br/>
+    --border-img_6325_784: #797d7c;<br/>
+    --text-img_6325_784: #4f4f50;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_785"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_785</span></button>
+    <div class="container-img_6325_785" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_785: linear-gradient(180deg, #525252 0%, #d3d3d3 100%);<br/>
+    --border-img_6325_785: #a5a5a5;<br/>
+    --text-img_6325_785: #dddddd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_786"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_786</span></button>
+    <div class="container-img_6325_786" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_786: linear-gradient(180deg, #d8d8d8 0%, #dfdfe0 100%);<br/>
+    --border-img_6325_786: #d4d4d4;<br/>
+    --text-img_6325_786: #dedede;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_787"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_787</span></button>
+    <div class="container-img_6325_787" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_787: linear-gradient(180deg, #d8d8d8 0%, #e0e0e0 100%);<br/>
+    --border-img_6325_787: #d9d9d9;<br/>
+    --text-img_6325_787: #dedede;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_788"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_788</span></button>
+    <div class="container-img_6325_788" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_788: linear-gradient(180deg, #d8d8d8 0%, #dfdfe0 100%);<br/>
+    --border-img_6325_788: #dcdcdc;<br/>
+    --text-img_6325_788: #dedede;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_789"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_789</span></button>
+    <div class="container-img_6325_789" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_789: linear-gradient(180deg, #a2aba0 0%, #d7d7d7 100%);<br/>
+    --border-img_6325_789: #a9aca9;<br/>
+    --text-img_6325_789: #dddddd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_790"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_790</span></button>
+    <div class="container-img_6325_790" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_790: linear-gradient(180deg, #cfcfcf 0%, #e0e0e0 100%);<br/>
+    --border-img_6325_790: #bbbbbb;<br/>
+    --text-img_6325_790: #b8b8b8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_791"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_791</span></button>
+    <div class="container-img_6325_791" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_791: linear-gradient(180deg, #cfcfcf 0%, #b6b6b6 100%);<br/>
+    --border-img_6325_791: #cbcbcb;<br/>
+    --text-img_6325_791: #bababa;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_792"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_792</span></button>
+    <div class="container-img_6325_792" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_792: linear-gradient(180deg, #cfcfcf 0%, #cfd6cd 100%);<br/>
+    --border-img_6325_792: #b6bab5;<br/>
+    --text-img_6325_792: #dedede;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_793"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_793</span></button>
+    <div class="container-img_6325_793" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_793: linear-gradient(180deg, #dddddd 0%, #9f9f9f 100%);<br/>
+    --border-img_6325_793: #a1a1a1;<br/>
+    --text-img_6325_793: #d9d9d9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_794"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_794</span></button>
+    <div class="container-img_6325_794" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_794: linear-gradient(180deg, #dedede 0%, #505050 100%);<br/>
+    --border-img_6325_794: #b6b7b5;<br/>
+    --text-img_6325_794: #e0e0e0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_795"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_795</span></button>
+    <div class="container-img_6325_795" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_795: linear-gradient(180deg, #dedede 0%, #8cbe7f 100%);<br/>
+    --border-img_6325_795: #bbceb6;<br/>
+    --text-img_6325_795: #dedede;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_796"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_796</span></button>
+    <div class="container-img_6325_796" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_796: linear-gradient(180deg, #dddddd 0%, #afc8a9 100%);<br/>
+    --border-img_6325_796: #a5afa3;<br/>
+    --text-img_6325_796: #dfdfdf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_797"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_797</span></button>
+    <div class="container-img_6325_797" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_797: linear-gradient(180deg, #d4d4d4 0%, #bbbbbb 100%);<br/>
+    --border-img_6325_797: #a3a3a3;<br/>
+    --text-img_6325_797: #e1e1e1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_798"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_798</span></button>
+    <div class="container-img_6325_798" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_798: linear-gradient(180deg, #e1e1e1 0%, #434343 100%);<br/>
+    --border-img_6325_798: #a9a9a9;<br/>
+    --text-img_6325_798: #4d4d4d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_799"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_799</span></button>
+    <div class="container-img_6325_799" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_799: linear-gradient(180deg, #9e9e9e 0%, #84b579 100%);<br/>
+    --border-img_6325_799: #98aa94;<br/>
+    --text-img_6325_799: #79bc68;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_800"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_800</span></button>
+    <div class="container-img_6325_800" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_800: linear-gradient(180deg, #85ad7a 0%, #40543a 100%);<br/>
+    --border-img_6325_800: #99ae94;<br/>
+    --text-img_6325_800: #619455;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_801"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_801</span></button>
+    <div class="container-img_6325_801" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_801: linear-gradient(180deg, #d9d9d8 0%, #c3c6c2 100%);<br/>
+    --border-img_6325_801: #959f93;<br/>
+    --text-img_6325_801: #e1e1e1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_802"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_802</span></button>
+    <div class="container-img_6325_802" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_802: linear-gradient(180deg, #787878 0%, #cecdcd 100%);<br/>
+    --border-img_6325_802: #949494;<br/>
+    --text-img_6325_802: #545454;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_803"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_803</span></button>
+    <div class="container-img_6325_803" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_803: linear-gradient(180deg, #85b27a 0%, #d4d1d2 100%);<br/>
+    --border-img_6325_803: #b0b9ac;<br/>
+    --text-img_6325_803: #6eab60;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_804"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_804</span></button>
+    <div class="container-img_6325_804" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_804: linear-gradient(180deg, #8db484 0%, #bebdbd 100%);<br/>
+    --border-img_6325_804: #99a995;<br/>
+    --text-img_6325_804: #445d3e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_805"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_805</span></button>
+    <div class="container-img_6325_805" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_805: linear-gradient(180deg, #9b9b9b 0%, #d6d5d5 100%);<br/>
+    --border-img_6325_805: #a1a1a1;<br/>
+    --text-img_6325_805: #d8d8d8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_806"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_806</span></button>
+    <div class="container-img_6325_806" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_806: linear-gradient(180deg, #454545 0%, #cbccca 100%);<br/>
+    --border-img_6325_806: #afb4ad;<br/>
+    --text-img_6325_806: #d2d0d0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_807"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_807</span></button>
+    <div class="container-img_6325_807" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_807: linear-gradient(180deg, #7ba171 0%, #bab9b9 100%);<br/>
+    --border-img_6325_807: #b8c5b4;<br/>
+    --text-img_6325_807: #c8c6c6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_808"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_808</span></button>
+    <div class="container-img_6325_808" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_808: linear-gradient(180deg, #a1ad9e 0%, #d3d2d1 100%);<br/>
+    --border-img_6325_808: #a6aaa4;<br/>
+    --text-img_6325_808: #d4d4d4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_809"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_809</span></button>
+    <div class="container-img_6325_809" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_809: linear-gradient(180deg, #d2d2d2 0%, #d4d4d4 100%);<br/>
+    --border-img_6325_809: #adacac;<br/>
+    --text-img_6325_809: #e5e5e5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_810"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_810</span></button>
+    <div class="container-img_6325_810" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_810: linear-gradient(180deg, #cccbcb 0%, #fcfcfc 100%);<br/>
+    --border-img_6325_810: #dfdede;<br/>
+    --text-img_6325_810: #c5c5c5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_811"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_811</span></button>
+    <div class="container-img_6325_811" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_811: linear-gradient(180deg, #d6d3d3 0%, #fcfcfc 100%);<br/>
+    --border-img_6325_811: #e2e2e0;<br/>
+    --text-img_6325_811: #b3cfad;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_812"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_812</span></button>
+    <div class="container-img_6325_812" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_812: linear-gradient(180deg, #bbb8b8 0%, #fcfcfc 100%);<br/>
+    --border-img_6325_812: #d8d7d7;<br/>
+    --text-img_6325_812: #979797;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_813"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_813</span></button>
+    <div class="container-img_6325_813" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_813: linear-gradient(180deg, #d3d3d3 0%, #d9d9d9 100%);<br/>
+    --border-img_6325_813: #a8a7a7;<br/>
+    --text-img_6325_813: #e5e5e5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_814"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_814</span></button>
+    <div class="container-img_6325_814" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_814: linear-gradient(180deg, #d3d3d3 0%, #eaeaea 100%);<br/>
+    --border-img_6325_814: #b4bbb2;<br/>
+    --text-img_6325_814: #c0c0c0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_815"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_815</span></button>
+    <div class="container-img_6325_815" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_815: linear-gradient(180deg, #bfd5ba 0%, #ececec 100%);<br/>
+    --border-img_6325_815: #e2e3e1;<br/>
+    --text-img_6325_815: #e9e9e7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_816"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_816</span></button>
+    <div class="container-img_6325_816" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_816: linear-gradient(180deg, #d4d3d3 0%, #eaeaea 100%);<br/>
+    --border-img_6325_816: #bbbbbb;<br/>
+    --text-img_6325_816: #c1bebe;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_817"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_817</span></button>
+    <div class="container-img_6325_817" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_817: linear-gradient(180deg, #d6d5d5 0%, #959595 100%);<br/>
+    --border-img_6325_817: #949c92;<br/>
+    --text-img_6325_817: #b5d2ad;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_818"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_818</span></button>
+    <div class="container-img_6325_818" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_818: linear-gradient(180deg, #cecccc 0%, #d1d9ce 100%);<br/>
+    --border-img_6325_818: #ccd5c9;<br/>
+    --text-img_6325_818: #cecece;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_819"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_819</span></button>
+    <div class="container-img_6325_819" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_819: linear-gradient(180deg, #d2d0d0 0%, #e0e1df 100%);<br/>
+    --border-img_6325_819: #d1d7ce;<br/>
+    --text-img_6325_819: #cfcfcf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_820"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_820</span></button>
+    <div class="container-img_6325_820" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_820: linear-gradient(180deg, #d8d7d7 0%, #ebebeb 100%);<br/>
+    --border-img_6325_820: #bcbbbb;<br/>
+    --text-img_6325_820: #eaeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_821"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_821</span></button>
+    <div class="container-img_6325_821" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_821: linear-gradient(180deg, #dcdcdc 0%, #dedede 100%);<br/>
+    --border-img_6325_821: #a8afa7;<br/>
+    --text-img_6325_821: #e9e9e9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_822"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_822</span></button>
+    <div class="container-img_6325_822" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_822: linear-gradient(180deg, #ebebeb 0%, #e7e6e6 100%);<br/>
+    --border-img_6325_822: #cad3c7;<br/>
+    --text-img_6325_822: #e8e8e8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_823"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_823</span></button>
+    <div class="container-img_6325_823" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_823: linear-gradient(180deg, #ebecec 0%, #97be8d 100%);<br/>
+    --border-img_6325_823: #ccd4c9;<br/>
+    --text-img_6325_823: #cccccc;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_824"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_824</span></button>
+    <div class="container-img_6325_824" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_824: linear-gradient(180deg, #ebebeb 0%, #e4e4e4 100%);<br/>
+    --border-img_6325_824: #dedddd;<br/>
+    --text-img_6325_824: #dad9d9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_825"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_825</span></button>
+    <div class="container-img_6325_825" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_825: linear-gradient(180deg, #e0e1e0 0%, #e3e3e3 100%);<br/>
+    --border-img_6325_825: #bcbcbc;<br/>
+    --text-img_6325_825: #e9e9e9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_826"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_826</span></button>
+    <div class="container-img_6325_826" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_826: linear-gradient(180deg, #99c38f 0%, #ededed 100%);<br/>
+    --border-img_6325_826: #bfc7bd;<br/>
+    --text-img_6325_826: #4e6249;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_827"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_827</span></button>
+    <div class="container-img_6325_827" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_827: linear-gradient(180deg, #e6e6e6 0%, #67a658 100%);<br/>
+    --border-img_6325_827: #abc3a5;<br/>
+    --text-img_6325_827: #67a658;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_828"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_828</span></button>
+    <div class="container-img_6325_828" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_828: linear-gradient(180deg, #e9e9e9 0%, #e8e7e7 100%);<br/>
+    --border-img_6325_828: #c1c4c0;<br/>
+    --text-img_6325_828: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_829"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_829</span></button>
+    <div class="container-img_6325_829" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_829: linear-gradient(180deg, #b9bbb8 0%, #cdd9ca 100%);<br/>
+    --border-img_6325_829: #90a08c;<br/>
+    --text-img_6325_829: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_830"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_830</span></button>
+    <div class="container-img_6325_830" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_830: linear-gradient(180deg, #e5e4e4 0%, #e1dfdf 100%);<br/>
+    --border-img_6325_830: #b1c2ac;<br/>
+    --text-img_6325_830: #dedcdc;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_831"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_831</span></button>
+    <div class="container-img_6325_831" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_831: linear-gradient(180deg, #67a658 0%, #dbd8d8 100%);<br/>
+    --border-img_6325_831: #9dbc94;<br/>
+    --text-img_6325_831: #8fb884;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_832"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_832</span></button>
+    <div class="container-img_6325_832" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_832: linear-gradient(180deg, #b7ccb1 0%, #dbd8d8 100%);<br/>
+    --border-img_6325_832: #cad3c6;<br/>
+    --text-img_6325_832: #ced5ca;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_833"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_833</span></button>
+    <div class="container-img_6325_833" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_833: linear-gradient(180deg, #e3e3e3 0%, #e4e4e4 100%);<br/>
+    --border-img_6325_833: #c1c1c1;<br/>
+    --text-img_6325_833: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_834"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_834</span></button>
+    <div class="container-img_6325_834" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_834: linear-gradient(180deg, #949494 0%, #ececec 100%);<br/>
+    --border-img_6325_834: #a0a89f;<br/>
+    --text-img_6325_834: #c9e2c4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_835"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_835</span></button>
+    <div class="container-img_6325_835" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_835: linear-gradient(180deg, #7fb172 0%, #f2f2f2 100%);<br/>
+    --border-img_6325_835: #cedccb;<br/>
+    --text-img_6325_835: #d1cfcf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_836"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_836</span></button>
+    <div class="container-img_6325_836" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_836: linear-gradient(180deg, #67a658 0%, #f2f2f2 100%);<br/>
+    --border-img_6325_836: #c5d5c0;<br/>
+    --text-img_6325_836: #d6d4d4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_837"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_837</span></button>
+    <div class="container-img_6325_837" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_837: linear-gradient(180deg, #ececec 0%, #ececec 100%);<br/>
+    --border-img_6325_837: #c2c1c1;<br/>
+    --text-img_6325_837: #ededed;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_838"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_838</span></button>
+    <div class="container-img_6325_838" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_838: linear-gradient(180deg, #b5ddab 0%, #ededed 100%);<br/>
+    --border-img_6325_838: #bcbebb;<br/>
+    --text-img_6325_838: #ededed;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_839"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_839</span></button>
+    <div class="container-img_6325_839" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_839: linear-gradient(180deg, #dbd9d9 0%, #f2f2f2 100%);<br/>
+    --border-img_6325_839: #e1e0e0;<br/>
+    --text-img_6325_839: #f4f4f4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_840"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_840</span></button>
+    <div class="container-img_6325_840" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_840: linear-gradient(180deg, #e7e6e6 0%, #ededed 100%);<br/>
+    --border-img_6325_840: #cbcaca;<br/>
+    --text-img_6325_840: #ededed;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_841"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_841</span></button>
+    <div class="container-img_6325_841" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_841: linear-gradient(180deg, #e0e0e0 0%, #e2e2e2 100%);<br/>
+    --border-img_6325_841: #c2c2c2;<br/>
+    --text-img_6325_841: #ebebeb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_842"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_842</span></button>
+    <div class="container-img_6325_842" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_842: linear-gradient(180deg, #f0f0f0 0%, #eaeaea 100%);<br/>
+    --border-img_6325_842: #e9e9e9;<br/>
+    --text-img_6325_842: #f0f0f0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_843"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_843</span></button>
+    <div class="container-img_6325_843" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_843: linear-gradient(180deg, #f4f4f4 0%, #f7f7f7 100%);<br/>
+    --border-img_6325_843: #f3f4f3;<br/>
+    --text-img_6325_843: #f2f2f2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_844"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_844</span></button>
+    <div class="container-img_6325_844" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_844: linear-gradient(180deg, #f0f0f0 0%, #fcfcfc 100%);<br/>
+    --border-img_6325_844: #f4f4f4;<br/>
+    --text-img_6325_844: #f0f0f0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_845"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_845</span></button>
+    <div class="container-img_6325_845" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_845: linear-gradient(180deg, #e4e4e4 0%, #e8e8e8 100%);<br/>
+    --border-img_6325_845: #c4c4c4;<br/>
+    --text-img_6325_845: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_846"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_846</span></button>
+    <div class="container-img_6325_846" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_846: linear-gradient(180deg, #ececec 0%, #f0f0f0 100%);<br/>
+    --border-img_6325_846: #c6c5c5;<br/>
+    --text-img_6325_846: #f2f2f2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_847"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_847</span></button>
+    <div class="container-img_6325_847" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_847: linear-gradient(180deg, #f0f0f0 0%, #f7f7f7 100%);<br/>
+    --border-img_6325_847: #eeeeee;<br/>
+    --text-img_6325_847: #f7f7f7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_848"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_848</span></button>
+    <div class="container-img_6325_848" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_848: linear-gradient(180deg, #f0f0f0 0%, #f1f1f1 100%);<br/>
+    --border-img_6325_848: #f2f3f2;<br/>
+    --text-img_6325_848: #f5f7f5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_849"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_849</span></button>
+    <div class="container-img_6325_849" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_849: linear-gradient(180deg, #ececec 0%, #eceded 100%);<br/>
+    --border-img_6325_849: #c7c7c7;<br/>
+    --text-img_6325_849: #f2f4f2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_850"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_850</span></button>
+    <div class="container-img_6325_850" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_850: linear-gradient(180deg, #f4f4f4 0%, #f3f3f3 100%);<br/>
+    --border-img_6325_850: #cdcdcd;<br/>
+    --text-img_6325_850: #f6f6f6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_851"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_851</span></button>
+    <div class="container-img_6325_851" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_851: linear-gradient(180deg, #e8eee6 0%, #ededed 100%);<br/>
+    --border-img_6325_851: #f4f4f4;<br/>
+    --text-img_6325_851: #f1f2f1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_852"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_852</span></button>
+    <div class="container-img_6325_852" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_852: linear-gradient(180deg, #f7f8f7 0%, #ececec 100%);<br/>
+    --border-img_6325_852: #d1d1d1;<br/>
+    --text-img_6325_852: #f4f4f4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_853"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_853</span></button>
+    <div class="container-img_6325_853" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_853: linear-gradient(180deg, #e2e2e2 0%, #e0e0e0 100%);<br/>
+    --border-img_6325_853: #c2c2c2;<br/>
+    --text-img_6325_853: #e8e8e8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_854"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_854</span></button>
+    <div class="container-img_6325_854" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_854: linear-gradient(180deg, #f3f4f3 0%, #eaebea 100%);<br/>
+    --border-img_6325_854: #f2f2f2;<br/>
+    --text-img_6325_854: #eef0ee;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_855"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_855</span></button>
+    <div class="container-img_6325_855" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_855: linear-gradient(180deg, #f7f7f7 0%, #ebebeb 100%);<br/>
+    --border-img_6325_855: #f1f1f1;<br/>
+    --text-img_6325_855: #f1f1f1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_856"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_856</span></button>
+    <div class="container-img_6325_856" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_856: linear-gradient(180deg, #e6e6e6 0%, #e0e1e0 100%);<br/>
+    --border-img_6325_856: #c3c3c3;<br/>
+    --text-img_6325_856: #e6e8e6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_857"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_857</span></button>
+    <div class="container-img_6325_857" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_857: linear-gradient(180deg, #f0f0f0 0%, #343739 100%);<br/>
+    --border-img_6325_857: #929992;<br/>
+    --text-img_6325_857: #d3e4cf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_858"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_858</span></button>
+    <div class="container-img_6325_858" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_858: linear-gradient(180deg, #f7f7f7 0%, #343739 100%);<br/>
+    --border-img_6325_858: #aeb3af;<br/>
+    --text-img_6325_858: #c9e6c2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_859"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_859</span></button>
+    <div class="container-img_6325_859" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_859: linear-gradient(180deg, #eaeaea 0%, #343739 100%);<br/>
+    --border-img_6325_859: #a0a1a1;<br/>
+    --text-img_6325_859: #b1b1b1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_860"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_860</span></button>
+    <div class="container-img_6325_860" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_860: linear-gradient(180deg, #e8e9e8 0%, #343739 100%);<br/>
+    --border-img_6325_860: #8a8b8b;<br/>
+    --text-img_6325_860: #bfbfbf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_861"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_861</span></button>
+    <div class="container-img_6325_861" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_861: linear-gradient(180deg, #f4f4f4 0%, #343739 100%);<br/>
+    --border-img_6325_861: #8d938e;<br/>
+    --text-img_6325_861: #afe5a4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_862"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_862</span></button>
+    <div class="container-img_6325_862" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_862: linear-gradient(180deg, #e9eae9 0%, #3c4042 100%);<br/>
+    --border-img_6325_862: #9ea59e;<br/>
+    --text-img_6325_862: #9a9a9a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_863"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_863</span></button>
+    <div class="container-img_6325_863" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_863: linear-gradient(180deg, #e7e7e7 0%, #343739 100%);<br/>
+    --border-img_6325_863: #8c8d8e;<br/>
+    --text-img_6325_863: #838383;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_864"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_864</span></button>
+    <div class="container-img_6325_864" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_864: linear-gradient(180deg, #e0e0e0 0%, #343739 100%);<br/>
+    --border-img_6325_864: #899288;<br/>
+    --text-img_6325_864: #e5e5e5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_865"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_865</span></button>
+    <div class="container-img_6325_865" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_865: linear-gradient(180deg, #f7f7f7 0%, #343739 100%);<br/>
+    --border-img_6325_865: #a1b29f;<br/>
+    --text-img_6325_865: #8fb985;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_866"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_866</span></button>
+    <div class="container-img_6325_866" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_866: linear-gradient(180deg, #e6e7e6 0%, #494d50 100%);<br/>
+    --border-img_6325_866: #9ba49b;<br/>
+    --text-img_6325_866: #7a7a7a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_867"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_867</span></button>
+    <div class="container-img_6325_867" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_867: linear-gradient(180deg, #e6e6e5 0%, #343739 100%);<br/>
+    --border-img_6325_867: #979899;<br/>
+    --text-img_6325_867: #7b7b7b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6325_868"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6325_868</span></button>
+    <div class="container-img_6325_868" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6325_868: linear-gradient(180deg, #dedede 0%, #343739 100%);<br/>
+    --border-img_6325_868: #808182;<br/>
+    --text-img_6325_868: #dedede;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_869"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_869</span></button>
+    <div class="container-img_6326_869" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_869: linear-gradient(180deg, #5e6367 0%, #e1e1e1 100%);<br/>
+    --border-img_6326_869: #8b8d8f;<br/>
+    --text-img_6326_869: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_870"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_870</span></button>
+    <div class="container-img_6326_870" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_870: linear-gradient(180deg, #5e6367 0%, #e1e1e1 100%);<br/>
+    --border-img_6326_870: #8b8e8f;<br/>
+    --text-img_6326_870: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_871"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_871</span></button>
+    <div class="container-img_6326_871" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_871: linear-gradient(180deg, #5e6367 0%, #e2e2e2 100%);<br/>
+    --border-img_6326_871: #8d9091;<br/>
+    --text-img_6326_871: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_872"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_872</span></button>
+    <div class="container-img_6326_872" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_872: linear-gradient(180deg, #5e6367 0%, #e2e2e2 100%);<br/>
+    --border-img_6326_872: #888d8c;<br/>
+    --text-img_6326_872: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_873"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_873</span></button>
+    <div class="container-img_6326_873" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_873: linear-gradient(180deg, #5e6367 0%, #e2e2e2 100%);<br/>
+    --border-img_6326_873: #7d877f;<br/>
+    --text-img_6326_873: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_874"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_874</span></button>
+    <div class="container-img_6326_874" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_874: linear-gradient(180deg, #5e6367 0%, #525252 100%);<br/>
+    --border-img_6326_874: #6e7072;<br/>
+    --text-img_6326_874: #6f7173;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_875"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_875</span></button>
+    <div class="container-img_6326_875" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_875: linear-gradient(180deg, #5e6367 0%, #525252 100%);<br/>
+    --border-img_6326_875: #6d6f71;<br/>
+    --text-img_6326_875: #6f7173;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_876"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_876</span></button>
+    <div class="container-img_6326_876" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_876: linear-gradient(180deg, #5e6367 0%, #7ec46b 100%);<br/>
+    --border-img_6326_876: #7d947c;<br/>
+    --text-img_6326_876: #484b4c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_877"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_877</span></button>
+    <div class="container-img_6326_877" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_877: linear-gradient(180deg, #5e6367 0%, #505050 100%);<br/>
+    --border-img_6326_877: #6e7072;<br/>
+    --text-img_6326_877: #aeafaf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_878"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_878</span></button>
+    <div class="container-img_6326_878" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_878: linear-gradient(180deg, #5e6367 0%, #505050 100%);<br/>
+    --border-img_6326_878: #6e7072;<br/>
+    --text-img_6326_878: #afafb0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_879"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_879</span></button>
+    <div class="container-img_6326_879" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_879: linear-gradient(180deg, #5e6367 0%, #767676 100%);<br/>
+    --border-img_6326_879: #7e8480;<br/>
+    --text-img_6326_879: #afb0b0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_880"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_880</span></button>
+    <div class="container-img_6326_880" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_880: linear-gradient(180deg, #5e6367 0%, #7bc068 100%);<br/>
+    --border-img_6326_880: #789475;<br/>
+    --text-img_6326_880: #929393;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_881"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_881</span></button>
+    <div class="container-img_6326_881" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_881: linear-gradient(180deg, #4f4f4f 0%, #464646 100%);<br/>
+    --border-img_6326_881: #585858;<br/>
+    --text-img_6326_881: #ffffff;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_882"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_882</span></button>
+    <div class="container-img_6326_882" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_882: linear-gradient(180deg, #4f4f4f 0%, #464646 100%);<br/>
+    --border-img_6326_882: #4f4f4f;<br/>
+    --text-img_6326_882: #4b4b4b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_883"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_883</span></button>
+    <div class="container-img_6326_883" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_883: linear-gradient(180deg, #4f4f4f 0%, #464646 100%);<br/>
+    --border-img_6326_883: #4b4b4b;<br/>
+    --text-img_6326_883: #4b4b4b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_884"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_884</span></button>
+    <div class="container-img_6326_884" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_884: linear-gradient(180deg, #b8cdb3 0%, #b5c9b1 100%);<br/>
+    --border-img_6326_884: #809a79;<br/>
+    --text-img_6326_884: #e4e4e4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_885"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_885</span></button>
+    <div class="container-img_6326_885" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_885: linear-gradient(180deg, #79bf67 0%, #6aac5b 100%);<br/>
+    --border-img_6326_885: #80bd71;<br/>
+    --text-img_6326_885: #cfe7ca;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_886"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_886</span></button>
+    <div class="container-img_6326_886" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_886: linear-gradient(180deg, #4e4e4e 0%, #434343 100%);<br/>
+    --border-img_6326_886: #575757;<br/>
+    --text-img_6326_886: #7b7b7b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_887"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_887</span></button>
+    <div class="container-img_6326_887" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_887: linear-gradient(180deg, #4e4e4e 0%, #434343 100%);<br/>
+    --border-img_6326_887: #585858;<br/>
+    --text-img_6326_887: #484848;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_888"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_888</span></button>
+    <div class="container-img_6326_888" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_888: linear-gradient(180deg, #76bb65 0%, #65a657 100%);<br/>
+    --border-img_6326_888: #90c085;<br/>
+    --text-img_6326_888: #f2f8f1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_889"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_889</span></button>
+    <div class="container-img_6326_889" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_889: linear-gradient(180deg, #ffffff 0%, #e4e4e4 100%);<br/>
+    --border-img_6326_889: #989898;<br/>
+    --text-img_6326_889: #454545;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_890"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_890</span></button>
+    <div class="container-img_6326_890" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_890: linear-gradient(180deg, #4b4b4b 0%, #e5e5e5 100%);<br/>
+    --border-img_6326_890: #848484;<br/>
+    --text-img_6326_890: #454545;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_891"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_891</span></button>
+    <div class="container-img_6326_891" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_891: linear-gradient(180deg, #727272 0%, #e6e6e6 100%);<br/>
+    --border-img_6326_891: #96a293;<br/>
+    --text-img_6326_891: #454545;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_892"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_892</span></button>
+    <div class="container-img_6326_892" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_892: linear-gradient(180deg, #d2e8cd 0%, #e6e6e6 100%);<br/>
+    --border-img_6326_892: #a5c99d;<br/>
+    --text-img_6326_892: #69aa5a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_893"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_893</span></button>
+    <div class="container-img_6326_893" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_893: linear-gradient(180deg, #9c9c9c 0%, #c3c2c2 100%);<br/>
+    --border-img_6326_893: #aaaaaa;<br/>
+    --text-img_6326_893: #cccbcb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_894"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_894</span></button>
+    <div class="container-img_6326_894" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_894: linear-gradient(180deg, #9c9c9c 0%, #e5e5e5 100%);<br/>
+    --border-img_6326_894: #b1b1b1;<br/>
+    --text-img_6326_894: #d1d0d0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_895"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_895</span></button>
+    <div class="container-img_6326_895" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_895: linear-gradient(180deg, #9c9c9c 0%, #d2d1d1 100%);<br/>
+    --border-img_6326_895: #b0b0af;<br/>
+    --text-img_6326_895: #d5d4d4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_896"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_896</span></button>
+    <div class="container-img_6326_896" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_896: linear-gradient(180deg, #c7d5c3 0%, #e5e5e5 100%);<br/>
+    --border-img_6326_896: #c6cec4;<br/>
+    --text-img_6326_896: #dad8d8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_897"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_897</span></button>
+    <div class="container-img_6326_897" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_897: linear-gradient(180deg, #64a456 0%, #dbddda 100%);<br/>
+    --border-img_6326_897: #b5c8af;<br/>
+    --text-img_6326_897: #d3d1d1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_898"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_898</span></button>
+    <div class="container-img_6326_898" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_898: linear-gradient(180deg, #e4e4e4 0%, #dadada 100%);<br/>
+    --border-img_6326_898: #d8d8d8;<br/>
+    --text-img_6326_898: #c6c5c5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_899"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_899</span></button>
+    <div class="container-img_6326_899" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_899: linear-gradient(180deg, #e6e6e6 0%, #dddcdb 100%);<br/>
+    --border-img_6326_899: #e1e1e1;<br/>
+    --text-img_6326_899: #cecdcd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_900"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_900</span></button>
+    <div class="container-img_6326_900" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_900: linear-gradient(180deg, #e6e6e6 0%, #ececeb 100%);<br/>
+    --border-img_6326_900: #e0dfdf;<br/>
+    --text-img_6326_900: #d7d9d5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_901"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_901</span></button>
+    <div class="container-img_6326_901" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_901: linear-gradient(180deg, #c4c3c3 0%, #cfcfcf 100%);<br/>
+    --border-img_6326_901: #c6c6c6;<br/>
+    --text-img_6326_901: #c0bfbf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_902"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_902</span></button>
+    <div class="container-img_6326_902" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_902: linear-gradient(180deg, #cdcbcb 0%, #717070 100%);<br/>
+    --border-img_6326_902: #c1c0c0;<br/>
+    --text-img_6326_902: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_903"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_903</span></button>
+    <div class="container-img_6326_903" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_903: linear-gradient(180deg, #d6d4d4 0%, #b5d0af 100%);<br/>
+    --border-img_6326_903: #c3cfbf;<br/>
+    --text-img_6326_903: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_904"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_904</span></button>
+    <div class="container-img_6326_904" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_904: linear-gradient(180deg, #d0cdcd 0%, #accca5 100%);<br/>
+    --border-img_6326_904: #c0cbbc;<br/>
+    --text-img_6326_904: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_905"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_905</span></button>
+    <div class="container-img_6326_905" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_905: linear-gradient(180deg, #c0bfbf 0%, #bfbfbf 100%);<br/>
+    --border-img_6326_905: #d1d1d1;<br/>
+    --text-img_6326_905: #c2c2c2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_906"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_906</span></button>
+    <div class="container-img_6326_906" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_906: linear-gradient(180deg, #eaeaea 0%, #f7f7f7 100%);<br/>
+    --border-img_6326_906: #dadada;<br/>
+    --text-img_6326_906: #717070;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_907"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_907</span></button>
+    <div class="container-img_6326_907" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_907: linear-gradient(180deg, #dad9d9 0%, #dfdede 100%);<br/>
+    --border-img_6326_907: #d9dcd8;<br/>
+    --text-img_6326_907: #d3d2d2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_908"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_908</span></button>
+    <div class="container-img_6326_908" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_908: linear-gradient(180deg, #eaeaea 0%, #f7f7f7 100%);<br/>
+    --border-img_6326_908: #e0e7de;<br/>
+    --text-img_6326_908: #7ab06d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_909"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_909</span></button>
+    <div class="container-img_6326_909" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_909: linear-gradient(180deg, #e3e4e2 0%, #eeefed 100%);<br/>
+    --border-img_6326_909: #d4d9d2;<br/>
+    --text-img_6326_909: #f1f1f1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_910"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_910</span></button>
+    <div class="container-img_6326_910" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_910: linear-gradient(180deg, #d4d4d4 0%, #c3c2c2 100%);<br/>
+    --border-img_6326_910: #c0bfbf;<br/>
+    --text-img_6326_910: #eaeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_911"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_911</span></button>
+    <div class="container-img_6326_911" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_911: linear-gradient(180deg, #dfdfde 0%, #cecdcd 100%);<br/>
+    --border-img_6326_911: #dadad9;<br/>
+    --text-img_6326_911: #dcdbdb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_912"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_912</span></button>
+    <div class="container-img_6326_912" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_912: linear-gradient(180deg, #b3cfac 0%, #d8d5d5 100%);<br/>
+    --border-img_6326_912: #c8d2c4;<br/>
+    --text-img_6326_912: #f8f8f8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_913"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_913</span></button>
+    <div class="container-img_6326_913" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_913: linear-gradient(180deg, #d1d0d0 0%, #eaeaea 100%);<br/>
+    --border-img_6326_913: #dbdbdb;<br/>
+    --text-img_6326_913: #c1c1c1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_914"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_914</span></button>
+    <div class="container-img_6326_914" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_914: linear-gradient(180deg, #fafafa 0%, #ebebeb 100%);<br/>
+    --border-img_6326_914: #eae9e9;<br/>
+    --text-img_6326_914: #cac8c8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_915"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_915</span></button>
+    <div class="container-img_6326_915" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_915: linear-gradient(180deg, #f4f5f3 0%, #ececec 100%);<br/>
+    --border-img_6326_915: #e6e5e5;<br/>
+    --text-img_6326_915: #d2d0d0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_916"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_916</span></button>
+    <div class="container-img_6326_916" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_916: linear-gradient(180deg, #f7f8f6 0%, #ececec 100%);<br/>
+    --border-img_6326_916: #e7e6e6;<br/>
+    --text-img_6326_916: #d9d6d6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_917"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_917</span></button>
+    <div class="container-img_6326_917" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_917: linear-gradient(180deg, #bfbebe 0%, #e9e9e9 100%);<br/>
+    --border-img_6326_917: #d7d6d6;<br/>
+    --text-img_6326_917: #c0c0c0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_918"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_918</span></button>
+    <div class="container-img_6326_918" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_918: linear-gradient(180deg, #fcfcfc 0%, #eaebeb 100%);<br/>
+    --border-img_6326_918: #e7e7e7;<br/>
+    --text-img_6326_918: #c7c6c6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_919"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_919</span></button>
+    <div class="container-img_6326_919" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_919: linear-gradient(180deg, #e1e0e0 0%, #ebebeb 100%);<br/>
+    --border-img_6326_919: #e2e2e1;<br/>
+    --text-img_6326_919: #cecccc;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_920"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_920</span></button>
+    <div class="container-img_6326_920" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_920: linear-gradient(180deg, #fcfcfc 0%, #ececec 100%);<br/>
+    --border-img_6326_920: #ebebeb;<br/>
+    --text-img_6326_920: #d4d2d2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_921"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_921</span></button>
+    <div class="container-img_6326_921" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_921: linear-gradient(180deg, #f2f3f2 0%, #ececec 100%);<br/>
+    --border-img_6326_921: #e6e5e4;<br/>
+    --text-img_6326_921: #d9d6d6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_922"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_922</span></button>
+    <div class="container-img_6326_922" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_922: linear-gradient(180deg, #c2c2c2 0%, #88c17a 100%);<br/>
+    --border-img_6326_922: #c1d2bd;<br/>
+    --text-img_6326_922: #dae1d8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_923"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_923</span></button>
+    <div class="container-img_6326_923" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_923: linear-gradient(180deg, #cdcccc 0%, #e8e8e8 100%);<br/>
+    --border-img_6326_923: #dcdbdb;<br/>
+    --text-img_6326_923: #e8e8e8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_924"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_924</span></button>
+    <div class="container-img_6326_924" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_924: linear-gradient(180deg, #d8d5d5 0%, #e8e8e8 100%);<br/>
+    --border-img_6326_924: #e3e2e2;<br/>
+    --text-img_6326_924: #e9e9e9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_925"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_925</span></button>
+    <div class="container-img_6326_925" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_925: linear-gradient(180deg, #679c59 0%, #6aab5a 100%);<br/>
+    --border-img_6326_925: #97c58c;<br/>
+    --text-img_6326_925: #c0dfb8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_926"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_926</span></button>
+    <div class="container-img_6326_926" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_926: linear-gradient(180deg, #e7e7e7 0%, #e9e9e9 100%);<br/>
+    --border-img_6326_926: #d1dcce;<br/>
+    --text-img_6326_926: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_927"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_927</span></button>
+    <div class="container-img_6326_927" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_927: linear-gradient(180deg, #d5d5d5 0%, #e6e6e6 100%);<br/>
+    --border-img_6326_927: #dddddd;<br/>
+    --text-img_6326_927: #d5d5d5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_928"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_928</span></button>
+    <div class="container-img_6326_928" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_928: linear-gradient(180deg, #d5d5d5 0%, #e6e6e6 100%);<br/>
+    --border-img_6326_928: #e1e0e0;<br/>
+    --text-img_6326_928: #d1d0d0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_929"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_929</span></button>
+    <div class="container-img_6326_929" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_929: linear-gradient(180deg, #d5d5d5 0%, #e6e6e6 100%);<br/>
+    --border-img_6326_929: #e5e4e4;<br/>
+    --text-img_6326_929: #d2d2d2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_930"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_930</span></button>
+    <div class="container-img_6326_930" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_930: linear-gradient(180deg, #79be67 0%, #ececec 100%);<br/>
+    --border-img_6326_930: #a2c39a;<br/>
+    --text-img_6326_930: #a5cd9c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_931"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_931</span></button>
+    <div class="container-img_6326_931" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_931: linear-gradient(180deg, #e8e8e8 0%, #e4e3e3 100%);<br/>
+    --border-img_6326_931: #e4e4e4;<br/>
+    --text-img_6326_931: #e6e6e6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_932"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_932</span></button>
+    <div class="container-img_6326_932" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_932: linear-gradient(180deg, #e9e8e9 0%, #e4e3e3 100%);<br/>
+    --border-img_6326_932: #d1d6cf;<br/>
+    --text-img_6326_932: #e1e1e1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_933"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_933</span></button>
+    <div class="container-img_6326_933" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_933: linear-gradient(180deg, #e9e9e9 0%, #b5ccaf 100%);<br/>
+    --border-img_6326_933: #ccd6c9;<br/>
+    --text-img_6326_933: #dcdbdb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_934"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_934</span></button>
+    <div class="container-img_6326_934" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_934: linear-gradient(180deg, #81b774 0%, #555555 100%);<br/>
+    --border-img_6326_934: #aab3a8;<br/>
+    --text-img_6326_934: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_935"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_935</span></button>
+    <div class="container-img_6326_935" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_935: linear-gradient(180deg, #e6e6e6 0%, #c7d4c3 100%);<br/>
+    --border-img_6326_935: #d3dbd0;<br/>
+    --text-img_6326_935: #e5e4e4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_936"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_936</span></button>
+    <div class="container-img_6326_936" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_936: linear-gradient(180deg, #e6e6e6 0%, #67a658 100%);<br/>
+    --border-img_6326_936: #b2caac;<br/>
+    --text-img_6326_936: #aac7a2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_937"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_937</span></button>
+    <div class="container-img_6326_937" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_937: linear-gradient(180deg, #ececec 0%, #8cd579 100%);<br/>
+    --border-img_6326_937: #889c83;<br/>
+    --text-img_6326_937: #383838;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_938"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_938</span></button>
+    <div class="container-img_6326_938" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_938: linear-gradient(180deg, #e9e9e9 0%, #e9e9e9 100%);<br/>
+    --border-img_6326_938: #cdcdcd;<br/>
+    --text-img_6326_938: #eeeeee;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_939"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_939</span></button>
+    <div class="container-img_6326_939" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_939: linear-gradient(180deg, #e5e4e4 0%, #82b376 100%);<br/>
+    --border-img_6326_939: #bacfb5;<br/>
+    --text-img_6326_939: #e3e2e2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_940"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_940</span></button>
+    <div class="container-img_6326_940" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_940: linear-gradient(180deg, #e5e4e4 0%, #67a658 100%);<br/>
+    --border-img_6326_940: #94bc8a;<br/>
+    --text-img_6326_940: #67a658;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_941"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_941</span></button>
+    <div class="container-img_6326_941" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_941: linear-gradient(180deg, #e5e4e4 0%, #67a658 100%);<br/>
+    --border-img_6326_941: #9cc092;<br/>
+    --text-img_6326_941: #6ca95e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_942"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_942</span></button>
+    <div class="container-img_6326_942" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_942: linear-gradient(180deg, #363636 0%, #afeaa3 100%);<br/>
+    --border-img_6326_942: #889885;<br/>
+    --text-img_6326_942: #313131;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_943"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_943</span></button>
+    <div class="container-img_6326_943" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_943: linear-gradient(180deg, #e2e1e1 0%, #dedddd 100%);<br/>
+    --border-img_6326_943: #d2dbce;<br/>
+    --text-img_6326_943: #e0dfdf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_944"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_944</span></button>
+    <div class="container-img_6326_944" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_944: linear-gradient(180deg, #67a658 0%, #67a658 100%);<br/>
+    --border-img_6326_944: #83b377;<br/>
+    --text-img_6326_944: #67a658;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_945"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_945</span></button>
+    <div class="container-img_6326_945" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_945: linear-gradient(180deg, #68a759 0%, #67a658 100%);<br/>
+    --border-img_6326_945: #81b275;<br/>
+    --text-img_6326_945: #67a658;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_946"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_946</span></button>
+    <div class="container-img_6326_946" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_946: linear-gradient(180deg, #85b07a 0%, #afe4a4 100%);<br/>
+    --border-img_6326_946: #b1ccaa;<br/>
+    --text-img_6326_946: #c3c3c3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_947"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_947</span></button>
+    <div class="container-img_6326_947" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_947: linear-gradient(180deg, #86b57b 0%, #dddbdb 100%);<br/>
+    --border-img_6326_947: #b5caaf;<br/>
+    --text-img_6326_947: #67a658;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_948"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_948</span></button>
+    <div class="container-img_6326_948" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_948: linear-gradient(180deg, #67a658 0%, #dddbdb 100%);<br/>
+    --border-img_6326_948: #93ba89;<br/>
+    --text-img_6326_948: #67a658;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_949"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_949</span></button>
+    <div class="container-img_6326_949" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_949: linear-gradient(180deg, #303030 0%, #8bbb81 100%);<br/>
+    --border-img_6326_949: #7e9879;<br/>
+    --text-img_6326_949: #bce1b5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_950"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_950</span></button>
+    <div class="container-img_6326_950" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_950: linear-gradient(180deg, #e9e9e9 0%, #e9e8e8 100%);<br/>
+    --border-img_6326_950: #d4dcd1;<br/>
+    --text-img_6326_950: #efefef;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_951"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_951</span></button>
+    <div class="container-img_6326_951" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_951: linear-gradient(180deg, #67a658 0%, #dddada 100%);<br/>
+    --border-img_6326_951: #b2c7ab;<br/>
+    --text-img_6326_951: #80b174;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_952"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_952</span></button>
+    <div class="container-img_6326_952" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_952: linear-gradient(180deg, #67a658 0%, #dddada 100%);<br/>
+    --border-img_6326_952: #9bbd92;<br/>
+    --text-img_6326_952: #67a658;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_953"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_953</span></button>
+    <div class="container-img_6326_953" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_953: linear-gradient(180deg, #67a658 0%, #dddada 100%);<br/>
+    --border-img_6326_953: #9abc91;<br/>
+    --text-img_6326_953: #67a658;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_954"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_954</span></button>
+    <div class="container-img_6326_954" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_954: linear-gradient(180deg, #6d8a65 0%, #343739 100%);<br/>
+    --border-img_6326_954: #8caa87;<br/>
+    --text-img_6326_954: #9ad18c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_955"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_955</span></button>
+    <div class="container-img_6326_955" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_955: linear-gradient(180deg, #d8d6d6 0%, #343739 100%);<br/>
+    --border-img_6326_955: #b3b3b3;<br/>
+    --text-img_6326_955: #dcdada;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_956"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_956</span></button>
+    <div class="container-img_6326_956" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_956: linear-gradient(180deg, #dcdada 0%, #343739 100%);<br/>
+    --border-img_6326_956: #b1b1b1;<br/>
+    --text-img_6326_956: #dcdada;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_957"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_957</span></button>
+    <div class="container-img_6326_957" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_957: linear-gradient(180deg, #d4d2d2 0%, #343739 100%);<br/>
+    --border-img_6326_957: #acacac;<br/>
+    --text-img_6326_957: #dcdada;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_958"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_958</span></button>
+    <div class="container-img_6326_958" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_958: linear-gradient(180deg, #687464 0%, #343739 100%);<br/>
+    --border-img_6326_958: #879386;<br/>
+    --text-img_6326_958: #bcdbb4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_959"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_959</span></button>
+    <div class="container-img_6326_959" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_959: linear-gradient(180deg, #b7b6b6 0%, #3c4042 100%);<br/>
+    --border-img_6326_959: #9f9fa0;<br/>
+    --text-img_6326_959: #e4e3e3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_960"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_960</span></button>
+    <div class="container-img_6326_960" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_960: linear-gradient(180deg, #a9a8a8 0%, #343739 100%);<br/>
+    --border-img_6326_960: #9d9d9e;<br/>
+    --text-img_6326_960: #e5e4e4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_961"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_961</span></button>
+    <div class="container-img_6326_961" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_961: linear-gradient(180deg, #95d586 0%, #343739 100%);<br/>
+    --border-img_6326_961: #778875;<br/>
+    --text-img_6326_961: #e1e8e0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_962"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_962</span></button>
+    <div class="container-img_6326_962" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_962: linear-gradient(180deg, #e9e8e8 0%, #343739 100%);<br/>
+    --border-img_6326_962: #a3aaa2;<br/>
+    --text-img_6326_962: #f0f0f0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_963"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_963</span></button>
+    <div class="container-img_6326_963" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_963: linear-gradient(180deg, #dbd8d9 0%, #494d50 100%);<br/>
+    --border-img_6326_963: #aeaeaf;<br/>
+    --text-img_6326_963: #ededed;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_964"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_964</span></button>
+    <div class="container-img_6326_964" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_964: linear-gradient(180deg, #dbd8d9 0%, #343739 100%);<br/>
+    --border-img_6326_964: #b2b2b3;<br/>
+    --text-img_6326_964: #efefef;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6326_965"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6326_965</span></button>
+    <div class="container-img_6326_965" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6326_965: linear-gradient(180deg, #dbd9d9 0%, #343739 100%);<br/>
+    --border-img_6326_965: #a9a9aa;<br/>
+    --text-img_6326_965: #eeeeee;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_966"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_966</span></button>
+    <div class="container-img_6327_966" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_966: linear-gradient(180deg, #5e6367 0%, #c9c9c9 100%);<br/>
+    --border-img_6327_966: #7f8183;<br/>
+    --text-img_6327_966: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_967"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_967</span></button>
+    <div class="container-img_6327_967" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_967: linear-gradient(180deg, #5e6367 0%, #dddddd 100%);<br/>
+    --border-img_6327_967: #929496;<br/>
+    --text-img_6327_967: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_968"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_968</span></button>
+    <div class="container-img_6327_968" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_968: linear-gradient(180deg, #5e6367 0%, #dddddd 100%);<br/>
+    --border-img_6327_968: #939697;<br/>
+    --text-img_6327_968: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_969"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_969</span></button>
+    <div class="container-img_6327_969" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_969: linear-gradient(180deg, #5e6367 0%, #dddddd 100%);<br/>
+    --border-img_6327_969: #909294;<br/>
+    --text-img_6327_969: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_970"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_970</span></button>
+    <div class="container-img_6327_970" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_970: linear-gradient(180deg, #5e6367 0%, #dddddd 100%);<br/>
+    --border-img_6327_970: #919395;<br/>
+    --text-img_6327_970: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_971"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_971</span></button>
+    <div class="container-img_6327_971" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_971: linear-gradient(180deg, #5e6367 0%, #b9b9b9 100%);<br/>
+    --border-img_6327_971: #828486;<br/>
+    --text-img_6327_971: #707274;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_972"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_972</span></button>
+    <div class="container-img_6327_972" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_972: linear-gradient(180deg, #5e6367 0%, #dadada 100%);<br/>
+    --border-img_6327_972: #999c9d;<br/>
+    --text-img_6327_972: #707274;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_973"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_973</span></button>
+    <div class="container-img_6327_973" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_973: linear-gradient(180deg, #5e6367 0%, #dadada 100%);<br/>
+    --border-img_6327_973: #9a9c9e;<br/>
+    --text-img_6327_973: #707274;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_974"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_974</span></button>
+    <div class="container-img_6327_974" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_974: linear-gradient(180deg, #5e6367 0%, #858585 100%);<br/>
+    --border-img_6327_974: #919395;<br/>
+    --text-img_6327_974: #afb0b1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_975"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_975</span></button>
+    <div class="container-img_6327_975" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_975: linear-gradient(180deg, #5e6367 0%, #d6d6d6 100%);<br/>
+    --border-img_6327_975: #9ea0a2;<br/>
+    --text-img_6327_975: #afb0b1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_976"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_976</span></button>
+    <div class="container-img_6327_976" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_976: linear-gradient(180deg, #5e6367 0%, #d6d6d6 100%);<br/>
+    --border-img_6327_976: #a0a2a3;<br/>
+    --text-img_6327_976: #afb0b1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_977"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_977</span></button>
+    <div class="container-img_6327_977" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_977: linear-gradient(180deg, #5e6367 0%, #d6d6d6 100%);<br/>
+    --border-img_6327_977: #9ea0a2;<br/>
+    --text-img_6327_977: #afb0b1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_978"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_978</span></button>
+    <div class="container-img_6327_978" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_978: linear-gradient(180deg, #d4d4d4 0%, #dddddd 100%);<br/>
+    --border-img_6327_978: #bdbdbd;<br/>
+    --text-img_6327_978: #d3d3d3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_979"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_979</span></button>
+    <div class="container-img_6327_979" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_979: linear-gradient(180deg, #d4d4d4 0%, #dedede 100%);<br/>
+    --border-img_6327_979: #d8d8d8;<br/>
+    --text-img_6327_979: #d3d3d3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_980"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_980</span></button>
+    <div class="container-img_6327_980" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_980: linear-gradient(180deg, #d4d4d4 0%, #dedede 100%);<br/>
+    --border-img_6327_980: #d8d8d8;<br/>
+    --text-img_6327_980: #d3d3d3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_981"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_981</span></button>
+    <div class="container-img_6327_981" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_981: linear-gradient(180deg, #d4d4d4 0%, #dedede 100%);<br/>
+    --border-img_6327_981: #d8d8d8;<br/>
+    --text-img_6327_981: #d3d3d3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_982"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_982</span></button>
+    <div class="container-img_6327_982" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_982: linear-gradient(180deg, #d4d4d4 0%, #dedede 100%);<br/>
+    --border-img_6327_982: #d9d9d9;<br/>
+    --text-img_6327_982: #d3d3d3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_983"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_983</span></button>
+    <div class="container-img_6327_983" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_983: linear-gradient(180deg, #d0d0d0 0%, #a7a7a7 100%);<br/>
+    --border-img_6327_983: #cccccc;<br/>
+    --text-img_6327_983: #dddddd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_984"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_984</span></button>
+    <div class="container-img_6327_984" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_984: linear-gradient(180deg, #d0d0d0 0%, #969696 100%);<br/>
+    --border-img_6327_984: #c8c8c8;<br/>
+    --text-img_6327_984: #dedede;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_985"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_985</span></button>
+    <div class="container-img_6327_985" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_985: linear-gradient(180deg, #d0d0d0 0%, #b8b8b8 100%);<br/>
+    --border-img_6327_985: #cccccc;<br/>
+    --text-img_6327_985: #dedede;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_986"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_986</span></button>
+    <div class="container-img_6327_986" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_986: linear-gradient(180deg, #cbcbcb 0%, #dedede 100%);<br/>
+    --border-img_6327_986: #d6d6d6;<br/>
+    --text-img_6327_986: #dddddd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_987"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_987</span></button>
+    <div class="container-img_6327_987" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_987: linear-gradient(180deg, #cbcbcb 0%, #dfdfdf 100%);<br/>
+    --border-img_6327_987: #d4d4d4;<br/>
+    --text-img_6327_987: #dedede;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_988"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_988</span></button>
+    <div class="container-img_6327_988" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_988: linear-gradient(180deg, #cbcbcb 0%, #dfe0df 100%);<br/>
+    --border-img_6327_988: #cfcfcf;<br/>
+    --text-img_6327_988: #dfdfdf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_989"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_989</span></button>
+    <div class="container-img_6327_989" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_989: linear-gradient(180deg, #cbcbcb 0%, #e0e0e0 100%);<br/>
+    --border-img_6327_989: #d4d4d4;<br/>
+    --text-img_6327_989: #dfdfdf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_990"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_990</span></button>
+    <div class="container-img_6327_990" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_990: linear-gradient(180deg, #bdbdbd 0%, #dfdfdf 100%);<br/>
+    --border-img_6327_990: #d1d1d1;<br/>
+    --text-img_6327_990: #d5d5d5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_991"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_991</span></button>
+    <div class="container-img_6327_991" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_991: linear-gradient(180deg, #b6b6b6 0%, #e0e0e0 100%);<br/>
+    --border-img_6327_991: #c4c4c4;<br/>
+    --text-img_6327_991: #dddddd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_992"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_992</span></button>
+    <div class="container-img_6327_992" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_992: linear-gradient(180deg, #cacaca 0%, #e0e0e0 100%);<br/>
+    --border-img_6327_992: #c6c6c6;<br/>
+    --text-img_6327_992: #e0e0e0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_993"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_993</span></button>
+    <div class="container-img_6327_993" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_993: linear-gradient(180deg, #acacac 0%, #e1e1e1 100%);<br/>
+    --border-img_6327_993: #c4c4c4;<br/>
+    --text-img_6327_993: #e0e0e0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_994"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_994</span></button>
+    <div class="container-img_6327_994" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_994: linear-gradient(180deg, #cfcfcf 0%, #959595 100%);<br/>
+    --border-img_6327_994: #c2c2c2;<br/>
+    --text-img_6327_994: #e0e0e0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_995"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_995</span></button>
+    <div class="container-img_6327_995" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_995: linear-gradient(180deg, #dfdfdf 0%, #e0e0e0 100%);<br/>
+    --border-img_6327_995: #dedede;<br/>
+    --text-img_6327_995: #dfdfdf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_996"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_996</span></button>
+    <div class="container-img_6327_996" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_996: linear-gradient(180deg, #e0e0e0 0%, #e2e2e2 100%);<br/>
+    --border-img_6327_996: #d9d9d9;<br/>
+    --text-img_6327_996: #d3d3d3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_997"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_997</span></button>
+    <div class="container-img_6327_997" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_997: linear-gradient(180deg, #dfdfdf 0%, #676767 100%);<br/>
+    --border-img_6327_997: #b8b8b8;<br/>
+    --text-img_6327_997: #e0e0e0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_998"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_998</span></button>
+    <div class="container-img_6327_998" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_998: linear-gradient(180deg, #e0e0e0 0%, #4f4f4f 100%);<br/>
+    --border-img_6327_998: #9e9e9e;<br/>
+    --text-img_6327_998: #e1e1e1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_999"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_999</span></button>
+    <div class="container-img_6327_999" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_999: linear-gradient(180deg, #e0e0e0 0%, #4f4f4f 100%);<br/>
+    --border-img_6327_999: #aaaaaa;<br/>
+    --text-img_6327_999: #e2e2e2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1000"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1000</span></button>
+    <div class="container-img_6327_1000" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1000: linear-gradient(180deg, #e0e1e1 0%, #78be66 100%);<br/>
+    --border-img_6327_1000: #bacfb5;<br/>
+    --text-img_6327_1000: #d9d9d9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1001"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1001</span></button>
+    <div class="container-img_6327_1001" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1001: linear-gradient(180deg, #e0e0e0 0%, #7e7e7e 100%);<br/>
+    --border-img_6327_1001: #c2c2c2;<br/>
+    --text-img_6327_1001: #5f5f5f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1002"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1002</span></button>
+    <div class="container-img_6327_1002" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1002: linear-gradient(180deg, #e1e1e1 0%, #4c4c4c 100%);<br/>
+    --border-img_6327_1002: #9e9e9e;<br/>
+    --text-img_6327_1002: #515151;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1003"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1003</span></button>
+    <div class="container-img_6327_1003" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1003: linear-gradient(180deg, #e1e1e1 0%, #4c4c4c 100%);<br/>
+    --border-img_6327_1003: #8d8d8d;<br/>
+    --text-img_6327_1003: #515151;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1004"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1004</span></button>
+    <div class="container-img_6327_1004" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1004: linear-gradient(180deg, #e1e1e1 0%, #6c6c6c 100%);<br/>
+    --border-img_6327_1004: #b2b2b2;<br/>
+    --text-img_6327_1004: #525252;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1005"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1005</span></button>
+    <div class="container-img_6327_1005" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1005: linear-gradient(180deg, #e1e2e2 0%, #9ccd8f 100%);<br/>
+    --border-img_6327_1005: #9bbc92;<br/>
+    --text-img_6327_1005: #7cc26a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1006"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1006</span></button>
+    <div class="container-img_6327_1006" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1006: linear-gradient(180deg, #525251 0%, #474747 100%);<br/>
+    --border-img_6327_1006: #7d7d7d;<br/>
+    --text-img_6327_1006: #eeeeee;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1007"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1007</span></button>
+    <div class="container-img_6327_1007" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1007: linear-gradient(180deg, #505050 0%, #464646 100%);<br/>
+    --border-img_6327_1007: #4b4b4b;<br/>
+    --text-img_6327_1007: #4b4b4b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1008"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1008</span></button>
+    <div class="container-img_6327_1008" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1008: linear-gradient(180deg, #95c887 0%, #89ba7e 100%);<br/>
+    --border-img_6327_1008: #80a277;<br/>
+    --text-img_6327_1008: #74b764;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1009"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1009</span></button>
+    <div class="container-img_6327_1009" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1009: linear-gradient(180deg, #bdbdbd 0%, #cccbcb 100%);<br/>
+    --border-img_6327_1009: #c6c6c6;<br/>
+    --text-img_6327_1009: #464646;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1010"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1010</span></button>
+    <div class="container-img_6327_1010" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1010: linear-gradient(180deg, #4a4a4a 0%, #cac9c9 100%);<br/>
+    --border-img_6327_1010: #929191;<br/>
+    --text-img_6327_1010: #464646;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1011"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1011</span></button>
+    <div class="container-img_6327_1011" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1011: linear-gradient(180deg, #4a4a4a 0%, #d4d1d1 100%);<br/>
+    --border-img_6327_1011: #929191;<br/>
+    --text-img_6327_1011: #464646;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1012"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1012</span></button>
+    <div class="container-img_6327_1012" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1012: linear-gradient(180deg, #d7ead2 0%, #d5d2d2 100%);<br/>
+    --border-img_6327_1012: #cdd9c9;<br/>
+    --text-img_6327_1012: #66a758;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1013"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1013</span></button>
+    <div class="container-img_6327_1013" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1013: linear-gradient(180deg, #7c7b7b 0%, #e4e4e4 100%);<br/>
+    --border-img_6327_1013: #c0c0c0;<br/>
+    --text-img_6327_1013: #525252;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1014"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1014</span></button>
+    <div class="container-img_6327_1014" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1014: linear-gradient(180deg, #484848 0%, #e5e5e5 100%);<br/>
+    --border-img_6327_1014: #9c9c9c;<br/>
+    --text-img_6327_1014: #434343;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1015"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1015</span></button>
+    <div class="container-img_6327_1015" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1015: linear-gradient(180deg, #484848 0%, #e5e5e5 100%);<br/>
+    --border-img_6327_1015: #8b8b8b;<br/>
+    --text-img_6327_1015: #434344;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1016"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1016</span></button>
+    <div class="container-img_6327_1016" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1016: linear-gradient(180deg, #6a6a69 0%, #e6e6e6 100%);<br/>
+    --border-img_6327_1016: #b2b2b2;<br/>
+    --text-img_6327_1016: #444444;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1017"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1017</span></button>
+    <div class="container-img_6327_1017" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1017: linear-gradient(180deg, #ffffff 0%, #e6e6e6 100%);<br/>
+    --border-img_6327_1017: #bfd6ba;<br/>
+    --text-img_6327_1017: #66a758;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1018"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1018</span></button>
+    <div class="container-img_6327_1018" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1018: linear-gradient(180deg, #e4e4e4 0%, #c7c7c7 100%);<br/>
+    --border-img_6327_1018: #cccccc;<br/>
+    --text-img_6327_1018: #c3c2c2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1019"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1019</span></button>
+    <div class="container-img_6327_1019" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1019: linear-gradient(180deg, #e5e5e5 0%, #e4e4e4 100%);<br/>
+    --border-img_6327_1019: #c7c7c7;<br/>
+    --text-img_6327_1019: #cfcdcd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1020"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1020</span></button>
+    <div class="container-img_6327_1020" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1020: linear-gradient(180deg, #d4dbd2 0%, #e8e8e8 100%);<br/>
+    --border-img_6327_1020: #c8d4c4;<br/>
+    --text-img_6327_1020: #d8d5d5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1021"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1021</span></button>
+    <div class="container-img_6327_1021" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1021: linear-gradient(180deg, #cdcdcd 0%, #cecdce 100%);<br/>
+    --border-img_6327_1021: #d2d2d2;<br/>
+    --text-img_6327_1021: #c3c2c2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1022"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1022</span></button>
+    <div class="container-img_6327_1022" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1022: linear-gradient(180deg, #c8c6c7 0%, #efefef 100%);<br/>
+    --border-img_6327_1022: #c6c6c6;<br/>
+    --text-img_6327_1022: #e8e8e8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1023"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1023</span></button>
+    <div class="container-img_6327_1023" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1023: linear-gradient(180deg, #cfcdcd 0%, #efefee 100%);<br/>
+    --border-img_6327_1023: #d7d6d6;<br/>
+    --text-img_6327_1023: #e8e8e8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1024"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1024</span></button>
+    <div class="container-img_6327_1024" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1024: linear-gradient(180deg, #d6d4d4 0%, #edeeed 100%);<br/>
+    --border-img_6327_1024: #dbdbd9;<br/>
+    --text-img_6327_1024: #e8e8e8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1025"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1025</span></button>
+    <div class="container-img_6327_1025" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1025: linear-gradient(180deg, #d3d0d0 0%, #efefef 100%);<br/>
+    --border-img_6327_1025: #d8dcd6;<br/>
+    --text-img_6327_1025: #e8e8e8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1026"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1026</span></button>
+    <div class="container-img_6327_1026" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1026: linear-gradient(180deg, #c8c8c8 0%, #c7c7c7 100%);<br/>
+    --border-img_6327_1026: #d6d6d6;<br/>
+    --text-img_6327_1026: #c1c0c0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1027"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1027</span></button>
+    <div class="container-img_6327_1027" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1027: linear-gradient(180deg, #e5e5e6 0%, #717070 100%);<br/>
+    --border-img_6327_1027: #d8d8d8;<br/>
+    --text-img_6327_1027: #d3d3d3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1028"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1028</span></button>
+    <div class="container-img_6327_1028" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1028: linear-gradient(180deg, #d1d1cf 0%, #dbdad9 100%);<br/>
+    --border-img_6327_1028: #dce0db;<br/>
+    --text-img_6327_1028: #d3d1d1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1029"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1029</span></button>
+    <div class="container-img_6327_1029" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1029: linear-gradient(180deg, #e5e5e6 0%, #67a658 100%);<br/>
+    --border-img_6327_1029: #d9e1d7;<br/>
+    --text-img_6327_1029: #ededed;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1030"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1030</span></button>
+    <div class="container-img_6327_1030" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1030: linear-gradient(180deg, #c8c7c7 0%, #c9c9c9 100%);<br/>
+    --border-img_6327_1030: #d9d9d9;<br/>
+    --text-img_6327_1030: #c2c1c1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1031"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1031</span></button>
+    <div class="container-img_6327_1031" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1031: linear-gradient(180deg, #e9e9e9 0%, #f6f6f6 100%);<br/>
+    --border-img_6327_1031: #dad9d9;<br/>
+    --text-img_6327_1031: #979696;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1032"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1032</span></button>
+    <div class="container-img_6327_1032" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1032: linear-gradient(180deg, #ededed 0%, #fbfbfb 100%);<br/>
+    --border-img_6327_1032: #f4f4f4;<br/>
+    --text-img_6327_1032: #67a658;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1033"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1033</span></button>
+    <div class="container-img_6327_1033" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1033: linear-gradient(180deg, #cecdcd 0%, #cdcdcd 100%);<br/>
+    --border-img_6327_1033: #d2d2d2;<br/>
+    --text-img_6327_1033: #c2c1c1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1034"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1034</span></button>
+    <div class="container-img_6327_1034" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1034: linear-gradient(180deg, #969595 0%, #c5c4c4 100%);<br/>
+    --border-img_6327_1034: #bab9b9;<br/>
+    --text-img_6327_1034: #fafafa;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1035"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1035</span></button>
+    <div class="container-img_6327_1035" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1035: linear-gradient(180deg, #9e9e9e 0%, #cccaca 100%);<br/>
+    --border-img_6327_1035: #c3c1c1;<br/>
+    --text-img_6327_1035: #fafafa;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1036"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1036</span></button>
+    <div class="container-img_6327_1036" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1036: linear-gradient(180deg, #b9d3b3 0%, #d2d0d0 100%);<br/>
+    --border-img_6327_1036: #c9d3c5;<br/>
+    --text-img_6327_1036: #fafafa;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1037"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1037</span></button>
+    <div class="container-img_6327_1037" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1037: linear-gradient(180deg, #6da95e 0%, #d9d6d6 100%);<br/>
+    --border-img_6327_1037: #cbd9c6;<br/>
+    --text-img_6327_1037: #fafafa;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1038"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1038</span></button>
+    <div class="container-img_6327_1038" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1038: linear-gradient(180deg, #c7c7c7 0%, #e9e9e9 100%);<br/>
+    --border-img_6327_1038: #d9dbd8;<br/>
+    --text-img_6327_1038: #c0c0c0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1039"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1039</span></button>
+    <div class="container-img_6327_1039" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1039: linear-gradient(180deg, #fcfcfc 0%, #ebebeb 100%);<br/>
+    --border-img_6327_1039: #e8e8e8;<br/>
+    --text-img_6327_1039: #c7c6c6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1040"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1040</span></button>
+    <div class="container-img_6327_1040" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1040: linear-gradient(180deg, #dddcdb 0%, #ececec 100%);<br/>
+    --border-img_6327_1040: #e5e4e4;<br/>
+    --text-img_6327_1040: #cfcdcd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1041"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1041</span></button>
+    <div class="container-img_6327_1041" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1041: linear-gradient(180deg, #fcfcfc 0%, #ececec 100%);<br/>
+    --border-img_6327_1041: #eaeaea;<br/>
+    --text-img_6327_1041: #d6d4d4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1042"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1042</span></button>
+    <div class="container-img_6327_1042" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1042: linear-gradient(180deg, #c1c0c0 0%, #7cc269 100%);<br/>
+    --border-img_6327_1042: #c5d4c0;<br/>
+    --text-img_6327_1042: #e9e9e9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1043"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1043</span></button>
+    <div class="container-img_6327_1043" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1043: linear-gradient(180deg, #cccaca 0%, #e9e9e9 100%);<br/>
+    --border-img_6327_1043: #dcdcdc;<br/>
+    --text-img_6327_1043: #ebebeb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1044"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1044</span></button>
+    <div class="container-img_6327_1044" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1044: linear-gradient(180deg, #d6d4d4 0%, #e9e9e9 100%);<br/>
+    --border-img_6327_1044: #e1e0e0;<br/>
+    --text-img_6327_1044: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1045"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1045</span></button>
+    <div class="container-img_6327_1045" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1045: linear-gradient(180deg, #d4d4d4 0%, #94c788 100%);<br/>
+    --border-img_6327_1045: #c5d6c1;<br/>
+    --text-img_6327_1045: #e9e9e9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1046"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1046</span></button>
+    <div class="container-img_6327_1046" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1046: linear-gradient(180deg, #c4c3c3 0%, #b5d4ad 100%);<br/>
+    --border-img_6327_1046: #c7d5c3;<br/>
+    --text-img_6327_1046: #eaeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1047"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1047</span></button>
+    <div class="container-img_6327_1047" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1047: linear-gradient(180deg, #cbc9c9 0%, #e8e8e8 100%);<br/>
+    --border-img_6327_1047: #e0e0e0;<br/>
+    --text-img_6327_1047: #ebebeb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1048"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1048</span></button>
+    <div class="container-img_6327_1048" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1048: linear-gradient(180deg, #d1cfcf 0%, #e8e8e8 100%);<br/>
+    --border-img_6327_1048: #e2e2e2;<br/>
+    --text-img_6327_1048: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1049"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1049</span></button>
+    <div class="container-img_6327_1049" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1049: linear-gradient(180deg, #d7d5d5 0%, #e8e8e8 100%);<br/>
+    --border-img_6327_1049: #e4e3e3;<br/>
+    --text-img_6327_1049: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1050"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1050</span></button>
+    <div class="container-img_6327_1050" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1050: linear-gradient(180deg, #82bf73 0%, #343739 100%);<br/>
+    --border-img_6327_1050: #92a78e;<br/>
+    --text-img_6327_1050: #69aa5a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1051"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1051</span></button>
+    <div class="container-img_6327_1051" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1051: linear-gradient(180deg, #e9e9e9 0%, #343739 100%);<br/>
+    --border-img_6327_1051: #9baa99;<br/>
+    --text-img_6327_1051: #ebebeb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1052"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1052</span></button>
+    <div class="container-img_6327_1052" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1052: linear-gradient(180deg, #e8e8e8 0%, #343739 100%);<br/>
+    --border-img_6327_1052: #b0b1b1;<br/>
+    --text-img_6327_1052: #e6e5e5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1053"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1053</span></button>
+    <div class="container-img_6327_1053" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1053: linear-gradient(180deg, #e8e8e8 0%, #343739 100%);<br/>
+    --border-img_6327_1053: #abadac;<br/>
+    --text-img_6327_1053: #e6e5e5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1054"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1054</span></button>
+    <div class="container-img_6327_1054" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1054: linear-gradient(180deg, #bfdeb8 0%, #343739 100%);<br/>
+    --border-img_6327_1054: #98a597;<br/>
+    --text-img_6327_1054: #66a758;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1055"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1055</span></button>
+    <div class="container-img_6327_1055" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1055: linear-gradient(180deg, #9c9b9b 0%, #3c4042 100%);<br/>
+    --border-img_6327_1055: #aaabac;<br/>
+    --text-img_6327_1055: #e6e5e5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1056"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1056</span></button>
+    <div class="container-img_6327_1056" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1056: linear-gradient(180deg, #7e7e7e 0%, #343739 100%);<br/>
+    --border-img_6327_1056: #aaaaab;<br/>
+    --text-img_6327_1056: #e6e5e5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1057"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1057</span></button>
+    <div class="container-img_6327_1057" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1057: linear-gradient(180deg, #c3dcbe 0%, #343739 100%);<br/>
+    --border-img_6327_1057: #9da89c;<br/>
+    --text-img_6327_1057: #84b378;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1058"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1058</span></button>
+    <div class="container-img_6327_1058" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1058: linear-gradient(180deg, #c6dbc1 0%, #343739 100%);<br/>
+    --border-img_6327_1058: #9ea99d;<br/>
+    --text-img_6327_1058: #d4dfd2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1059"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1059</span></button>
+    <div class="container-img_6327_1059" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1059: linear-gradient(180deg, #aaaaaa 0%, #494d50 100%);<br/>
+    --border-img_6327_1059: #a5a6a7;<br/>
+    --text-img_6327_1059: #e5e4e4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1060"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1060</span></button>
+    <div class="container-img_6327_1060" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1060: linear-gradient(180deg, #898888 0%, #343739 100%);<br/>
+    --border-img_6327_1060: #9c9f9d;<br/>
+    --text-img_6327_1060: #e5e4e4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6327_1061"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6327_1061</span></button>
+    <div class="container-img_6327_1061" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6327_1061: linear-gradient(180deg, #868686 0%, #343739 100%);<br/>
+    --border-img_6327_1061: #8d908d;<br/>
+    --text-img_6327_1061: #e5e4e4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1062"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1062</span></button>
+    <div class="container-img_6328_1062" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1062: linear-gradient(180deg, #5e6367 0%, #323232 100%);<br/>
+    --border-img_6328_1062: #6b6e6f;<br/>
+    --text-img_6328_1062: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1063"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1063</span></button>
+    <div class="container-img_6328_1063" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1063: linear-gradient(180deg, #5e6367 0%, #b8ccb1 100%);<br/>
+    --border-img_6328_1063: #7c8b7d;<br/>
+    --text-img_6328_1063: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1064"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1064</span></button>
+    <div class="container-img_6328_1064" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1064: linear-gradient(180deg, #5e6367 0%, #67a658 100%);<br/>
+    --border-img_6328_1064: #5f7d5d;<br/>
+    --text-img_6328_1064: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1065"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1065</span></button>
+    <div class="container-img_6328_1065" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1065: linear-gradient(180deg, #5e6367 0%, #67a658 100%);<br/>
+    --border-img_6328_1065: #6e826d;<br/>
+    --text-img_6328_1065: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1066"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1066</span></button>
+    <div class="container-img_6328_1066" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1066: linear-gradient(180deg, #5e6367 0%, #e8e7e7 100%);<br/>
+    --border-img_6328_1066: #959799;<br/>
+    --text-img_6328_1066: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1067"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1067</span></button>
+    <div class="container-img_6328_1067" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1067: linear-gradient(180deg, #5e6367 0%, #808080 100%);<br/>
+    --border-img_6328_1067: #949697;<br/>
+    --text-img_6328_1067: #47494b;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1068"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1068</span></button>
+    <div class="container-img_6328_1068" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1068: linear-gradient(180deg, #5e6367 0%, #67a658 100%);<br/>
+    --border-img_6328_1068: #658462;<br/>
+    --text-img_6328_1068: #485e46;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1069"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1069</span></button>
+    <div class="container-img_6328_1069" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1069: linear-gradient(180deg, #5e6367 0%, #d7dcd5 100%);<br/>
+    --border-img_6328_1069: #8d988f;<br/>
+    --text-img_6328_1069: #707173;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1070"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1070</span></button>
+    <div class="container-img_6328_1070" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1070: linear-gradient(180deg, #5e6367 0%, #ededed 100%);<br/>
+    --border-img_6328_1070: #a0a7a3;<br/>
+    --text-img_6328_1070: #4d6349;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1071"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1071</span></button>
+    <div class="container-img_6328_1071" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1071: linear-gradient(180deg, #5e6367 0%, #6ca85e 100%);<br/>
+    --border-img_6328_1071: #7c927b;<br/>
+    --text-img_6328_1071: #769470;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1072"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1072</span></button>
+    <div class="container-img_6328_1072" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1072: linear-gradient(180deg, #5e6367 0%, #67a658 100%);<br/>
+    --border-img_6328_1072: #688964;<br/>
+    --text-img_6328_1072: #688d60;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1073"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1073</span></button>
+    <div class="container-img_6328_1073" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1073: linear-gradient(180deg, #5e6367 0%, #e4e3e3 100%);<br/>
+    --border-img_6328_1073: #a5a6a8;<br/>
+    --text-img_6328_1073: #b0b0b1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1074"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1074</span></button>
+    <div class="container-img_6328_1074" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1074: linear-gradient(180deg, #eaecea 0%, #ededed 100%);<br/>
+    --border-img_6328_1074: #dfe7dd;<br/>
+    --text-img_6328_1074: #54624f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1075"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1075</span></button>
+    <div class="container-img_6328_1075" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1075: linear-gradient(180deg, #c4d0be 0%, #f1f1f1 100%);<br/>
+    --border-img_6328_1075: #d7dfd5;<br/>
+    --text-img_6328_1075: #cfcccc;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1076"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1076</span></button>
+    <div class="container-img_6328_1076" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1076: linear-gradient(180deg, #67a658 0%, #f4f4f4 100%);<br/>
+    --border-img_6328_1076: #bdd0b7;<br/>
+    --text-img_6328_1076: #cac8c8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1077"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1077</span></button>
+    <div class="container-img_6328_1077" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1077: linear-gradient(180deg, #6da95f 0%, #f1f1f1 100%);<br/>
+    --border-img_6328_1077: #c7d5c2;<br/>
+    --text-img_6328_1077: #dcd9d9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1078"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1078</span></button>
+    <div class="container-img_6328_1078" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1078: linear-gradient(180deg, #e7e7e7 0%, #eeeeee 100%);<br/>
+    --border-img_6328_1078: #e8e8e8;<br/>
+    --text-img_6328_1078: #ebebeb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1079"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1079</span></button>
+    <div class="container-img_6328_1079" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1079: linear-gradient(180deg, #c1e6ba 0%, #efeeef 100%);<br/>
+    --border-img_6328_1079: #e1e9df;<br/>
+    --text-img_6328_1079: #b9dbb1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1080"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1080</span></button>
+    <div class="container-img_6328_1080" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1080: linear-gradient(180deg, #dddbdb 0%, #f3f3f3 100%);<br/>
+    --border-img_6328_1080: #e5e5e4;<br/>
+    --text-img_6328_1080: #e1dfdf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1081"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1081</span></button>
+    <div class="container-img_6328_1081" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1081: linear-gradient(180deg, #e0dede 0%, #efefef 100%);<br/>
+    --border-img_6328_1081: #e9e8e8;<br/>
+    --text-img_6328_1081: #dfdddd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1082"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1082</span></button>
+    <div class="container-img_6328_1082" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1082: linear-gradient(180deg, #5c6b57 0%, #ededed 100%);<br/>
+    --border-img_6328_1082: #dee4dc;<br/>
+    --text-img_6328_1082: #eeeeee;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1083"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1083</span></button>
+    <div class="container-img_6328_1083" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1083: linear-gradient(180deg, #bcbaba 0%, #f1f1f1 100%);<br/>
+    --border-img_6328_1083: #e3e3e3;<br/>
+    --text-img_6328_1083: #f2f2f2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1084"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1084</span></button>
+    <div class="container-img_6328_1084" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1084: linear-gradient(180deg, #bfbdbd 0%, #f1f2f2 100%);<br/>
+    --border-img_6328_1084: #e5e4e4;<br/>
+    --text-img_6328_1084: #f3f3f3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1085"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1085</span></button>
+    <div class="container-img_6328_1085" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1085: linear-gradient(180deg, #e3e1e1 0%, #eeeeee 100%);<br/>
+    --border-img_6328_1085: #eae9e9;<br/>
+    --text-img_6328_1085: #eeeeee;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1086"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1086</span></button>
+    <div class="container-img_6328_1086" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1086: linear-gradient(180deg, #ededed 0%, #f7f7f7 100%);<br/>
+    --border-img_6328_1086: #efefef;<br/>
+    --text-img_6328_1086: #ededed;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1087"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1087</span></button>
+    <div class="container-img_6328_1087" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1087: linear-gradient(180deg, #f1f1f1 0%, #f7f7f7 100%);<br/>
+    --border-img_6328_1087: #eaeaea;<br/>
+    --text-img_6328_1087: #f0f0f0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1088"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1088</span></button>
+    <div class="container-img_6328_1088" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1088: linear-gradient(180deg, #f3f3f3 0%, #f6f6f5 100%);<br/>
+    --border-img_6328_1088: #f4f4f4;<br/>
+    --text-img_6328_1088: #f2f2f2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1089"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1089</span></button>
+    <div class="container-img_6328_1089" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1089: linear-gradient(180deg, #f1f1f1 0%, #fcfcfc 100%);<br/>
+    --border-img_6328_1089: #f5f5f5;<br/>
+    --text-img_6328_1089: #f0f0f0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1090"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1090</span></button>
+    <div class="container-img_6328_1090" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1090: linear-gradient(180deg, #eeeeee 0%, #fcfcfc 100%);<br/>
+    --border-img_6328_1090: #f2f3f2;<br/>
+    --text-img_6328_1090: #ededed;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1091"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1091</span></button>
+    <div class="container-img_6328_1091" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1091: linear-gradient(180deg, #eeeeee 0%, #f7f7f7 100%);<br/>
+    --border-img_6328_1091: #f1f1f1;<br/>
+    --text-img_6328_1091: #f7f7f7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1092"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1092</span></button>
+    <div class="container-img_6328_1092" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1092: linear-gradient(180deg, #f2f2f2 0%, #f3f3f3 100%);<br/>
+    --border-img_6328_1092: #f1f2f0;<br/>
+    --text-img_6328_1092: #f5f7f5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1093"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1093</span></button>
+    <div class="container-img_6328_1093" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1093: linear-gradient(180deg, #eeeeee 0%, #f7f7f7 100%);<br/>
+    --border-img_6328_1093: #f4f4f4;<br/>
+    --text-img_6328_1093: #fdfdfd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1094"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1094</span></button>
+    <div class="container-img_6328_1094" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1094: linear-gradient(180deg, #f7f7f7 0%, #f7f7f7 100%);<br/>
+    --border-img_6328_1094: #e8e8e8;<br/>
+    --text-img_6328_1094: #f7f7f7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1095"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1095</span></button>
+    <div class="container-img_6328_1095" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1095: linear-gradient(180deg, #f7f7f7 0%, #f7f7f7 100%);<br/>
+    --border-img_6328_1095: #ececec;<br/>
+    --text-img_6328_1095: #f7f7f7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1096"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1096</span></button>
+    <div class="container-img_6328_1096" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1096: linear-gradient(180deg, #fefefe 0%, #f1f1f1 100%);<br/>
+    --border-img_6328_1096: #f3f5f3;<br/>
+    --text-img_6328_1096: #eff3ee;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1097"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1097</span></button>
+    <div class="container-img_6328_1097" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1097: linear-gradient(180deg, #fefefe 0%, #f1f1f1 100%);<br/>
+    --border-img_6328_1097: #f3f5f2;<br/>
+    --text-img_6328_1097: #f7f7f7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1098"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1098</span></button>
+    <div class="container-img_6328_1098" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1098: linear-gradient(180deg, #f7f7f7 0%, #d4d3d3 100%);<br/>
+    --border-img_6328_1098: #ededed;<br/>
+    --text-img_6328_1098: #f5f5f5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1099"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1099</span></button>
+    <div class="container-img_6328_1099" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1099: linear-gradient(180deg, #f3f4f3 0%, #ecedec 100%);<br/>
+    --border-img_6328_1099: #e9eee8;<br/>
+    --text-img_6328_1099: #eef0ed;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1100"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1100</span></button>
+    <div class="container-img_6328_1100" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1100: linear-gradient(180deg, #f8f8f8 0%, #eeeeee 100%);<br/>
+    --border-img_6328_1100: #edefec;<br/>
+    --text-img_6328_1100: #f3f3f3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1101"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1101</span></button>
+    <div class="container-img_6328_1101" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1101: linear-gradient(180deg, #f8f8f8 0%, #eeeeee 100%);<br/>
+    --border-img_6328_1101: #f3f3f3;<br/>
+    --text-img_6328_1101: #f3f3f3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1102"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1102</span></button>
+    <div class="container-img_6328_1102" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1102: linear-gradient(180deg, #f7f7f7 0%, #f7f7f7 100%);<br/>
+    --border-img_6328_1102: #f3f3f3;<br/>
+    --text-img_6328_1102: #ebeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1103"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1103</span></button>
+    <div class="container-img_6328_1103" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1103: linear-gradient(180deg, #f0f0f0 0%, #e9e9e9 100%);<br/>
+    --border-img_6328_1103: #f0f0f0;<br/>
+    --text-img_6328_1103: #eaecea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1104"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1104</span></button>
+    <div class="container-img_6328_1104" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1104: linear-gradient(180deg, #f3f3f3 0%, #e7e7e7 100%);<br/>
+    --border-img_6328_1104: #ededed;<br/>
+    --text-img_6328_1104: #ededed;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1105"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1105</span></button>
+    <div class="container-img_6328_1105" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1105: linear-gradient(180deg, #f7f7f7 0%, #abe79f 100%);<br/>
+    --border-img_6328_1105: #d1decf;<br/>
+    --text-img_6328_1105: #efefef;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1106"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1106</span></button>
+    <div class="container-img_6328_1106" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1106: linear-gradient(180deg, #f7f7f7 0%, #abe79f 100%);<br/>
+    --border-img_6328_1106: #d8e6d5;<br/>
+    --text-img_6328_1106: #efefef;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1107"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1107</span></button>
+    <div class="container-img_6328_1107" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1107: linear-gradient(180deg, #ebebeb 0%, #7a7a7a 100%);<br/>
+    --border-img_6328_1107: #bebebe;<br/>
+    --text-img_6328_1107: #e5e6e4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1108"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1108</span></button>
+    <div class="container-img_6328_1108" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1108: linear-gradient(180deg, #ebebeb 0%, #7a7a7a 100%);<br/>
+    --border-img_6328_1108: #bebebe;<br/>
+    --text-img_6328_1108: #e4e6e4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1109"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1109</span></button>
+    <div class="container-img_6328_1109" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1109: linear-gradient(180deg, #f7f7f7 0%, #aee9a1 100%);<br/>
+    --border-img_6328_1109: #dcecd9;<br/>
+    --text-img_6328_1109: #efefef;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1110"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1110</span></button>
+    <div class="container-img_6328_1110" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1110: linear-gradient(180deg, #f7f7f7 0%, #aee9a1 100%);<br/>
+    --border-img_6328_1110: #d5e8d1;<br/>
+    --text-img_6328_1110: #efefef;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1111"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1111</span></button>
+    <div class="container-img_6328_1111" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1111: linear-gradient(180deg, #e9eae9 0%, #a6a6a6 100%);<br/>
+    --border-img_6328_1111: #cfd5ce;<br/>
+    --text-img_6328_1111: #e4e7e4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1112"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1112</span></button>
+    <div class="container-img_6328_1112" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1112: linear-gradient(180deg, #eaeaea 0%, #7c7c7c 100%);<br/>
+    --border-img_6328_1112: #c1c1c1;<br/>
+    --text-img_6328_1112: #e4e6e3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1113"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1113</span></button>
+    <div class="container-img_6328_1113" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1113: linear-gradient(180deg, #eaeaea 0%, #7c7c7c 100%);<br/>
+    --border-img_6328_1113: #c1c1c1;<br/>
+    --text-img_6328_1113: #e3e5e3;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1114"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1114</span></button>
+    <div class="container-img_6328_1114" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1114: linear-gradient(180deg, #e7e7e7 0%, #a0de92 100%);<br/>
+    --border-img_6328_1114: #c6e3bf;<br/>
+    --text-img_6328_1114: #a4de98;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1115"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1115</span></button>
+    <div class="container-img_6328_1115" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1115: linear-gradient(180deg, #e9e9e9 0%, #98a196 100%);<br/>
+    --border-img_6328_1115: #b5c5b1;<br/>
+    --text-img_6328_1115: #9a9a9a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1116"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1116</span></button>
+    <div class="container-img_6328_1116" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1116: linear-gradient(180deg, #e7e7e7 0%, #a3a3a3 100%);<br/>
+    --border-img_6328_1116: #b3b2b2;<br/>
+    --text-img_6328_1116: #787878;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1117"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1117</span></button>
+    <div class="container-img_6328_1117" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1117: linear-gradient(180deg, #a7e49a 0%, #98d788 100%);<br/>
+    --border-img_6328_1117: #b5dfac;<br/>
+    --text-img_6328_1117: #9fde91;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1118"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1118</span></button>
+    <div class="container-img_6328_1118" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1118: linear-gradient(180deg, #a7e49a 0%, #98d788 100%);<br/>
+    --border-img_6328_1118: #9fdd91;<br/>
+    --text-img_6328_1118: #9fde91;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1119"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1119</span></button>
+    <div class="container-img_6328_1119" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1119: linear-gradient(180deg, #a2a2a2 0%, #999898 100%);<br/>
+    --border-img_6328_1119: #97ac92;<br/>
+    --text-img_6328_1119: #838383;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1120"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1120</span></button>
+    <div class="container-img_6328_1120" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1120: linear-gradient(180deg, #767676 0%, #d5d5d5 100%);<br/>
+    --border-img_6328_1120: #ababab;<br/>
+    --text-img_6328_1120: #d5d5d5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1121"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1121</span></button>
+    <div class="container-img_6328_1121" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1121: linear-gradient(180deg, #767676 0%, #afafaf 100%);<br/>
+    --border-img_6328_1121: #8a8989;<br/>
+    --text-img_6328_1121: #8a8989;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1122"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1122</span></button>
+    <div class="container-img_6328_1122" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1122: linear-gradient(180deg, #a3e095 0%, #8fd07f 100%);<br/>
+    --border-img_6328_1122: #afdba5;<br/>
+    --text-img_6328_1122: #99d88a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1123"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1123</span></button>
+    <div class="container-img_6328_1123" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1123: linear-gradient(180deg, #a3e095 0%, #8fd07f 100%);<br/>
+    --border-img_6328_1123: #b3dcaa;<br/>
+    --text-img_6328_1123: #99d88a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1124"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1124</span></button>
+    <div class="container-img_6328_1124" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1124: linear-gradient(180deg, #7d7c7c 0%, #605f5f 100%);<br/>
+    --border-img_6328_1124: #7e7e7e;<br/>
+    --text-img_6328_1124: #d5d5d5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1125"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1125</span></button>
+    <div class="container-img_6328_1125" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1125: linear-gradient(180deg, #727272 0%, #605f5f 100%);<br/>
+    --border-img_6328_1125: #7a7979;<br/>
+    --text-img_6328_1125: #d5d5d5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1126"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1126</span></button>
+    <div class="container-img_6328_1126" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1126: linear-gradient(180deg, #99d88a 0%, #e0e0e0 100%);<br/>
+    --border-img_6328_1126: #bfdbb8;<br/>
+    --text-img_6328_1126: #90d180;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1127"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1127</span></button>
+    <div class="container-img_6328_1127" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1127: linear-gradient(180deg, #9ca599 0%, #e1e1e1 100%);<br/>
+    --border-img_6328_1127: #b2c3ae;<br/>
+    --text-img_6328_1127: #8b8a8a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1128"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1128</span></button>
+    <div class="container-img_6328_1128" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1128: linear-gradient(180deg, #d5d5d5 0%, #e0e0e0 100%);<br/>
+    --border-img_6328_1128: #b2b1b1;<br/>
+    --text-img_6328_1128: #616161;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1129"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1129</span></button>
+    <div class="container-img_6328_1129" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1129: linear-gradient(180deg, #91d281 0%, #dfdfdf 100%);<br/>
+    --border-img_6328_1129: #c5dac0;<br/>
+    --text-img_6328_1129: #c4d7bf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1130"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1130</span></button>
+    <div class="container-img_6328_1130" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1130: linear-gradient(180deg, #91d281 0%, #dfdfdf 100%);<br/>
+    --border-img_6328_1130: #b9d8b2;<br/>
+    --text-img_6328_1130: #c5d8c0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1131"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1131</span></button>
+    <div class="container-img_6328_1131" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1131: linear-gradient(180deg, #959494 0%, #e0e0e0 100%);<br/>
+    --border-img_6328_1131: #b3bdb0;<br/>
+    --text-img_6328_1131: #c9c9c9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1132"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1132</span></button>
+    <div class="container-img_6328_1132" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1132: linear-gradient(180deg, #626161 0%, #e0e0df 100%);<br/>
+    --border-img_6328_1132: #a3a3a3;<br/>
+    --text-img_6328_1132: #b8b8b8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1133"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1133</span></button>
+    <div class="container-img_6328_1133" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1133: linear-gradient(180deg, #626161 0%, #dfdfdf 100%);<br/>
+    --border-img_6328_1133: #a4a3a3;<br/>
+    --text-img_6328_1133: #b7b7b7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1134"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1134</span></button>
+    <div class="container-img_6328_1134" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1134: linear-gradient(180deg, #e0e0e0 0%, #dcdcdc 100%);<br/>
+    --border-img_6328_1134: #dedede;<br/>
+    --text-img_6328_1134: #dedede;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1135"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1135</span></button>
+    <div class="container-img_6328_1135" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1135: linear-gradient(180deg, #e1e1e1 0%, #dddddd 100%);<br/>
+    --border-img_6328_1135: #dfdfdf;<br/>
+    --text-img_6328_1135: #dfdfdf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1136"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1136</span></button>
+    <div class="container-img_6328_1136" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1136: linear-gradient(180deg, #e1e1e1 0%, #dddddd 100%);<br/>
+    --border-img_6328_1136: #dfdfdf;<br/>
+    --text-img_6328_1136: #dfdfdf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1137"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1137</span></button>
+    <div class="container-img_6328_1137" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1137: linear-gradient(180deg, #e0e0e0 0%, #dcdcdc 100%);<br/>
+    --border-img_6328_1137: #dedede;<br/>
+    --text-img_6328_1137: #dedede;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1138"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1138</span></button>
+    <div class="container-img_6328_1138" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1138: linear-gradient(180deg, #dfdfdf 0%, #dcdcdc 100%);<br/>
+    --border-img_6328_1138: #dddddd;<br/>
+    --text-img_6328_1138: #dddddd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1139"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1139</span></button>
+    <div class="container-img_6328_1139" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1139: linear-gradient(180deg, #dfe0df 0%, #dcdcdc 100%);<br/>
+    --border-img_6328_1139: #dedede;<br/>
+    --text-img_6328_1139: #dedede;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1140"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1140</span></button>
+    <div class="container-img_6328_1140" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1140: linear-gradient(180deg, #dfdfdf 0%, #dcdcdc 100%);<br/>
+    --border-img_6328_1140: #dddddd;<br/>
+    --text-img_6328_1140: #dddddd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1141"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1141</span></button>
+    <div class="container-img_6328_1141" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1141: linear-gradient(180deg, #dedede 0%, #dbdbdb 100%);<br/>
+    --border-img_6328_1141: #c8c8c8;<br/>
+    --text-img_6328_1141: #dcdcdc;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1142"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1142</span></button>
+    <div class="container-img_6328_1142" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1142: linear-gradient(180deg, #dedede 0%, #dcdcdc 100%);<br/>
+    --border-img_6328_1142: #c9c9c9;<br/>
+    --text-img_6328_1142: #dddddd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1143"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1143</span></button>
+    <div class="container-img_6328_1143" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1143: linear-gradient(180deg, #dfdfdf 0%, #dcdcdc 100%);<br/>
+    --border-img_6328_1143: #c9c9c9;<br/>
+    --text-img_6328_1143: #dddddd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1144"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1144</span></button>
+    <div class="container-img_6328_1144" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1144: linear-gradient(180deg, #dedede 0%, #dcdcdc 100%);<br/>
+    --border-img_6328_1144: #c9c9c9;<br/>
+    --text-img_6328_1144: #dddddd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1145"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1145</span></button>
+    <div class="container-img_6328_1145" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1145: linear-gradient(180deg, #dedede 0%, #dbdbdb 100%);<br/>
+    --border-img_6328_1145: #c8c8c8;<br/>
+    --text-img_6328_1145: #dcdcdc;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1146"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1146</span></button>
+    <div class="container-img_6328_1146" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1146: linear-gradient(180deg, #7f7f7f 0%, #343739 100%);<br/>
+    --border-img_6328_1146: #9d9e9e;<br/>
+    --text-img_6328_1146: #c8c8c8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1147"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1147</span></button>
+    <div class="container-img_6328_1147" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1147: linear-gradient(180deg, #7f7f7f 0%, #343739 100%);<br/>
+    --border-img_6328_1147: #9d9e9f;<br/>
+    --text-img_6328_1147: #c6c5c5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1148"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1148</span></button>
+    <div class="container-img_6328_1148" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1148: linear-gradient(180deg, #7f7f7f 0%, #343739 100%);<br/>
+    --border-img_6328_1148: #9fa0a1;<br/>
+    --text-img_6328_1148: #c6c5c5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1149"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1149</span></button>
+    <div class="container-img_6328_1149" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1149: linear-gradient(180deg, #7f7f7f 0%, #343739 100%);<br/>
+    --border-img_6328_1149: #9d9d9e;<br/>
+    --text-img_6328_1149: #c8c7c7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1150"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1150</span></button>
+    <div class="container-img_6328_1150" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1150: linear-gradient(180deg, #cfcece 0%, #343739 100%);<br/>
+    --border-img_6328_1150: #7e7f80;<br/>
+    --text-img_6328_1150: #c8c7c7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1151"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1151</span></button>
+    <div class="container-img_6328_1151" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1151: linear-gradient(180deg, #cecdcd 0%, #3c4042 100%);<br/>
+    --border-img_6328_1151: #818182;<br/>
+    --text-img_6328_1151: #c6c4c4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1152"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1152</span></button>
+    <div class="container-img_6328_1152" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1152: linear-gradient(180deg, #cfcece 0%, #343739 100%);<br/>
+    --border-img_6328_1152: #838384;<br/>
+    --text-img_6328_1152: #c8c7c7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1153"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1153</span></button>
+    <div class="container-img_6328_1153" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1153: linear-gradient(180deg, #c8c8c8 0%, #343739 100%);<br/>
+    --border-img_6328_1153: #989999;<br/>
+    --text-img_6328_1153: #c8c8c8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1154"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1154</span></button>
+    <div class="container-img_6328_1154" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1154: linear-gradient(180deg, #c7c6c6 0%, #343739 100%);<br/>
+    --border-img_6328_1154: #979798;<br/>
+    --text-img_6328_1154: #c7c6c6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1155"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1155</span></button>
+    <div class="container-img_6328_1155" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1155: linear-gradient(180deg, #c6c5c5 0%, #494d50 100%);<br/>
+    --border-img_6328_1155: #9b9b9c;<br/>
+    --text-img_6328_1155: #c6c4c4;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1156"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1156</span></button>
+    <div class="container-img_6328_1156" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1156: linear-gradient(180deg, #c7c6c6 0%, #343739 100%);<br/>
+    --border-img_6328_1156: #9fa0a0;<br/>
+    --text-img_6328_1156: #c7c5c5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6328_1157"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6328_1157</span></button>
+    <div class="container-img_6328_1157" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6328_1157: linear-gradient(180deg, #c8c8c8 0%, #343739 100%);<br/>
+    --border-img_6328_1157: #989999;<br/>
+    --text-img_6328_1157: #c8c7c7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1158"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1158</span></button>
+    <div class="container-img_6329_1158" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1158: linear-gradient(180deg, #5e6367 0%, #f7f7f7 100%);<br/>
+    --border-img_6329_1158: #9c9ea0;<br/>
+    --text-img_6329_1158: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1159"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1159</span></button>
+    <div class="container-img_6329_1159" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1159: linear-gradient(180deg, #5e6367 0%, #f7f7f7 100%);<br/>
+    --border-img_6329_1159: #9b9d9f;<br/>
+    --text-img_6329_1159: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1160"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1160</span></button>
+    <div class="container-img_6329_1160" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1160: linear-gradient(180deg, #5e6367 0%, #eeeeee 100%);<br/>
+    --border-img_6329_1160: #9b9d9f;<br/>
+    --text-img_6329_1160: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1161"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1161</span></button>
+    <div class="container-img_6329_1161" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1161: linear-gradient(180deg, #5e6367 0%, #f3f3f3 100%);<br/>
+    --border-img_6329_1161: #999c9e;<br/>
+    --text-img_6329_1161: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1162"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1162</span></button>
+    <div class="container-img_6329_1162" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1162: linear-gradient(180deg, #5e6367 0%, #f3f3f3 100%);<br/>
+    --border-img_6329_1162: #9a9d9e;<br/>
+    --text-img_6329_1162: #45494c;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1163"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1163</span></button>
+    <div class="container-img_6329_1163" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1163: linear-gradient(180deg, #5e6367 0%, #f7f7f7 100%);<br/>
+    --border-img_6329_1163: #a9abad;<br/>
+    --text-img_6329_1163: #76797a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1164"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1164</span></button>
+    <div class="container-img_6329_1164" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1164: linear-gradient(180deg, #5e6367 0%, #ebedeb 100%);<br/>
+    --border-img_6329_1164: #9da0a1;<br/>
+    --text-img_6329_1164: #747677;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1165"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1165</span></button>
+    <div class="container-img_6329_1165" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1165: linear-gradient(180deg, #5e6367 0%, #f3f3f3 100%);<br/>
+    --border-img_6329_1165: #a6a8aa;<br/>
+    --text-img_6329_1165: #767879;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1166"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1166</span></button>
+    <div class="container-img_6329_1166" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1166: linear-gradient(180deg, #5e6367 0%, #f7f7f7 100%);<br/>
+    --border-img_6329_1166: #adb0b1;<br/>
+    --text-img_6329_1166: #bebfc0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1167"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1167</span></button>
+    <div class="container-img_6329_1167" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1167: linear-gradient(180deg, #5e6367 0%, #ececec 100%);<br/>
+    --border-img_6329_1167: #aaadae;<br/>
+    --text-img_6329_1167: #aeafb0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1168"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1168</span></button>
+    <div class="container-img_6329_1168" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1168: linear-gradient(180deg, #5e6367 0%, #f1f2f1 100%);<br/>
+    --border-img_6329_1168: #acaeb0;<br/>
+    --text-img_6329_1168: #bcbdbd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1169"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1169</span></button>
+    <div class="container-img_6329_1169" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1169: linear-gradient(180deg, #5e6367 0%, #f2f2f2 100%);<br/>
+    --border-img_6329_1169: #acaeb0;<br/>
+    --text-img_6329_1169: #bcbdbd;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1170"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1170</span></button>
+    <div class="container-img_6329_1170" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1170: linear-gradient(180deg, #f7f7f7 0%, #f7f7f7 100%);<br/>
+    --border-img_6329_1170: #f2f2f2;<br/>
+    --text-img_6329_1170: #f7f7f7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1171"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1171</span></button>
+    <div class="container-img_6329_1171" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1171: linear-gradient(180deg, #f2f2f2 0%, #f0f0f0 100%);<br/>
+    --border-img_6329_1171: #f1f1f1;<br/>
+    --text-img_6329_1171: #f1f1f1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1172"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1172</span></button>
+    <div class="container-img_6329_1172" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1172: linear-gradient(180deg, #f2f2f2 0%, #f0f0f0 100%);<br/>
+    --border-img_6329_1172: #f1f1f1;<br/>
+    --text-img_6329_1172: #f1f1f1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1173"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1173</span></button>
+    <div class="container-img_6329_1173" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1173: linear-gradient(180deg, #ebedea 0%, #eaebe9 100%);<br/>
+    --border-img_6329_1173: #e1e1e1;<br/>
+    --text-img_6329_1173: #ededed;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1174"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1174</span></button>
+    <div class="container-img_6329_1174" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1174: linear-gradient(180deg, #f2f2f2 0%, #efefef 100%);<br/>
+    --border-img_6329_1174: #f0f0f0;<br/>
+    --text-img_6329_1174: #f0f0f0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1175"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1175</span></button>
+    <div class="container-img_6329_1175" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1175: linear-gradient(180deg, #ececec 0%, #ebebeb 100%);<br/>
+    --border-img_6329_1175: #f0f0f0;<br/>
+    --text-img_6329_1175: #dfdfdf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1176"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1176</span></button>
+    <div class="container-img_6329_1176" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1176: linear-gradient(180deg, #f0f0f0 0%, #ecedec 100%);<br/>
+    --border-img_6329_1176: #edeeed;<br/>
+    --text-img_6329_1176: #efefef;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1177"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1177</span></button>
+    <div class="container-img_6329_1177" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1177: linear-gradient(180deg, #f1f1f1 0%, #eeeeee 100%);<br/>
+    --border-img_6329_1177: #efefef;<br/>
+    --text-img_6329_1177: #efefef;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1178"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1178</span></button>
+    <div class="container-img_6329_1178" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1178: linear-gradient(180deg, #f7f7f7 0%, #f7f7f7 100%);<br/>
+    --border-img_6329_1178: #f2f2f2;<br/>
+    --text-img_6329_1178: #f7f7f7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1179"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1179</span></button>
+    <div class="container-img_6329_1179" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1179: linear-gradient(180deg, #eeeeee 0%, #ececec 100%);<br/>
+    --border-img_6329_1179: #ededed;<br/>
+    --text-img_6329_1179: #ededed;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1180"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1180</span></button>
+    <div class="container-img_6329_1180" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1180: linear-gradient(180deg, #eeeeee 0%, #ececec 100%);<br/>
+    --border-img_6329_1180: #ededed;<br/>
+    --text-img_6329_1180: #ededed;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1181"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1181</span></button>
+    <div class="container-img_6329_1181" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1181: linear-gradient(180deg, #e9ebe9 0%, #e8eae8 100%);<br/>
+    --border-img_6329_1181: #dfdfde;<br/>
+    --text-img_6329_1181: #ebebeb;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1182"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1182</span></button>
+    <div class="container-img_6329_1182" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1182: linear-gradient(180deg, #ededed 0%, #eaeaea 100%);<br/>
+    --border-img_6329_1182: #ececec;<br/>
+    --text-img_6329_1182: #ececec;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1183"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1183</span></button>
+    <div class="container-img_6329_1183" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1183: linear-gradient(180deg, #ebebeb 0%, #eaeaeb 100%);<br/>
+    --border-img_6329_1183: #efefef;<br/>
+    --text-img_6329_1183: #dfdfdf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1184"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1184</span></button>
+    <div class="container-img_6329_1184" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1184: linear-gradient(180deg, #ebeceb 0%, #e7e8e7 100%);<br/>
+    --border-img_6329_1184: #e9eae9;<br/>
+    --text-img_6329_1184: #eaeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1185"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1185</span></button>
+    <div class="container-img_6329_1185" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1185: linear-gradient(180deg, #ececec 0%, #e9e9e9 100%);<br/>
+    --border-img_6329_1185: #eaeaea;<br/>
+    --text-img_6329_1185: #eaeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1186"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1186</span></button>
+    <div class="container-img_6329_1186" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1186: linear-gradient(180deg, #f7f7f7 0%, #f7f7f7 100%);<br/>
+    --border-img_6329_1186: #f1f1f1;<br/>
+    --text-img_6329_1186: #f7f7f7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1187"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1187</span></button>
+    <div class="container-img_6329_1187" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1187: linear-gradient(180deg, #ebebeb 0%, #e8e8e8 100%);<br/>
+    --border-img_6329_1187: #e9e9e9;<br/>
+    --text-img_6329_1187: #e9e9e9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1188"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1188</span></button>
+    <div class="container-img_6329_1188" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1188: linear-gradient(180deg, #ebebeb 0%, #e8e8e8 100%);<br/>
+    --border-img_6329_1188: #e9e9e9;<br/>
+    --text-img_6329_1188: #e9e9e9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1189"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1189</span></button>
+    <div class="container-img_6329_1189" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1189: linear-gradient(180deg, #e8eae8 0%, #e7e9e6 100%);<br/>
+    --border-img_6329_1189: #dddddc;<br/>
+    --text-img_6329_1189: #eaeaea;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1190"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1190</span></button>
+    <div class="container-img_6329_1190" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1190: linear-gradient(180deg, #e9e9e9 0%, #e6e6e6 100%);<br/>
+    --border-img_6329_1190: #e7e7e7;<br/>
+    --text-img_6329_1190: #e8e8e8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1191"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1191</span></button>
+    <div class="container-img_6329_1191" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1191: linear-gradient(180deg, #f7f7f7 0%, #e9e9e9 100%);<br/>
+    --border-img_6329_1191: #f1f1f1;<br/>
+    --text-img_6329_1191: #f7f7f7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1192"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1192</span></button>
+    <div class="container-img_6329_1192" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1192: linear-gradient(180deg, #eaeaea 0%, #e9e9e9 100%);<br/>
+    --border-img_6329_1192: #ececec;<br/>
+    --text-img_6329_1192: #dedede;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1193"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1193</span></button>
+    <div class="container-img_6329_1193" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1193: linear-gradient(180deg, #e6e7e6 0%, #e9e9e9 100%);<br/>
+    --border-img_6329_1193: #e7e8e7;<br/>
+    --text-img_6329_1193: #e5e5e5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1194"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1194</span></button>
+    <div class="container-img_6329_1194" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1194: linear-gradient(180deg, #e7e7e7 0%, #e9e9e9 100%);<br/>
+    --border-img_6329_1194: #e7e7e6;<br/>
+    --text-img_6329_1194: #e5e5e5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1195"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1195</span></button>
+    <div class="container-img_6329_1195" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1195: linear-gradient(180deg, #f7f7f7 0%, #e9e9e9 100%);<br/>
+    --border-img_6329_1195: #f1f1f1;<br/>
+    --text-img_6329_1195: #f7f7f7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1196"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1196</span></button>
+    <div class="container-img_6329_1196" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1196: linear-gradient(180deg, #f7f7f7 0%, #e9e9e9 100%);<br/>
+    --border-img_6329_1196: #ededed;<br/>
+    --text-img_6329_1196: #f7f7f7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1197"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1197</span></button>
+    <div class="container-img_6329_1197" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1197: linear-gradient(180deg, #e7e7e7 0%, #e9e9e9 100%);<br/>
+    --border-img_6329_1197: #e6e7e6;<br/>
+    --text-img_6329_1197: #e5e5e5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1198"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1198</span></button>
+    <div class="container-img_6329_1198" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1198: linear-gradient(180deg, #e7e7e7 0%, #e9e9e9 100%);<br/>
+    --border-img_6329_1198: #e6e7e6;<br/>
+    --text-img_6329_1198: #e5e5e5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1199"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1199</span></button>
+    <div class="container-img_6329_1199" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1199: linear-gradient(180deg, #f7f7f7 0%, #8fc783 100%);<br/>
+    --border-img_6329_1199: #d8ecd4;<br/>
+    --text-img_6329_1199: #e9e9e9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1200"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1200</span></button>
+    <div class="container-img_6329_1200" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1200: linear-gradient(180deg, #e9e9e9 0%, #e5e5e5 100%);<br/>
+    --border-img_6329_1200: #dbdbda;<br/>
+    --text-img_6329_1200: #e9e9e9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1201"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1201</span></button>
+    <div class="container-img_6329_1201" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1201: linear-gradient(180deg, #b9dab2 0%, #7b7b7b 100%);<br/>
+    --border-img_6329_1201: #c0c1c0;<br/>
+    --text-img_6329_1201: #e9e9e9;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1202"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1202</span></button>
+    <div class="container-img_6329_1202" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1202: linear-gradient(180deg, #e9e9e9 0%, #aee9a2 100%);<br/>
+    --border-img_6329_1202: #c6e7bf;<br/>
+    --text-img_6329_1202: #a2dc96;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1203"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1203</span></button>
+    <div class="container-img_6329_1203" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1203: linear-gradient(180deg, #e9e9e9 0%, #aee9a1 100%);<br/>
+    --border-img_6329_1203: #d1e7cc;<br/>
+    --text-img_6329_1203: #a0da94;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1204"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1204</span></button>
+    <div class="container-img_6329_1204" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1204: linear-gradient(180deg, #e9e9e9 0%, #e7e7e7 100%);<br/>
+    --border-img_6329_1204: #d2d2d2;<br/>
+    --text-img_6329_1204: #e8e8e8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1205"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1205</span></button>
+    <div class="container-img_6329_1205" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1205: linear-gradient(180deg, #e9e9e9 0%, #7c7c7c 100%);<br/>
+    --border-img_6329_1205: #aaaaaa;<br/>
+    --text-img_6329_1205: #757575;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1206"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1206</span></button>
+    <div class="container-img_6329_1206" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1206: linear-gradient(180deg, #e9e9e9 0%, #7c7c7c 100%);<br/>
+    --border-img_6329_1206: #aaaaaa;<br/>
+    --text-img_6329_1206: #757575;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1207"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1207</span></button>
+    <div class="container-img_6329_1207" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1207: linear-gradient(180deg, #e8e8e8 0%, #ace89f 100%);<br/>
+    --border-img_6329_1207: #bde7b5;<br/>
+    --text-img_6329_1207: #aeeaa2;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1208"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1208</span></button>
+    <div class="container-img_6329_1208" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1208: linear-gradient(180deg, #e9e9e9 0%, #c8e2c2 100%);<br/>
+    --border-img_6329_1208: #d3e7ce;<br/>
+    --text-img_6329_1208: #c5d6c1;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1209"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1209</span></button>
+    <div class="container-img_6329_1209" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1209: linear-gradient(180deg, #e9e9e9 0%, #7a7a7a 100%);<br/>
+    --border-img_6329_1209: #b8b8b8;<br/>
+    --text-img_6329_1209: #7d7d7d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1210"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1210</span></button>
+    <div class="container-img_6329_1210" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1210: linear-gradient(180deg, #e9e9e9 0%, #7a7a7a 100%);<br/>
+    --border-img_6329_1210: #9c9c9b;<br/>
+    --text-img_6329_1210: #7d7d7d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1211"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1211</span></button>
+    <div class="container-img_6329_1211" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1211: linear-gradient(180deg, #aeeaa2 0%, #aae69d 100%);<br/>
+    --border-img_6329_1211: #ace89f;<br/>
+    --text-img_6329_1211: #ace89f;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1212"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1212</span></button>
+    <div class="container-img_6329_1212" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1212: linear-gradient(180deg, #cfcfcf 0%, #cecece 100%);<br/>
+    --border-img_6329_1212: #a9b2a7;<br/>
+    --text-img_6329_1212: #e8e8e8;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1213"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1213</span></button>
+    <div class="container-img_6329_1213" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1213: linear-gradient(180deg, #7d7d7d 0%, #787878 100%);<br/>
+    --border-img_6329_1213: #7a7a7a;<br/>
+    --text-img_6329_1213: #7a7a7a;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1214"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1214</span></button>
+    <div class="container-img_6329_1214" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1214: linear-gradient(180deg, #ace8a0 0%, #a8e49b 100%);<br/>
+    --border-img_6329_1214: #aae69d;<br/>
+    --text-img_6329_1214: #aae69d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1215"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1215</span></button>
+    <div class="container-img_6329_1215" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1215: linear-gradient(180deg, #ace89f 0%, #a8e49b 100%);<br/>
+    --border-img_6329_1215: #bce4b3;<br/>
+    --text-img_6329_1215: #aae69d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1216"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1216</span></button>
+    <div class="container-img_6329_1216" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1216: linear-gradient(180deg, #e6e6e6 0%, #e6e6e6 100%);<br/>
+    --border-img_6329_1216: #bebebe;<br/>
+    --text-img_6329_1216: #e7e7e7;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1217"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1217</span></button>
+    <div class="container-img_6329_1217" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1217: linear-gradient(180deg, #7b7b7b 0%, #777777 100%);<br/>
+    --border-img_6329_1217: #797979;<br/>
+    --text-img_6329_1217: #797979;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1218"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1218</span></button>
+    <div class="container-img_6329_1218" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1218: linear-gradient(180deg, #7b7b7b 0%, #777777 100%);<br/>
+    --border-img_6329_1218: #797979;<br/>
+    --text-img_6329_1218: #797979;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1219"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1219</span></button>
+    <div class="container-img_6329_1219" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1219: linear-gradient(180deg, #a9e69c 0%, #a4e196 100%);<br/>
+    --border-img_6329_1219: #a7e399;<br/>
+    --text-img_6329_1219: #a7e399;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1220"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1220</span></button>
+    <div class="container-img_6329_1220" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1220: linear-gradient(180deg, #c7e1c1 0%, #c4dfbe 100%);<br/>
+    --border-img_6329_1220: #c6e4c0;<br/>
+    --text-img_6329_1220: #c4d6c0;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1221"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1221</span></button>
+    <div class="container-img_6329_1221" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1221: linear-gradient(180deg, #787878 0%, #737373 100%);<br/>
+    --border-img_6329_1221: #9b9a9a;<br/>
+    --text-img_6329_1221: #767575;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1222"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1222</span></button>
+    <div class="container-img_6329_1222" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1222: linear-gradient(180deg, #787878 0%, #737373 100%);<br/>
+    --border-img_6329_1222: #767575;<br/>
+    --text-img_6329_1222: #767575;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1223"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1223</span></button>
+    <div class="container-img_6329_1223" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1223: linear-gradient(180deg, #a8e49a 0%, #a3e095 100%);<br/>
+    --border-img_6329_1223: #a5e298;<br/>
+    --text-img_6329_1223: #a5e298;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1224"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1224</span></button>
+    <div class="container-img_6329_1224" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1224: linear-gradient(180deg, #cdcdcd 0%, #cccccc 100%);<br/>
+    --border-img_6329_1224: #a6afa4;<br/>
+    --text-img_6329_1224: #e6e6e6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1225"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1225</span></button>
+    <div class="container-img_6329_1225" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1225: linear-gradient(180deg, #767676 0%, #727272 100%);<br/>
+    --border-img_6329_1225: #747474;<br/>
+    --text-img_6329_1225: #747474;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1226"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1226</span></button>
+    <div class="container-img_6329_1226" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1226: linear-gradient(180deg, #a6e399 0%, #a2df94 100%);<br/>
+    --border-img_6329_1226: #a4e196;<br/>
+    --text-img_6329_1226: #a4e196;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1227"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1227</span></button>
+    <div class="container-img_6329_1227" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1227: linear-gradient(180deg, #a6e399 0%, #a2df94 100%);<br/>
+    --border-img_6329_1227: #b7e1ae;<br/>
+    --text-img_6329_1227: #a4e196;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1228"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1228</span></button>
+    <div class="container-img_6329_1228" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1228: linear-gradient(180deg, #e5e5e5 0%, #e4e5e5 100%);<br/>
+    --border-img_6329_1228: #bbbbbb;<br/>
+    --text-img_6329_1228: #e6e6e6;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1229"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1229</span></button>
+    <div class="container-img_6329_1229" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1229: linear-gradient(180deg, #757575 0%, #717171 100%);<br/>
+    --border-img_6329_1229: #737373;<br/>
+    --text-img_6329_1229: #737373;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1230"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1230</span></button>
+    <div class="container-img_6329_1230" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1230: linear-gradient(180deg, #757575 0%, #717171 100%);<br/>
+    --border-img_6329_1230: #737373;<br/>
+    --text-img_6329_1230: #737373;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1231"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1231</span></button>
+    <div class="container-img_6329_1231" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1231: linear-gradient(180deg, #a2df94 0%, #343739 100%);<br/>
+    --border-img_6329_1231: #81ad78;<br/>
+    --text-img_6329_1231: #9fdd91;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1232"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1232</span></button>
+    <div class="container-img_6329_1232" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1232: linear-gradient(180deg, #c3debe 0%, #343739 100%);<br/>
+    --border-img_6329_1232: #9ab097;<br/>
+    --text-img_6329_1232: #c2d4bf;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1233"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1233</span></button>
+    <div class="container-img_6329_1233" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1233: linear-gradient(180deg, #717171 0%, #343739 100%);<br/>
+    --border-img_6329_1233: #818282;<br/>
+    --text-img_6329_1233: #6f6e6e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1234"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1234</span></button>
+    <div class="container-img_6329_1234" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1234: linear-gradient(180deg, #717171 0%, #343739 100%);<br/>
+    --border-img_6329_1234: #696a6a;<br/>
+    --text-img_6329_1234: #6f6e6e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1235"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1235</span></button>
+    <div class="container-img_6329_1235" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1235: linear-gradient(180deg, #a1df93 0%, #343739 100%);<br/>
+    --border-img_6329_1235: #7ba473;<br/>
+    --text-img_6329_1235: #9fdd90;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1236"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1236</span></button>
+    <div class="container-img_6329_1236" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1236: linear-gradient(180deg, #cccccc 0%, #3c4042 100%);<br/>
+    --border-img_6329_1236: #7c847c;<br/>
+    --text-img_6329_1236: #e5e5e5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1237"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1237</span></button>
+    <div class="container-img_6329_1237" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1237: linear-gradient(180deg, #707070 0%, #343739 100%);<br/>
+    --border-img_6329_1237: #696a6a;<br/>
+    --text-img_6329_1237: #6e6e6e;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1238"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1238</span></button>
+    <div class="container-img_6329_1238" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1238: linear-gradient(180deg, #a0de92 0%, #343739 100%);<br/>
+    --border-img_6329_1238: #7ca774;<br/>
+    --text-img_6329_1238: #9edc90;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1239"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1239</span></button>
+    <div class="container-img_6329_1239" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1239: linear-gradient(180deg, #a0de92 0%, #343739 100%);<br/>
+    --border-img_6329_1239: #8da888;<br/>
+    --text-img_6329_1239: #9edc90;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1240"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1240</span></button>
+    <div class="container-img_6329_1240" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1240: linear-gradient(180deg, #e4e4e4 0%, #494d50 100%);<br/>
+    --border-img_6329_1240: #909192;<br/>
+    --text-img_6329_1240: #e5e5e5;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1241"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1241</span></button>
+    <div class="container-img_6329_1241" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1241: linear-gradient(180deg, #706f6f 0%, #343739 100%);<br/>
+    --border-img_6329_1241: #646565;<br/>
+    --text-img_6329_1241: #6e6e6d;
+  </code>
+</article>
+
+
+<article class="swatch">
+  <div class="preview">
+    <button class="btn-img_6329_1242"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M6 14a4 4 0 0 1 3.4-3.95A5 5 0 0 1 19 11a3 3 0 0 1 0 6H7a3 3 0 0 1-1-5.83Z"/></svg><span>Button img_6329_1242</span></button>
+    <div class="container-img_6329_1242" style="margin-top:.75rem;">Here is some sample text.</div>
+  </div>
+  <code class="tokens">
+    --gradient-img_6329_1242: linear-gradient(180deg, #706f6f 0%, #343739 100%);<br/>
+    --border-img_6329_1242: #696a6b;<br/>
+    --text-img_6329_1242: #838383;
+  </code>
+</article>
+
+</div></section>

--- a/scss/base/_reset.scss
+++ b/scss/base/_reset.scss
@@ -13,7 +13,7 @@ body {
   font-family: $font-family-base;
   font-size: $font-size-base;
   line-height: $line-height-base;
-  background: linear-gradient($gray-700, $gray-600);
+  background-color: #666;
   color: $white;
 }
 

--- a/scss/themes/_dark.scss
+++ b/scss/themes/_dark.scss
@@ -2,7 +2,7 @@
 @use "../tokens/colors" as *;
 
 body.theme-dark {
-  background: linear-gradient($gray-700, $gray-600);
+  background-color: #666;
   color: $white;
 
   a {


### PR DESCRIPTION
## Summary
- Move gray backdrop from swatch containers to page wrapper via body background
- Generate swatch catalog assets without container background override

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2c2dfce208325826a9a2e11e2ebbd