### PR TITLE
fix: prevent load freeze in book viewer

### DIFF
--- a/js/book-3d-viewer.js
+++ b/js/book-3d-viewer.js
@@ -153,8 +153,8 @@ if (book) {
     const centerObserver = new IntersectionObserver(entries => {
       const entry = entries[0];
       if (entry.intersectionRatio === 1) {
-        entry.target.scrollIntoView({ behavior: 'smooth', block: 'center' });
         centerObserver.unobserve(entry.target);
+        entry.target.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }
     }, { threshold: 1 });
     centerObserver.observe(bookContainer);


### PR DESCRIPTION
## Summary
- stop center observer before smooth scrolling so book view can load without hanging

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5685955408325aafad41bda7e6548