### PR TITLE
Use nullish coalescing for Supabase config fallbacks

### DIFF
--- a/supabase/client.js
+++ b/supabase/client.js
@@ -6,16 +6,18 @@ let key = '';
 const isBrowser = typeof window !== 'undefined';
 
 if (typeof Deno !== 'undefined' && typeof Deno.env !== 'undefined') {
-  const read = (name) => Deno.env.get(name) ?? '';
+  const read = (name) => Deno.env.get(name);
   url =
-    read('SUPABASE_DATABASE_URL') ||
-    read('NEXT_PUBLIC_SUPABASE_URL') ||
-    read('NEXT_PUBLIC_SUPABASE_DATABASE_URL');
+    read('SUPABASE_DATABASE_URL') ??
+    read('NEXT_PUBLIC_SUPABASE_URL') ??
+    read('NEXT_PUBLIC_SUPABASE_DATABASE_URL') ??
+    '';
   key =
-    read('SUPABASE_SERVICE_ROLE_KEY') ||
-    read('SUPABASE_ANON_KEY') ||
-    read('SUPABASE_PUBLIC_ANON_KEY') ||
-    read('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+    read('SUPABASE_SERVICE_ROLE_KEY') ??
+    read('SUPABASE_ANON_KEY') ??
+    read('SUPABASE_PUBLIC_ANON_KEY') ??
+    read('NEXT_PUBLIC_SUPABASE_ANON_KEY') ??
+    '';
 } else if (!isBrowser && typeof process !== 'undefined' && typeof process.env !== 'undefined') {
   const env = process.env;
   url =

--- a/supabase/client.ts
+++ b/supabase/client.ts
@@ -6,16 +6,18 @@ let key = '';
 const isBrowser = typeof window !== 'undefined';
 
 if (typeof Deno !== 'undefined' && typeof Deno.env !== 'undefined') {
-  const read = (name: string) => Deno.env.get(name) ?? '';
+  const read = (name: string) => Deno.env.get(name);
   url =
-    read('SUPABASE_DATABASE_URL') ||
-    read('NEXT_PUBLIC_SUPABASE_URL') ||
-    read('NEXT_PUBLIC_SUPABASE_DATABASE_URL');
+    read('SUPABASE_DATABASE_URL') ??
+    read('NEXT_PUBLIC_SUPABASE_URL') ??
+    read('NEXT_PUBLIC_SUPABASE_DATABASE_URL') ??
+    '';
   key =
-    read('SUPABASE_SERVICE_ROLE_KEY') ||
-    read('SUPABASE_ANON_KEY') ||
-    read('SUPABASE_PUBLIC_ANON_KEY') ||
-    read('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+    read('SUPABASE_SERVICE_ROLE_KEY') ??
+    read('SUPABASE_ANON_KEY') ??
+    read('SUPABASE_PUBLIC_ANON_KEY') ??
+    read('NEXT_PUBLIC_SUPABASE_ANON_KEY') ??
+    '';
 } else if (!isBrowser && typeof process !== 'undefined' && typeof process.env !== 'undefined') {
   const env = process.env;
   url =

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -2,13 +2,15 @@ import { describe, it, expect } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
 
 const url =
-  process.env.SUPABASE_DATABASE_URL ||
-  process.env.NEXT_PUBLIC_SUPABASE_URL ||
-  process.env.NEXT_PUBLIC_SUPABASE_DATABASE_URL;
+  process.env.SUPABASE_DATABASE_URL ??
+  process.env.NEXT_PUBLIC_SUPABASE_URL ??
+  process.env.NEXT_PUBLIC_SUPABASE_DATABASE_URL ??
+  '';
 const anonKey =
-  process.env.SUPABASE_ANON_KEY ||
-  process.env.SUPABASE_PUBLIC_ANON_KEY ||
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  process.env.SUPABASE_ANON_KEY ??
+  process.env.SUPABASE_PUBLIC_ANON_KEY ??
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+  '';
 
 if (!url || !anonKey) {
   // Skip tests when Supabase credentials are not provided

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -2,13 +2,15 @@ import { describe, it, expect } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
 
 const url =
-  process.env.SUPABASE_DATABASE_URL ||
-  process.env.NEXT_PUBLIC_SUPABASE_URL ||
-  process.env.NEXT_PUBLIC_SUPABASE_DATABASE_URL;
+  process.env.SUPABASE_DATABASE_URL ??
+  process.env.NEXT_PUBLIC_SUPABASE_URL ??
+  process.env.NEXT_PUBLIC_SUPABASE_DATABASE_URL ??
+  '';
 const anonKey =
-  process.env.SUPABASE_ANON_KEY ||
-  process.env.SUPABASE_PUBLIC_ANON_KEY ||
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  process.env.SUPABASE_ANON_KEY ??
+  process.env.SUPABASE_PUBLIC_ANON_KEY ??
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+  '';
 
 if (!url || !anonKey) {
   // Skip tests when Supabase credentials are not provided


### PR DESCRIPTION
## Summary
- align the Deno Supabase client fallback logic with the Node path by using nullish coalescing instead of logical OR
- mirror the fallback updates in the TypeScript client and related Vitest helpers so empty strings no longer short-circuit configuration resolution

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca89a93fa08325af483781f50f10de