### PR TITLE
Add CI check for apple asset materialization

### DIFF
--- a/.github/workflows/apple-assets.yml
+++ b/.github/workflows/apple-assets.yml
@@ -1,0 +1,25 @@
+name: Verify Apple Assets
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  apple-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Verify Apple icon payload
+        run: npm run check:apple-assets

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "npm run build:search && node scripts/generate-env.js && npm run generate:images && sass scss/styles.scss assets/styles.css",
     "watch": "node scripts/generate-env.js && npm run generate:images && sass scss/styles.scss assets/styles.css --watch",
     "test": "vitest run",
+    "check:apple-assets": "node scripts/check-apple-assets.mjs",
     "prepare": "command -v sass >/dev/null 2>&1 || npm install --no-save sass",
     "postinstall": "node scripts/materialize-apple-assets.mjs",
     "deploy": "netlify deploy --prod --site darenprince.netlify.app"

--- a/scripts/check-apple-assets.mjs
+++ b/scripts/check-apple-assets.mjs
@@ -1,0 +1,115 @@
+import { Buffer } from 'buffer';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { spawn } from 'child_process';
+import crypto from 'crypto';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const root = path.resolve(__dirname, '..');
+const iconsDir = path.join(root, 'assets', 'icons');
+const payloadPath = path.join(iconsDir, 'apple-assets.json');
+
+async function readPayload() {
+  const raw = await fs.readFile(payloadPath, 'utf8');
+  if (!raw.trim()) {
+    throw new Error('apple-assets.json is empty.');
+  }
+
+  const payload = JSON.parse(raw);
+  const entries = Object.entries(payload);
+  if (!entries.length) {
+    throw new Error('apple-assets.json contains no assets.');
+  }
+
+  return entries;
+}
+
+async function runMaterializeScript() {
+  await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [path.join(root, 'scripts', 'materialize-apple-assets.mjs')], {
+      stdio: 'inherit',
+    });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`materialize-apple-assets.mjs exited with status ${code}`));
+      }
+    });
+  });
+}
+
+function sha256(buffer) {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+async function ensureAssets(entries) {
+  const pngSignature = Buffer.from('89504e470d0a1a0a', 'hex');
+  const failures = [];
+
+  for (const [name, base64] of entries) {
+    const expectedPath = path.join(iconsDir, name);
+    const expectedBuffer = Buffer.from(base64, 'base64');
+
+    if (expectedBuffer.length === 0) {
+      failures.push(`Payload for ${name} is empty.`);
+      continue;
+    }
+
+    try {
+      const fileBuffer = await fs.readFile(expectedPath);
+      if (!fileBuffer.subarray(0, pngSignature.length).equals(pngSignature)) {
+        failures.push(`${name} is not a valid PNG.`);
+        continue;
+      }
+
+      if (!fileBuffer.equals(expectedBuffer)) {
+        failures.push(
+          `${name} does not match payload checksum (expected ${sha256(expectedBuffer)}, got ${sha256(fileBuffer)}).`,
+        );
+      }
+    } catch (error) {
+      failures.push(`Missing icon ${name}: ${(error instanceof Error && error.message) || error}`);
+    }
+  }
+
+  if (failures.length) {
+    const message = failures.map((line) => ` - ${line}`).join('\n');
+    throw new Error(`Apple asset verification failed:\n${message}`);
+  }
+}
+
+async function removeExistingOutputs(entries) {
+  await Promise.all(
+    entries.map(async ([name]) => {
+      try {
+        await fs.rm(path.join(iconsDir, name), { force: true });
+      } catch (error) {
+        // Best effort cleanup; ignore individual failures so the check can surface
+        // more meaningful errors when verifying output later.
+        console.warn(`Warning: unable to remove ${name}:`, error);
+      }
+    }),
+  );
+}
+
+async function main() {
+  const entries = await readPayload();
+  await fs.mkdir(iconsDir, { recursive: true });
+  await removeExistingOutputs(entries);
+  await runMaterializeScript();
+  await ensureAssets(entries);
+  console.log(`[apple-assets] Verified ${entries.length} Apple icon files.`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/scripts/materialize-apple-assets.mjs
+++ b/scripts/materialize-apple-assets.mjs
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';


### PR DESCRIPTION
## Summary
- add a verification script that re-runs materialize-apple-assets.mjs and asserts every payload PNG is regenerated correctly
- expose the verifier through an npm script and GitHub Actions workflow so CI fails fast when assets are missing or corrupted
- update the materialization script to import Buffer explicitly for compatibility across environments

## Testing
- npm run check:apple-assets

------
https://chatgpt.com/codex/tasks/task_e_68ca42bc9270832587248824d3dbb1c7