### PR TITLE
Use absolute path for shared stylesheet

### DIFF
--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Admin Dashboard</title>
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/styles.css">
+  <link rel="stylesheet" href="/assets/styles.css">
   <link rel="stylesheet" href="https://unpkg.com/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
   <style>
     .auth-gate{position:fixed;inset:0;background:rgba(0,0,0,.85);display:flex;align-items:center;justify-content:center;z-index:2000;}

--- a/components/book-details-tab-demo.html
+++ b/components/book-details-tab-demo.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Book Details Demo</title>
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/styles.css" />
+  <link rel="stylesheet" href="/assets/styles.css" />
 </head>
 <body class="dark">
 

--- a/style-classes.html
+++ b/style-classes.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Style Classes</title>
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/styles.css">
+  <link rel="stylesheet" href="/assets/styles.css">
   <link rel="stylesheet" href="https://unpkg.com/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
 </head>
 <body class="theme-dark">


### PR DESCRIPTION
## Summary
- Switch relative stylesheet links to `/assets/styles.css` in admin dashboard, book details demo, and style classes pages
- Confirm no pages still reference `assets/styles.css`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a57acb94fc8325b775a7872b45163b