### PR TITLE
docs: add Netlify deployment link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ The official project **README.md** is located inside of the main docs folder her
 =====
 [View Documentation Folder](./docs/)
 
+**Live Site:** [darenprince.netlify.app](https://darenprince.netlify.app)
 
 # 🖥️ Daren Prince Author Platform & Website
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -205,7 +205,7 @@ npm install -g netlify-cli
 netlify dev
 ```
 
-Deployment: Push to `main` auto-deploys via Netlify CI/CD.
+Deployment: The live site runs at [darenprince.netlify.app](https://darenprince.netlify.app); pushing to `main` auto-deploys via Netlify CI/CD.
 
 ### Dashboard on Netlify
 1. Set `SUPABASE_DATABASE_URL` and `SUPABASE_ANON_KEY` env vars in your Netlify project.

--- a/tests/netlify-rules.spec.ts
+++ b/tests/netlify-rules.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+
+const SITE = 'https://darenprince.netlify.app';
+
+function curlStatus(url: string): number {
+  const output = execSync(`curl -s -o /dev/null -w "%{http_code}" ${url}`, {
+    encoding: 'utf8',
+  });
+  return Number(output.trim());
+}
+
+describe('netlify rules', () => {
+  it('serves the homepage', () => {
+    const status = curlStatus(SITE);
+    expect(status).toBe(200);
+  });
+
+  it('returns 404 for missing paths', () => {
+    const status = curlStatus(`${SITE}/__missing-test`);
+    expect(status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- clarify that deployments land at Netlify-hosted site
- surface live site URL in the root README
- add tests verifying Netlify site routing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a59c67d6248325bd673c85fa5084dc