### PR TITLE
Reduce book preview border opacity

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3098,7 +3098,7 @@ input:checked + .toggle-slider::before {
 }
 
 .book-preview {
-  border: 1px solid var(--gray-100);
+  border: 1px solid color-mix(in srgb, var(--gray-100) 10%, transparent);
   border-radius: 0.6875rem;
   background: url("../assets/images/IMG_6246.jpeg") center/cover no-repeat;
   padding: 1rem;

--- a/scss/components/_book-details-wrapper.scss
+++ b/scss/components/_book-details-wrapper.scss
@@ -11,7 +11,7 @@
 }
 
 .book-preview {
-  border: 1px solid $light-gray;
+  border: 1px solid color-mix(in srgb, $light-gray 10%, transparent);
   border-radius: $border-radius;
   background: url('../assets/images/IMG_6246.jpeg') center/cover no-repeat;
   padding: $spacing-md;


### PR DESCRIPTION
## Summary
- soften book preview container stroke using 10% transparent gray
- regenerate compiled CSS

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af735d51ec8325bc3f5100380db2ab