### PR TITLE
Increase 3D book container padding

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2140,7 +2140,7 @@ input:checked + .toggle-slider::before {
   align-items: center;
   justify-content: center;
   width: 100%;
-  padding-block: 3rem;
+  padding-block: calc(3rem + 50px);
   padding-inline: 1rem;
   margin-inline: auto;
   background-image: var(--book-bg);

--- a/scss/components/_book-3d.scss
+++ b/scss/components/_book-3d.scss
@@ -8,7 +8,7 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  padding-block: $spacing-xl;
+  padding-block: calc(#{$spacing-xl} + 50px);
   padding-inline: $spacing-md;
   margin-inline: auto;
   background-image: var(--book-bg);


### PR DESCRIPTION
## Summary
- expand top and bottom padding inside `.book-3d-container` to give the 3D book more vertical space
- compile CSS assets to reflect the new padding

## Testing
- `npx sass scss/styles.scss assets/styles.css`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adfb9a460c8325b6a975b9b25ab64f