### PR TITLE
fix: restore book control bar

### DIFF
--- a/book.html
+++ b/book.html
@@ -111,7 +111,7 @@
         <div class="book-preview">
           <div class="book-media">
             <!-- Book control toolbar -->
-            <nav class="book-toolbar book-rail" aria-label="Book controls">
+            <nav class="book-toolbar book-rail visible" aria-label="Book controls">
               <span class="book-rail__badge" aria-hidden="true">
                 <svg class="book-rail__badge-icon" viewBox="0 0 24 24" aria-hidden="true">
                   <circle cx="12" cy="12" r="8"/>

--- a/js/book-3d-viewer.js
+++ b/js/book-3d-viewer.js
@@ -238,27 +238,7 @@ addToCartBtn?.addEventListener('click', () => {
   purchaseOptions?.scrollIntoView({ behavior: 'smooth' });
 });
 
-if (bookToolbar && bookViewer && 'IntersectionObserver' in window) {
-  const toolbarObserver = new IntersectionObserver(entries => {
-    const entry = entries[0];
-    if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
-      bookToolbar.classList.add('visible');
-    } else {
-      bookToolbar.classList.remove('visible');
-    }
-  }, { threshold: 0.5 });
-  toolbarObserver.observe(bookViewer);
-} else {
-  bookToolbar?.classList.add('visible');
-}
-
-['pointerenter', 'pointerdown', 'focusin'].forEach(evt => {
-  purchaseOptions?.addEventListener(evt, () => bookToolbar?.classList.remove('visible'));
-});
-
-['pointerenter', 'pointerdown', 'focusin'].forEach(evt => {
-  bookViewer?.addEventListener(evt, () => bookToolbar?.classList.add('visible'));
-});
+bookToolbar?.classList.add('visible');
 
 closeBtn?.addEventListener('click', () => {
   bookContainer?.classList.remove('fullscreen');

--- a/partials/book-toolbar.html
+++ b/partials/book-toolbar.html
@@ -1,5 +1,5 @@
 <!-- 📚 Book Control Toolbar Partial Component -->
-<nav class="book-toolbar book-rail" aria-label="Book controls">
+<nav class="book-toolbar book-rail visible" aria-label="Book controls">
   <span class="book-rail__badge" aria-hidden="true">
     <svg class="book-rail__badge-icon" viewBox="0 0 24 24" aria-hidden="true">
       <circle cx="12" cy="12" r="8"/>


### PR DESCRIPTION
## Summary
- ensure book toolbar markup is visible by default
- remove intersection logic so book control bar shows consistently

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8be36b2a08325a28bdec473bf3947