### PR TITLE
fix: restore book control bar

### DIFF
--- a/book.html
+++ b/book.html
@@ -111,7 +111,7 @@
         <div class="book-preview">
           <div class="book-media">
             <!-- Book control toolbar -->
-            <nav class="book-toolbar book-rail" aria-label="Book controls">
+            <nav class="book-toolbar book-rail visible" aria-label="Book controls">
               <span class="book-rail__badge" aria-hidden="true">
                 <svg class="book-rail__badge-icon" viewBox="0 0 24 24" aria-hidden="true">
                   <circle cx="12" cy="12" r="8"/>

--- a/index.html
+++ b/index.html
@@ -110,22 +110,102 @@
     <!-- 2. Get the Book Section -->
     <section id="book-viewer" class="book-section">
       <div class="book-block container max-width-adaptive-lg">
-        <div class="book-3d-container">
-          <div id="book-3d-viewer" class="book-3d-viewer">
-            <div class="book-loader"></div>
-            <div class="rotate-hint" aria-hidden="true">
-              <img src="assets/images/360rotate.png" alt="" />
-            </div>
-            <div class="scene">
-              <div class="book" id="book">
-                <div class="face front"></div>
-                <div class="face back"></div>
-                <div class="face spine"></div>
-                <div class="face pages"></div>
-                <div class="face top"></div>
-                <div class="face bottom"></div>
+        <div class="book-preview">
+          <div class="book-media">
+            <!-- Book control toolbar -->
+            <nav class="book-toolbar book-rail visible" aria-label="Book controls">
+              <span class="book-rail__badge" aria-hidden="true">
+                <svg class="book-rail__badge-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <circle cx="12" cy="12" r="8" />
+                  <line x1="16" y1="16" x2="21" y2="21" />
+                </svg>
+              </span>
+              <ul class="book-rail__list">
+                <li class="book-rail__item">
+                  <button id="zoom-cover" class="book-rail__btn" data-tool="zoom" aria-label="Zoom" title="Zoom">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                      <circle cx="11" cy="11" r="8" />
+                      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                      <line x1="11" y1="8" x2="11" y2="14" />
+                      <line x1="8" y1="11" x2="14" y2="11" />
+                    </svg>
+                    <span class="book-rail__label">Zoom</span>
+                  </button>
+                </li>
+                <li class="book-rail__item">
+                  <button id="snap-front" class="book-rail__btn" data-tool="front" aria-label="Front" title="Front">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                      <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+                      <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+                    </svg>
+                    <span class="book-rail__label">Front</span>
+                  </button>
+                </li>
+                <li class="book-rail__item">
+                  <button id="snap-back" class="book-rail__btn" data-tool="back" aria-label="Back" title="Back">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                      <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+                      <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+                    </svg>
+                    <span class="book-rail__label">Back</span>
+                  </button>
+                </li>
+                <li class="book-rail__item">
+                  <button id="rotate-360" class="book-rail__btn" data-tool="spin360" aria-label="Rotate 360 degrees" title="Rotate 360 degrees">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                      <polyline points="23 4 23 10 17 10" />
+                      <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+                    </svg>
+                    <span class="book-rail__label">360°</span>
+                  </button>
+                </li>
+                <li class="book-rail__item">
+                  <button id="add-to-cart" class="book-rail__btn" data-tool="buy" aria-label="Buy" title="Buy">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                      <circle cx="9" cy="21" r="1" />
+                      <circle cx="20" cy="21" r="1" />
+                      <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6" />
+                    </svg>
+                    <span class="book-rail__label">Buy</span>
+                  </button>
+                </li>
+              </ul>
+              <button class="book-rail__toggle" data-action="toggle" aria-label="Toggle labels" title="Toggle labels">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <polyline points="11 17 6 12 11 7" />
+                  <polyline points="18 17 13 12 18 7" />
+                </svg>
+              </button>
+            </nav>
+            <div class="book-3d-container" style="--book-bg: url('assets/images/3d-book-bg-1.png');">
+              <div id="book-3d-viewer" class="book-3d-viewer">
+                <div class="book-loader"></div>
+                <div class="rotate-hint" aria-hidden="true">
+                  <img src="assets/images/360rotate.png" alt="" />
+                </div>
+                <div class="scene">
+                  <div class="book" id="book">
+                    <div class="face front"></div>
+                    <div class="face back"></div>
+                    <div class="face spine"></div>
+                    <div class="face pages"></div>
+                    <div class="face top"></div>
+                    <div class="face bottom"></div>
+                  </div>
+                  <div class="shadow"></div>
+                </div>
               </div>
-              <div class="shadow"></div>
+              <button class="book-3d-close" id="book-close" aria-label="Close expanded view" hidden>&times;</button>
+            </div>
+            <div class="cover-zoom-modal" id="cover-zoom" hidden>
+              <div class="cover-zoom-content">
+                <button class="close-btn" id="close-cover-zoom"><i class="ti ti-x"></i></button>
+                <img id="zoom-full" src="assets/images/book-front.jpg" alt="Zoomed cover" />
+                <div class="thumbnails">
+                  <img src="assets/images/book-front.jpg" data-full="assets/images/book-front.jpg" class="active" alt="Front cover" />
+                  <img src="assets/images/book-back.jpg" data-full="assets/images/book-back.jpg" alt="Back cover" />
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/js/book-3d-viewer.js
+++ b/js/book-3d-viewer.js
@@ -238,27 +238,7 @@ addToCartBtn?.addEventListener('click', () => {
   purchaseOptions?.scrollIntoView({ behavior: 'smooth' });
 });
 
-if (bookToolbar && bookViewer && 'IntersectionObserver' in window) {
-  const toolbarObserver = new IntersectionObserver(entries => {
-    const entry = entries[0];
-    if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
-      bookToolbar.classList.add('visible');
-    } else {
-      bookToolbar.classList.remove('visible');
-    }
-  }, { threshold: 0.5 });
-  toolbarObserver.observe(bookViewer);
-} else {
-  bookToolbar?.classList.add('visible');
-}
-
-['pointerenter', 'pointerdown', 'focusin'].forEach(evt => {
-  purchaseOptions?.addEventListener(evt, () => bookToolbar?.classList.remove('visible'));
-});
-
-['pointerenter', 'pointerdown', 'focusin'].forEach(evt => {
-  bookViewer?.addEventListener(evt, () => bookToolbar?.classList.add('visible'));
-});
+bookToolbar?.classList.add('visible');
 
 closeBtn?.addEventListener('click', () => {
   bookContainer?.classList.remove('fullscreen');

--- a/partials/book-toolbar.html
+++ b/partials/book-toolbar.html
@@ -1,5 +1,5 @@
 <!-- 📚 Book Control Toolbar Partial Component -->
-<nav class="book-toolbar book-rail" aria-label="Book controls">
+<nav class="book-toolbar book-rail visible" aria-label="Book controls">
   <span class="book-rail__badge" aria-hidden="true">
     <svg class="book-rail__badge-icon" viewBox="0 0 24 24" aria-hidden="true">
       <circle cx="12" cy="12" r="8"/>


### PR DESCRIPTION
## Summary
- ensure book toolbar markup is visible by default
- remove intersection logic so book control bar shows consistently
- include book toolbar on homepage for consistent controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8be36b2a08325a28bdec473bf3947