### PR TITLE
Add configurable robots directives for public launch

### DIFF
--- a/All-heroes-demos.html
+++ b/All-heroes-demos.html
@@ -86,6 +86,6 @@
       }
     });
   </script>
-
+  <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>

--- a/assets/image-manifest.json
+++ b/assets/image-manifest.json
@@ -62,7 +62,7 @@
   "assets/images/heroposter2.png",
   "assets/images/levelup.png",
   "assets/images/levelup2.png",
-  "assets/images/og-image.jpg",
+  "assets/images/Og-daren-prince.PNG",
   "assets/images/paperside.jpg",
   "assets/images/placeholders/book-3d.jpg",
   "assets/images/placeholders/video-thumbnail.jpg",

--- a/book.html
+++ b/book.html
@@ -7,13 +7,13 @@
     <meta name="description" content="No gimmicks. No games. Just results. Game On! is the bold, psychology-backed guide to flirting, confidence, and connection. Available in print, Kindle, & audiobook.">
     <meta property="og:title" content="Game On! by Daren Prince">
     <meta property="og:description" content="Discover the psychology-backed men's playbook for real attraction and conversation mastery.">
-    <meta property="og:image" content="https://darenprince.com/assets/images/og-image.jpg">
+    <meta property="og:image" content="https://darenprince.com/assets/images/Og-daren-prince.PNG">
     <meta property="og:type" content="book">
     <meta property="og:url" content="https://darenprince.com/books/game-on">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Game On! by Daren Prince">
     <meta name="twitter:description" content="Learn how to spark real connection, master confidence, and win her heart with no gimmicks.">
-    <meta name="twitter:image" content="https://darenprince.com/assets/images/og-image.jpg">
+    <meta name="twitter:image" content="https://darenprince.com/assets/images/Og-daren-prince.PNG">
     <link rel="canonical" href="https://darenprince.com/books/game-on">
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/styles.css">
@@ -27,7 +27,7 @@
       "@type": "Person",
       "name": "Daren Prince"
     },
