### PR TITLE
fix: prevent load freeze in book viewer

### DIFF
--- a/js/book-3d-viewer.js
+++ b/js/book-3d-viewer.js
@@ -153,8 +153,10 @@ if (book) {
     const centerObserver = new IntersectionObserver(entries => {
       const entry = entries[0];
       if (entry.intersectionRatio === 1) {
-        entry.target.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        centerObserver.unobserve(entry.target);
+        centerObserver.disconnect();
+        requestAnimationFrame(() => {
+          entry.target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        });
       }
     }, { threshold: 1 });
     centerObserver.observe(bookContainer);


### PR DESCRIPTION
## Summary
- disconnect IntersectionObserver and defer scroll to center book without blocking load

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5685955408325aafad41bda7e6548