### PR TITLE
Ensure Netlify watcher cleanup

### DIFF
--- a/scripts/start_dev.sh
+++ b/scripts/start_dev.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 # start_dev.sh - Watch SCSS and launch Netlify dev server
 
+command -v netlify >/dev/null || { echo "Netlify CLI required"; exit 1; }
+
 npm run watch &
 NETLIFY_PID=$!
+trap 'kill $NETLIFY_PID' EXIT
 
-npx netlify-cli dev
+netlify dev
 
-# kill the watch process on exit
-kill $NETLIFY_PID
+wait


### PR DESCRIPTION
## Summary
- verify Netlify CLI is installed before starting development server
- watch SCSS in background, track PID, and cleanly terminate on exit
- use `netlify dev` and wait for background tasks instead of killing them manually

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a59a832cf0832596451060073310d8