### PR TITLE
Add sitemap page for primary site links

### DIFF
--- a/sitemap.html
+++ b/sitemap.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Site Map | Daren Prince</title>
+  <link rel="stylesheet" href="/assets/styles.css" />
+</head>
+<body class="theme-dark">
+  <main class="container max-width-adaptive-lg padding-y-lg">
+    <h1>Site Map</h1>
+    <nav aria-label="Site Map">
+      <ul class="sitemap-list">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="book.html">Book</a></li>
+        <li><a href="press.html">Press</a></li>
+        <li><a href="contact.html">Contact</a></li>
+        <li><a href="dashboard.html">Dashboard</a>
+          <ul>
+            <li><a href="admin-dashboard.html">Admin Dashboard</a></li>
+          </ul>
+        </li>
+        <li>Account
+          <ul>
+            <li><a href="login.html">Login</a></li>
+            <li><a href="reset-password.html">Reset Password</a></li>
+            <li><a href="verify-email.html">Verify Email</a></li>
+          </ul>
+        </li>
+        <li>Resources
+          <ul>
+            <li><a href="components.html">Components</a></li>
+            <li><a href="style-classes.html">Style Classes</a></li>
+            <li><a href="themes.html">Themes</a></li>
+            <li><a href="image-index.html">Image Index</a></li>
+            <li><a href="pages/search.html">Search</a></li>
+          </ul>
+        </li>
+        <li>Demos
+          <ul>
+            <li><a href="All-heroes-demos.html">All Heroes Demos</a></li>
+            <li><a href="brandon.html">Brandon</a></li>
+            <li><a href="shhh.html">Secret</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `sitemap.html` with dark-theme layout showing primary site links and nested sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1db4973c883259c395fe3e9fc85b6