-      "image": "https://darenprince.com/assets/images/og-image.jpg",
+      "image": "https://darenprince.com/assets/images/Og-daren-prince.PNG",
     "bookFormat": "https://schema.org/EBook",
     "isbn": "9798303844407",
     "offers": {

--- a/brandon.html
+++ b/brandon.html
@@ -18,5 +18,6 @@
     <p class="quote" style="top:85%;left:40%;">"Turn setbacks into fuel"</p>
   </div>
   <a href="/member/index.html" class="login-btn">Fuck your shit up and log in now</a>
+  <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -7,13 +7,13 @@
     <meta name="description" content="Want to connect with Daren Prince? Submit interview requests, speaking inquiries, or direct messages here. Let’s talk about it.">
     <meta property="og:title" content="Contact Daren Prince">
     <meta property="og:description" content="Reach out to Daren Prince for media, coaching, or collab opportunities. He reads every message.">
-    <meta property="og:image" content="https://darenprince.com/assets/images/og-image.jpg">
+    <meta property="og:image" content="https://darenprince.com/assets/images/Og-daren-prince.PNG">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://darenprince.com/contact">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Contact Daren Prince">
     <meta name="twitter:description" content="Have a question, request, or idea? Send a message directly to Daren Prince.">
-    <meta name="twitter:image" content="https://darenprince.com/assets/images/og-image.jpg">
+    <meta name="twitter:image" content="https://darenprince.com/assets/images/Og-daren-prince.PNG">
     <link rel="canonical" href="https://darenprince.com/contact">
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/styles.css">

--- a/docs/indexing-strategy.md
+++ b/docs/indexing-strategy.md
@@ -1,0 +1,22 @@
+# Indexing Strategy Playbook
+
+Launching the public site means every crawl should reinforce the brand story while keeping prototypes and auth flows private. The following map balances discoverability with security.
+
+## Pages to Index
+- **Home (`/`, `/index.html`)** — Primary authority signal and conversion gateway.
+- **Books (`/book`)** — Core offer that should rank for branded and product-intent queries.
+- **Press (`/press`)** — Media coverage that boosts expertise and trust.
+- **Contact (`/contact`)** — Lead capture surface for speaking, coaching, and partnerships.
+- **Image Index (`/image-index`)** — Asset library that legitimizes brand creatives and helps journalists.
+- **Sitemap (`/sitemap`)** — Crawl aid that gives bots a clean view of the architecture.
+- **Search (`/pages/search`)** — Utility page that supports user navigation and long-tail discovery.
+
+## Pages to Keep Out of Index
+- **Authentication surfaces (`/login`, `/reset-password`, `/verify-email`)** — Avoid thin-content penalties and brute-force attention.
+- **Member dashboards (`/dashboard`, `/admin-dashboard`, `/member`)** — Protect gated experiences and internal tooling.
+- **Design system & experiments (`/components`, `/style-classes`, `/themes`, `/All-heroes-demos`, `/brandon`, `/shhh`, `/home`)** — Internal sandboxes that should stay invisible to preserve brand polish.
+
+## Implementation Details
+- `js/seo-indexing.js` exports `applyIndexingMeta()` and `getIndexingRule()` which normalize URLs, look up the directive, and enforce `<meta name="robots">` content on every load.
+- `js/main.js` imports the module so all primary marketing pages automatically receive the correct directive; standalone pages include the module directly.
+- Default behavior is **index, follow** so new marketing content is crawlable unless explicitly flagged otherwise. Update the configuration arrays in `js/seo-indexing.js` when new sections launch.

--- a/image-index.html
+++ b/image-index.html
@@ -7,13 +7,13 @@
   <meta name="description" content="Browse a searchable catalog of images from Daren Prince's official site. View and copy asset links quickly.">
   <meta property="og:title" content="Image Index | Daren Prince">
   <meta property="og:description" content="Search and preview images from Daren Prince's official site in one place.">
-  <meta property="og:image" content="https://darenprince.com/assets/images/og-image.jpg">
+  <meta property="og:image" content="https://darenprince.com/assets/images/Og-daren-prince.PNG">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://darenprince.com/image-index">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Image Index | Daren Prince">
   <meta name="twitter:description" content="Quickly browse and copy image assets from Daren Prince's site.">
-  <meta name="twitter:image" content="https://darenprince.com/assets/images/og-image.jpg">
+  <meta name="twitter:image" content="https://darenprince.com/assets/images/Og-daren-prince.PNG">
   <link rel="canonical" href="https://darenprince.com/image-index">
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/styles.css">

--- a/index.html
+++ b/index.html
@@ -7,13 +7,13 @@
     <meta name="description" content="Official site of Daren Prince, author and communication coach. Explore real tools for confidence, relationships, and emotional healing through his bestselling books.">
     <meta property="og:title" content="Daren Prince | Author of Game On! & Unshakeable">
     <meta property="og:description" content="Official author site of Daren Prince. Explore books on connection, healing, and confidence.">
-    <meta property="og:image" content="https://darenprince.com/assets/images/og-image.jpg">
+    <meta property="og:image" content="https://darenprince.com/assets/images/Og-daren-prince.PNG">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://darenprince.com/">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Daren Prince | Author of Game On! & Unshakeable">
     <meta name="twitter:description" content="Explore Daren Prince’s bestselling books and breakthrough tools for confidence and connection.">
-    <meta name="twitter:image" content="https://darenprince.com/assets/images/og-image.jpg">
+    <meta name="twitter:image" content="https://darenprince.com/assets/images/Og-daren-prince.PNG">
     <link rel="canonical" href="https://darenprince.com/">
     <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/styles.css">
@@ -24,7 +24,7 @@
     "@type": "Person",
     "name": "Daren Prince",
       "url": "https://darenprince.com",
-      "image": "https://darenprince.com/assets/images/og-image.jpg",
+      "image": "https://darenprince.com/assets/images/Og-daren-prince.PNG",
     "sameAs": [
       "https://www.amazon.com/author/darenprince",
       "https://www.goodreads.com/author/show/53671567.Daren_Prince"

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,12 @@
+import { applyIndexingMeta } from './seo-indexing.js';
+
 document.addEventListener('DOMContentLoaded', async function () {
+  const indexingRule = applyIndexingMeta();
+  if (indexingRule) {
+    console.debug(
+      `[SEO] Robots directive set to "${indexingRule.directive}" — ${indexingRule.reason}`
+    );
+  }
   const menuToggle = document.querySelector('.js-menu-toggle');
   const megaMenu = document.querySelector('.js-mega-menu');
   const menuOverlay = document.querySelector('.js-menu-overlay');

--- a/js/seo-indexing.js
+++ b/js/seo-indexing.js
@@ -1,0 +1,189 @@
+const INDEXABLE_PAGES = [
+  {
+    label: 'Home',
+    reason: 'Primary marketing hub and top-level brand destination.',
+    paths: ['/', '/index.html']
+  },
+  {
+    label: 'Books',
+    reason: 'Core product landing page that should appear in search.',
+    paths: ['/book', '/book.html']
+  },
+  {
+    label: 'Press',
+    reason: 'Media coverage and assets that support authority signals.',
+    paths: ['/press', '/press.html']
+  },
+  {
+    label: 'Contact',
+    reason: 'Lead generation touchpoint for speaking and coaching requests.',
+    paths: ['/contact', '/contact.html']
+  },
+  {
+    label: 'Image Index',
+    reason: 'Reference hub for approved creative assets.',
+    paths: ['/image-index', '/image-index.html']
+  },
+  {
+    label: 'Sitemap',
+    reason: 'Structured crawl map for search engines.',
+    paths: ['/sitemap', '/sitemap.html']
+  },
+  {
+    label: 'Search Results',
+    reason: 'Search utility that supports user navigation.',
+    paths: ['/pages/search', '/pages/search.html']
+  }
+];
+
+const NON_INDEXABLE_PAGES = [
+  {
+    label: 'Login',
+    reason: 'Authentication surface that should stay private and avoid thin-content penalties.',
+    paths: ['/login', '/login.html']
+  },
+  {
+    label: 'Reset Password',
+    reason: 'One-time credential workflow with no marketing value.',
+    paths: ['/reset-password', '/reset-password.html']
+  },
+  {
+    label: 'Verify Email',
+    reason: 'Verification callback page only used during onboarding.',
+    paths: ['/verify-email', '/verify-email.html']
+  },
+  {
+    label: 'Dashboard',
+    reason: 'Authenticated experience for members only.',
+    paths: ['/dashboard', '/dashboard.html', '/admin-dashboard', '/admin-dashboard.html', '/member', '/member/index.html']
+  },
+  {
+    label: 'Internal Design References',
+    reason: 'Design system and prototype sandboxes not meant for public discovery.',
+    paths: [
+      '/components',
+      '/components.html',
+      '/style-classes',
+      '/style-classes.html',
+      '/themes',
+      '/themes.html',
+      '/All-heroes-demos',
+      '/All-heroes-demos.html',
+      '/brandon',
+      '/brandon.html',
+      '/shhh',
+      '/shhh.html',
+      '/home',
+      '/home.html'
+    ]
+  }
+];
+
+const INDEX_DIRECTIVE = 'index, follow';
+const NOINDEX_DIRECTIVE = 'noindex, nofollow';
+
+function flattenConfig(config, directive) {
+  return config.reduce((map, entry) => {
+    entry.paths.forEach((path) => {
+      map.set(path, { ...entry, directive });
+    });
+    return map;
+  }, new Map());
+}
+
+const indexableMap = flattenConfig(INDEXABLE_PAGES, INDEX_DIRECTIVE);
+const nonIndexableMap = flattenConfig(NON_INDEXABLE_PAGES, NOINDEX_DIRECTIVE);
+const combinedRules = new Map([...indexableMap, ...nonIndexableMap]);
+
+function normalizePath(pathname) {
+  if (!pathname) return '/';
+  let path = pathname;
+  try {
+    if (typeof window !== 'undefined') {
+      path = new URL(pathname, window.location.origin).pathname;
+    }
+  } catch (error) {
+    console.warn('[SEO] Unable to normalize pathname via URL constructor:', error);
+  }
+
+  path = path.replace(/\\/g, '/');
+  if (!path.startsWith('/')) path = `/${path}`;
+
+  const matchCandidates = new Set([path]);
+
+  if (path.endsWith('/')) {
+    matchCandidates.add(path.slice(0, -1) || '/');
+  }
+
+  if (path.endsWith('/index.html')) {
+    const stripped = path.slice(0, -'/index.html'.length) || '/';
+    matchCandidates.add(stripped);
+  }
+
+  const segments = path.split('/').filter(Boolean);
+  if (segments.length > 1) {
+    matchCandidates.add(`/${segments.slice(-2).join('/')}`);
+  }
+  if (segments.length) {
+    matchCandidates.add(`/${segments[segments.length - 1]}`);
+  }
+
+  for (const candidate of matchCandidates) {
+    if (combinedRules.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  return path;
+}
+
+function getIndexingRule(pathname = (typeof window !== 'undefined' ? window.location.pathname : '/')) {
+  const normalized = normalizePath(pathname);
+  const rule = combinedRules.get(normalized);
+  if (rule) {
+    return { ...rule, path: normalized };
+  }
+  return {
+    label: 'Default',
+    reason: 'No explicit directive configured — defaulting to marketing-friendly indexing.',
+    directive: INDEX_DIRECTIVE,
+    path: normalized
+  };
+}
+
+function ensureRobotsMeta(doc = typeof document !== 'undefined' ? document : undefined) {
+  if (!doc || !doc.head) return undefined;
+  let meta = doc.querySelector('meta[name="robots"]');
+  if (!meta) {
+    meta = doc.createElement('meta');
+    meta.setAttribute('name', 'robots');
+    doc.head.appendChild(meta);
+  }
+  return meta;
+}
+
+function applyIndexingMeta(doc = typeof document !== 'undefined' ? document : undefined) {
+  if (!doc) return;
+  const rule = getIndexingRule(doc.location ? doc.location.pathname : (typeof window !== 'undefined' ? window.location.pathname : '/'));
+  const meta = ensureRobotsMeta(doc);
+  if (meta) {
+    meta.setAttribute('content', rule.directive);
+  }
+  return rule;
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => applyIndexingMeta());
+  } else {
+    applyIndexingMeta();
+  }
+}
+
+export {
+  INDEXABLE_PAGES,
+  NON_INDEXABLE_PAGES,
+  applyIndexingMeta,
+  getIndexingRule,
+  normalizePath
+};

--- a/member/index.html
+++ b/member/index.html
@@ -22,5 +22,6 @@
       <button type="submit" class="btn">Sign In</button>
     </form>
   </main>
+  <script type="module" src="../js/seo-indexing.js"></script>
 </body>
 </html>

--- a/pages/search.html
+++ b/pages/search.html
@@ -53,6 +53,7 @@
       <p>&copy; 2024 Daren Prince</p>
     </div>
   </footer>
+  <script type="module" src="../js/seo-indexing.js"></script>
   <script type="module" src="/src/js/search.js"></script>
   <script type="module" src="/src/js/search-results.js"></script>
 </body>

--- a/press.html
+++ b/press.html
@@ -7,13 +7,13 @@
     <meta name="description" content="Official press kit for Daren Prince. Download high-res headshots, author bio, and request interviews or media appearances.">
     <meta property="og:title" content="Press & Media | Daren Prince">
     <meta property="og:description" content="Get press materials, headshots, and media inquiries for Daren Prince—author of Game On! and Unshakeable.">
-    <meta property="og:image" content="https://darenprince.com/assets/images/og-image.jpg">
+    <meta property="og:image" content="https://darenprince.com/assets/images/Og-daren-prince.PNG">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://darenprince.com/media">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Daren Prince | Press Kit & Media Info">
     <meta name="twitter:description" content="Download official press kit, author bio, and media assets for Daren Prince. Book him for podcasts, interviews, or speaking events.">
-    <meta name="twitter:image" content="https://darenprince.com/assets/images/og-image.jpg">
+    <meta name="twitter:image" content="https://darenprince.com/assets/images/Og-daren-prince.PNG">
     <link rel="canonical" href="https://darenprince.com/media">
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/styles.css">
@@ -24,7 +24,7 @@
     "@type": "Person",
     "name": "Daren Prince",
       "url": "https://darenprince.com",
-      "image": "https://darenprince.com/assets/images/og-image.jpg",
+      "image": "https://darenprince.com/assets/images/Og-daren-prince.PNG",
     "sameAs": [
       "https://www.amazon.com/author/darenprince",
       "https://www.goodreads.com/author/show/53671567.Daren_Prince"

--- a/reset-password.html
+++ b/reset-password.html
@@ -73,5 +73,6 @@
       messageEl.textContent = error ? error.message : 'Password updated. You may now sign in.';
     });
   </script>
+  <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>

--- a/shhh.html
+++ b/shhh.html
@@ -84,5 +84,6 @@ document.addEventListener('keydown', e => {
   }
 });
 
+  <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>

--- a/sitemap.html
+++ b/sitemap.html
@@ -46,5 +46,6 @@
       </ul>
     </nav>
   </main>
+  <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>

--- a/themes.html
+++ b/themes.html
@@ -343,5 +343,7 @@ body{
 <!-- footer pads like the mock -->
 <div class="block" aria-hidden="true"></div>
 <div class="block light" aria-hidden="true"></div>
+
+<script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>

--- a/verify-email.html
+++ b/verify-email.html
@@ -39,5 +39,6 @@
         : 'Check your email to verify your account.';
     }
   </script>
+  <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a reusable `seo-indexing` module that normalizes paths and enforces the correct robots directive for each route
- wire the module into existing UI bootstrap code and standalone pages so every surface sets the intended indexing policy
- document the go-live indexing plan with clear guidance on which sections should be indexed versus hidden

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca26e96f3483258c015d1843045042