### PR TITLE
Implement book rail view handlers

### DIFF
--- a/js/book-3d-viewer.js
+++ b/js/book-3d-viewer.js
@@ -1,3 +1,5 @@
+import { setActiveTool } from './book-rail.js';
+
 const book = document.getElementById('book');
 const rotate360 = document.getElementById('rotate-360');
 const snapFrontBtn = document.getElementById('snap-front');
@@ -13,6 +15,7 @@ let rotateHintTimeout;
 
 const SNAP_FRONT = 18;
 const SNAP_BACK = 199;
+const ORIENTATION_TOLERANCE = 20;
 const PAUSE_BEFORE_RESUME_MS = 4000;
 const QUICK_TRANSITION = 'transform 0.3s ease';
 const DEFAULT_TRANSITION = 'transform 0.6s ease';
@@ -54,9 +57,23 @@ window.addEventListener('load', () => {
   }
 });
 
+function updateActiveTool(angle) {
+  const normalized = ((angle % 360) + 360) % 360;
+  const frontDiff = Math.abs(normalized - SNAP_FRONT);
+  const backDiff = Math.abs(normalized - SNAP_BACK);
+  if (frontDiff <= ORIENTATION_TOLERANCE) {
+    setActiveTool('front');
+  } else if (backDiff <= ORIENTATION_TOLERANCE) {
+    setActiveTool('back');
+  } else {
+    setActiveTool(null);
+  }
+}
+
 function applyRotation(angle) {
   book.style.transform = `rotateY(${angle}deg)`;
   book.style.setProperty('--light-angle', `${angle}deg`);
+  updateActiveTool(angle);
 }
 
 function startAutoRotate() {

--- a/js/book-rail.js
+++ b/js/book-rail.js
@@ -8,7 +8,8 @@ export function onViewBack() {
   setActiveTool('back');
 }
 export function onToggleSpin360() {
-  setActiveTool('spin360');
+  const btn = rail.querySelector('[data-tool="spin360"]');
+  setActiveTool(btn?.classList.contains('is-active') ? null : 'spin360');
 }
 export function onBuyClick() {}
 

--- a/js/book-rail.js
+++ b/js/book-rail.js
@@ -1,9 +1,15 @@
 const rail = document.querySelector('.book-rail');
 
 export function onZoom() {}
-export function onViewFront() {}
-export function onViewBack() {}
-export function onToggleSpin360() {}
+export function onViewFront() {
+  setActiveTool('front');
+}
+export function onViewBack() {
+  setActiveTool('back');
+}
+export function onToggleSpin360() {
+  setActiveTool('spin360');
+}
 export function onBuyClick() {}
 
 export function setActiveTool(name) {


### PR DESCRIPTION
## Summary
- Call `setActiveTool` within `onViewFront`, `onViewBack`, and `onToggleSpin360` to activate the correct tool
- Ensure front, back, and 360 spin buttons use these handlers so the `is-active` class toggles properly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4282c57548325b7998f38f64eb7c3