### PR TITLE
Make Supabase debug console opt-in and persisted

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -3,8 +3,9 @@ import {
   passwordsValid,
   resetPasswordStrength,
 } from './password-strength.js';
-import { getSupabase } from './supabase-helper.js';
+import { getSupabase, SUPABASE_SETUP_MESSAGE } from './supabase-helper.js';
 import { getUserRole, isElevatedRole } from './user-role.js';
+import { logSupabaseError, logSupabaseWarning } from './supabase-logger.js';
 
 function resolveRedirectTarget(role) {
   try {
@@ -19,7 +20,9 @@ function resolveRedirectTarget(role) {
     }
     return `${target.pathname}${target.search}${target.hash}` || target.pathname;
   } catch (error) {
-    console.warn('Invalid redirect parameter, ignoring', error);
+    logSupabaseWarning('auth.resolveRedirect', 'Invalid redirect parameter, ignoring', {
+      message: error?.message,
+    });
     return null;
   }
 }
@@ -36,7 +39,9 @@ async function redirectToDashboard(sb, user) {
     const destination = isElevatedRole(role) ? 'admin-dashboard.html' : 'dashboard.html';
     window.location.href = destination;
   } catch (error) {
-    console.warn('Role-based redirect failed, sending to member dashboard', error);
+    logSupabaseWarning('auth.redirect', 'Role-based redirect failed, sending to member dashboard', {
+      message: error?.message,
+    });
     window.location.href = 'dashboard.html';
   }
 }
@@ -48,60 +53,106 @@ async function checkSession(sb) {
   }
 }
 
-const signupFields = document.querySelectorAll('.signup-only');
-const signinFields = document.querySelectorAll('.signin-only');
-const titleEl = document.querySelector('.login-container h1');
-
-function toggleMode() {
-  mode = mode === 'signin' ? 'signup' : 'signin';
-  submitBtn.textContent = mode === 'signin' ? 'Sign In' : 'Sign Up';
-  toggleLink.textContent =
-    mode === 'signin' ? 'Need an account? Sign Up' : 'Already have an account? Sign In';
-  signupFields.forEach((el) => (el.hidden = mode !== 'signup'));
-  signinFields.forEach((el) => (el.hidden = mode !== 'signin'));
-  if (mode === 'signup') {
-    resetPasswordStrength(submitBtn);
-  } else {
-    submitBtn.disabled = false;
-  }
-  if (titleEl) titleEl.textContent = mode === 'signin' ? 'Member Login' : 'Create Account';
-  errorEl.textContent = '';
-}
-
 let mode = 'signin';
 const form = document.getElementById('auth-form');
 const submitBtn = document.querySelector('.js-submit');
 const toggleLink = document.querySelector('.js-toggle-auth');
 const errorEl = document.querySelector('.auth-error');
 const resetLink = document.querySelector('.js-reset-password');
+const signupFields = document.querySelectorAll('.signup-only');
+const signinFields = document.querySelectorAll('.signin-only');
+const titleEl = document.querySelector('.login-container h1');
+const signinPasswordInput = document.getElementById('signin-password');
+const signupPasswordInput = document.getElementById('password');
+const signupConfirmInput = document.getElementById('confirm-password');
+
+function handleMissingSupabase(message) {
+  const notice = message || SUPABASE_SETUP_MESSAGE;
+  if (submitBtn) submitBtn.disabled = true;
+  if (errorEl) errorEl.textContent = notice;
+  logSupabaseWarning('auth.missingSupabase', notice);
+}
+
+function setRequired(field, isRequired) {
+  if (!field) return;
+  field.required = Boolean(isRequired);
+  if (isRequired) {
+    field.setAttribute('aria-required', 'true');
+  } else {
+    field.removeAttribute('aria-required');
+  }
+}
+
+function updateSubmitLabel() {
+  if (!submitBtn) return;
+  const isSignin = mode === 'signin';
+  const label = isSignin ? 'Sign In' : 'Create Account';
+  const icon = isSignin ? 'ti ti-key' : 'ti ti-user-plus';
+  submitBtn.innerHTML = `<i class="${icon}"></i> ${label}`;
+}
+
+function applyMode(nextMode) {
+  mode = nextMode;
+  const isSignin = mode === 'signin';
+  signupFields.forEach((el) => {
+    el.hidden = isSignin;
+    el.setAttribute('aria-hidden', String(isSignin));
+  });
+  signinFields.forEach((el) => {
+    el.hidden = !isSignin;
+    el.setAttribute('aria-hidden', String(!isSignin));
+  });
+  setRequired(signinPasswordInput, isSignin);
+  setRequired(signupPasswordInput, !isSignin);
+  setRequired(signupConfirmInput, !isSignin);
+  if (!isSignin) {
+    if (signinPasswordInput) {
+      signinPasswordInput.value = '';
+    }
+    resetPasswordStrength(submitBtn);
+    signupPasswordInput?.focus({ preventScroll: true });
+  } else {
+    if (submitBtn) submitBtn.disabled = false;
+    if (signupPasswordInput) signupPasswordInput.value = '';
+    if (signupConfirmInput) signupConfirmInput.value = '';
+  }
+  updateSubmitLabel();
+  if (toggleLink) {
+    toggleLink.textContent = isSignin
+      ? 'Need an account? Sign Up'
+      : 'Already have an account? Sign In';
+  }
+  if (titleEl) titleEl.textContent = isSignin ? 'Member Login' : 'Create Account';
+  if (errorEl) errorEl.textContent = '';
+}
+
+function toggleMode() {
+  applyMode(mode === 'signin' ? 'signup' : 'signin');
+}
 
 document.addEventListener('DOMContentLoaded', () => {
-  const sb = getSupabase(() => {
-    submitBtn.disabled = true;
-    errorEl.textContent = 'Supabase is not configured.';
-  });
+  applyMode(mode);
+  initPasswordStrength(submitBtn);
+
+  const sb = getSupabase(handleMissingSupabase);
   if (!sb) return;
   checkSession(sb).catch((error) => {
-    console.warn('Session check failed', error);
+    logSupabaseError('auth.sessionCheck', error);
   });
-  signupFields.forEach((el) => (el.hidden = true));
-  signinFields.forEach((el) => (el.hidden = false));
-  initPasswordStrength(submitBtn);
+  // applyMode already ran above to ensure UI defaults
 });
 if (toggleLink) toggleLink.addEventListener('click', (e) => { e.preventDefault(); toggleMode(); });
 if (resetLink)
   resetLink.addEventListener('click', async (e) => {
     e.preventDefault();
-    const sb = getSupabase(() => {
-      errorEl.textContent = 'Supabase is not configured.';
-    });
+    const sb = getSupabase(handleMissingSupabase);
     if (!sb) return;
     const email = document.getElementById('email').value;
     const { error } = await sb.auth.resetPasswordForEmail(email, {
       redirectTo: `${location.origin}/reset-password.html`,
     });
     if (error) {
-      errorEl.textContent = error.message;
+      if (errorEl) errorEl.textContent = error.message;
     } else {
       window.location.href = `verify-email.html?mode=reset`;
     }
@@ -110,14 +161,11 @@ if (resetLink)
 if (form) {
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
-    const sb = getSupabase(() => {
-      errorEl.textContent = 'Supabase is not configured.';
-      submitBtn.disabled = true;
-    });
+    const sb = getSupabase(handleMissingSupabase);
     if (!sb) return;
     const email = document.getElementById('email').value;
-    const loginPassword = document.getElementById('signin-password')?.value;
-    const password = document.getElementById('password')?.value;
+    const loginPassword = signinPasswordInput?.value;
+    const password = signupPasswordInput?.value;
     const firstName = document.getElementById('first-name')?.value;
     const lastName = document.getElementById('last-name')?.value;
     const phone = document.getElementById('phone')?.value;
@@ -126,7 +174,7 @@ if (form) {
     if (mode === 'signin') {
       result = await sb.auth.signInWithPassword({ email, password: loginPassword });
       if (result.error) {
-        errorEl.textContent = result.error.message;
+        if (errorEl) errorEl.textContent = result.error.message;
       } else if (result.data?.user) {
         await redirectToDashboard(sb, result.data.user);
       }
@@ -134,7 +182,7 @@ if (form) {
     }
 
     if (!passwordsValid()) {
-      errorEl.textContent = 'Please meet password requirements.';
+      if (errorEl) errorEl.textContent = 'Please meet password requirements.';
       return;
     }
 
@@ -152,7 +200,7 @@ if (form) {
       },
     });
     if (result.error) {
-      errorEl.textContent = result.error.message;
+      if (errorEl) errorEl.textContent = result.error.message;
     } else {
       window.location.href = `verify-email.html?mode=signup`;
     }

--- a/js/supabase-helper.js
+++ b/js/supabase-helper.js
@@ -1,4 +1,10 @@
 import supabaseClient from '../supabase/client.js';
+import { bindSupabaseClient, logSupabaseWarning } from './supabase-logger.js';
+
+export const SUPABASE_SETUP_MESSAGE =
+  'Supabase is not configured. Add your project URL and anon key to .env (or assets/js/env.js) and run "npm run build" so the client can initialize. See docs/supabase/README.md for full setup steps.';
+
+const boundClient = bindSupabaseClient(supabaseClient, 'supabase');
 
 /**
  * Retrieves the Supabase client if it is configured.
@@ -9,17 +15,20 @@ import supabaseClient from '../supabase/client.js';
  * @returns {import('@supabase/supabase-js').SupabaseClient|null}
  */
 export function getSupabase(onMissing) {
-  if (!supabaseClient) {
+  if (!boundClient) {
+    logSupabaseWarning('supabase.init', SUPABASE_SETUP_MESSAGE);
     if (typeof onMissing === 'function') {
       try {
-        onMissing();
-      } catch (_) {
-        // ignore errors from callbacks
+        onMissing(SUPABASE_SETUP_MESSAGE);
+      } catch (error) {
+        logSupabaseWarning('supabase.init', 'Supabase fallback handler threw an error', {
+          message: error?.message,
+        });
       }
     } else {
-      alert('Supabase is not configured.');
+      alert(SUPABASE_SETUP_MESSAGE);
     }
     return null;
   }
-  return supabaseClient;
+  return boundClient;
 }

--- a/js/supabase-logger.js
+++ b/js/supabase-logger.js
@@ -1,0 +1,559 @@
+const MAX_LOGS = 200;
+const STORAGE_KEY = 'supabaseLogBuffer';
+const STORAGE_VERSION = 1;
+const logs = [];
+let panel;
+let badge;
+let autoScroll = true;
+let panelInitialized = false;
+let debugActive = false;
+let panelHost = null;
+let badgeHost = null;
+const proxyCache = new WeakMap();
+let keyboardListenerAttached = false;
+let storageWarningLogged = false;
+
+function isBrowser() {
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
+}
+
+function safeStorage() {
+  if (!isBrowser()) return null;
+  try {
+    return window.localStorage;
+  } catch (error) {
+    if (!storageWarningLogged) {
+      console.warn('[Supabase]', 'client.storage', 'Unable to access localStorage for debug logs', error);
+      storageWarningLogged = true;
+    }
+    return null;
+  }
+}
+
+function loadPersistedLogs() {
+  const storage = safeStorage();
+  if (!storage) return;
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const payload = JSON.parse(raw);
+    if (!payload || payload.version !== STORAGE_VERSION || !Array.isArray(payload.logs)) return;
+    payload.logs.slice(-MAX_LOGS).forEach((entry) => {
+      logs.push({ ...entry });
+    });
+  } catch (error) {
+    console.warn('[Supabase]', 'client.storage', 'Unable to restore persisted Supabase logs', error);
+  }
+}
+
+function persistLogs() {
+  const storage = safeStorage();
+  if (!storage) return;
+  try {
+    const payload = {
+      version: STORAGE_VERSION,
+      logs: logs.map((entry) => ({
+        ...entry,
+        detail: serializeDetail(entry.detail),
+      })),
+    };
+    storage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    if (error?.name === 'QuotaExceededError') {
+      console.warn('[Supabase]', 'client.storage', 'Supabase log persistence quota exceeded');
+    } else {
+      console.warn('[Supabase]', 'client.storage', 'Unable to persist Supabase logs', error);
+    }
+  }
+}
+
+function serializeDetail(detail) {
+  if (!detail) return undefined;
+  try {
+    if (typeof detail === 'string') return detail;
+    return JSON.stringify(detail, null, 2);
+  } catch (error) {
+    return String(detail);
+  }
+}
+
+function pushLog(entry) {
+  logs.push(entry);
+  if (logs.length > MAX_LOGS) {
+    logs.shift();
+  }
+  persistLogs();
+  if (entry.level === 'error') {
+    console.error('[Supabase]', entry.context, entry.message, entry.detail);
+  } else if (entry.level === 'warn') {
+    console.warn('[Supabase]', entry.context, entry.message, entry.detail);
+  } else {
+    console.info('[Supabase]', entry.context, entry.message, entry.detail);
+  }
+  if (isBrowser()) {
+    renderLogs();
+    if (!panel || panel.hidden) {
+      updateBadge();
+    }
+    const event = new CustomEvent('supabase:log', { detail: entry });
+    window.dispatchEvent(event);
+  }
+}
+
+function ensurePanel() {
+  if (!isBrowser()) return;
+  if (!panelInitialized) {
+    panelInitialized = true;
+    panel = document.createElement('section');
+    panel.className = 'supabase-log-panel';
+    panel.setAttribute('role', 'log');
+    panel.hidden = true;
+    panel.innerHTML = `
+      <header>
+        <div>
+          <h2>Supabase Debug Logs</h2>
+          <p>Latest client-side authentication and database activity</p>
+        </div>
+        <div class="actions">
+          <label><input type="checkbox" class="js-autoscroll" checked> Auto-scroll</label>
+          <button type="button" class="js-clear">Clear</button>
+          <button type="button" class="js-close" aria-label="Close">×</button>
+        </div>
+      </header>
+      <ol class="entries" aria-live="polite"></ol>
+    `;
+    const styles = document.createElement('style');
+    styles.textContent = `
+      .supabase-log-panel {
+        position: fixed;
+        inset: 4rem 2rem auto;
+        background: rgba(12, 12, 14, 0.94);
+        color: #f6f6f7;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 1rem;
+        max-height: calc(100vh - 8rem);
+        width: min(40rem, calc(100% - 4rem));
+        display: flex;
+        flex-direction: column;
+        z-index: 9999;
+        box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.35);
+        font-family: 'Inter', 'Segoe UI', system-ui, sans-serif;
+      }
+      .supabase-log-panel header {
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+        padding: 1rem 1.25rem;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        background: rgba(0, 0, 0, 0.5);
+      }
+      .supabase-log-panel header h2 {
+        margin: 0;
+        font-size: 1.1rem;
+      }
+      .supabase-log-panel header p {
+        margin: 0.15rem 0 0;
+        font-size: 0.85rem;
+        color: rgba(255, 255, 255, 0.65);
+      }
+      .supabase-log-panel header .actions {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+      }
+      .supabase-log-panel header button,
+      .supabase-log-panel header label {
+        font-size: 0.85rem;
+        background: rgba(255, 255, 255, 0.08);
+        color: inherit;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        padding: 0.35rem 0.65rem;
+        border-radius: 0.5rem;
+        cursor: pointer;
+      }
+      .supabase-log-panel header button:hover,
+      .supabase-log-panel header label:hover {
+        border-color: rgba(255, 255, 255, 0.3);
+      }
+      .supabase-log-panel header button.js-close {
+        font-size: 1.1rem;
+        line-height: 1;
+        padding: 0.1rem 0.55rem;
+        background: rgba(255, 255, 255, 0.15);
+      }
+      .supabase-log-panel .entries {
+        flex: 1;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        overflow: auto;
+        font-size: 0.9rem;
+      }
+      .supabase-log-panel .entries li {
+        padding: 0.9rem 1.25rem;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+        display: grid;
+        gap: 0.35rem;
+      }
+      .supabase-log-panel .entries li:last-child {
+        border-bottom: none;
+      }
+      .supabase-log-panel .meta {
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: rgba(255, 255, 255, 0.6);
+      }
+      .supabase-log-panel .message {
+        font-weight: 600;
+      }
+      .supabase-log-panel .detail {
+        white-space: pre-wrap;
+        word-break: break-word;
+        font-family: 'JetBrains Mono', 'Fira Code', monospace;
+        font-size: 0.78rem;
+        color: rgba(255, 255, 255, 0.8);
+      }
+      .supabase-log-panel .level-error {
+        border-left: 0.25rem solid #ff6b6b;
+        padding-left: 1rem;
+      }
+      .supabase-log-panel .level-warn {
+        border-left: 0.25rem solid #ffa94d;
+        padding-left: 1rem;
+      }
+      .supabase-log-panel .level-info {
+        border-left: 0.25rem solid #4dabf7;
+        padding-left: 1rem;
+      }
+      .supabase-log-badge {
+        position: fixed;
+        right: 1.5rem;
+        bottom: 1.5rem;
+        background: rgba(0, 0, 0, 0.82);
+        color: #fff;
+        border-radius: 999px;
+        padding: 0.55rem 0.9rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-family: 'Inter', 'Segoe UI', system-ui, sans-serif;
+        font-size: 0.85rem;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        cursor: pointer;
+        z-index: 9998;
+        box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.3);
+      }
+      .supabase-log-badge.hidden {
+        display: none;
+      }
+    `;
+    document.head.appendChild(styles);
+    badge = document.createElement('button');
+    badge.type = 'button';
+    badge.className = 'supabase-log-badge hidden';
+    badge.innerHTML = '<span class="dot"></span><span>Supabase Logs</span>';
+    badge.addEventListener('click', () => togglePanel(true));
+    panel.querySelector('.js-close').addEventListener('click', () => togglePanel(false));
+    panel.querySelector('.js-clear').addEventListener('click', clearLogs);
+    panel.querySelector('.js-autoscroll').addEventListener('change', (event) => {
+      autoScroll = event.target.checked;
+    });
+  }
+
+  const targetPanelHost = resolvePanelHost();
+  if (panel && targetPanelHost && panel.parentElement !== targetPanelHost) {
+    targetPanelHost.appendChild(panel);
+  }
+
+  const targetBadgeHost = resolveBadgeHost();
+  if (badge && targetBadgeHost && badge.parentElement !== targetBadgeHost) {
+    targetBadgeHost.appendChild(badge);
+  }
+
+  if (!keyboardListenerAttached) {
+    document.addEventListener('keydown', handleDebugShortcut);
+    keyboardListenerAttached = true;
+  }
+}
+
+function clearLogs() {
+  logs.splice(0, logs.length);
+  renderLogs();
+  updateBadge();
+  const storage = safeStorage();
+  if (storage) {
+    storage.removeItem(STORAGE_KEY);
+  }
+}
+
+function updateBadge() {
+  if (!badge) return;
+  if (!debugActive) {
+    badge.classList.add('hidden');
+    badge.innerHTML = '<span>Supabase Logs</span>';
+    return;
+  }
+  const unreadErrors = logs.filter((entry) => entry.level === 'error').length;
+  if (unreadErrors === 0) {
+    badge.classList.add('hidden');
+    badge.innerHTML = '<span>Supabase Logs</span>';
+    return;
+  }
+  badge.classList.remove('hidden');
+  badge.innerHTML = `<strong>${unreadErrors}</strong> Supabase ${unreadErrors === 1 ? 'issue' : 'issues'}`;
+}
+
+function togglePanel(forceOpen) {
+  if (!debugActive) return;
+  if (!panel) return;
+  const shouldOpen = typeof forceOpen === 'boolean' ? forceOpen : panel.hidden;
+  panel.hidden = !shouldOpen;
+  if (shouldOpen) {
+    if (autoScroll) {
+      const entriesEl = panel.querySelector('.entries');
+      entriesEl.scrollTop = entriesEl.scrollHeight;
+    }
+  }
+  updateBadge();
+}
+
+function renderLogs() {
+  if (!panel || !debugActive) return;
+  const list = panel.querySelector('.entries');
+  if (!list) return;
+  list.innerHTML = logs
+    .map((entry) => {
+      const time = new Date(entry.timestamp).toLocaleTimeString();
+      const detail = serializeDetail(entry.detail);
+      return `
+        <li class="level-${entry.level}">
+          <div class="meta">
+            <span>${time}</span>
+            <span>${entry.context}</span>
+            <span>${entry.level.toUpperCase()}</span>
+          </div>
+          <div class="message">${entry.message}</div>
+          ${detail ? `<pre class="detail">${detail}</pre>` : ''}
+        </li>
+      `;
+    })
+    .join('');
+  if (autoScroll) {
+    list.scrollTop = list.scrollHeight;
+  }
+}
+
+function initDebugPanel() {
+  if (!isBrowser()) return;
+  const params = new URLSearchParams(window.location.search);
+  const storedPreference = getStoredDebugPreference();
+  if (storedPreference) {
+    activateDebug({ persist: true, open: false });
+  }
+  if (params.has('supabaseDebug')) {
+    const value = params.get('supabaseDebug');
+    const shouldPersist = value === 'persist' || value === '1';
+    const shouldOpen = value !== 'hidden';
+    activateDebug({ persist: shouldPersist ? true : null, open: shouldOpen });
+  }
+  window.supabaseDebug = {
+    toggle: () => {
+      if (!debugActive) {
+        activateDebug({ persist: null, open: true });
+      } else {
+        togglePanel();
+      }
+    },
+    show: () => {
+      if (!debugActive) {
+        activateDebug({ persist: null, open: true });
+      } else {
+        togglePanel(true);
+      }
+    },
+    hide: () => togglePanel(false),
+    enable: (options = {}) => activateDebug({ persist: options.persist ?? true, open: options.open ?? true }),
+    disable: () => deactivateDebug(),
+    export: () => logs.slice(),
+    clear: () => clearLogs(),
+    mount: (panelContainer, badgeContainer) => {
+      if (!isBrowser()) return;
+      panelHost = resolveElement(panelContainer) || null;
+      badgeHost = resolveElement(badgeContainer) || panelHost || null;
+      if (debugActive) {
+        ensurePanel();
+      }
+    },
+    isEnabled: () => debugActive,
+  };
+}
+
+if (isBrowser()) {
+  loadPersistedLogs();
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initDebugPanel);
+  } else {
+    initDebugPanel();
+  }
+}
+
+export function logSupabaseEvent(level, context, message, detail) {
+  const hasUUID = typeof globalThis !== 'undefined' && globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function';
+  pushLog({
+    id: hasUUID ? globalThis.crypto.randomUUID() : `${Date.now()}-${Math.random()}`,
+    timestamp: Date.now(),
+    level,
+    context,
+    message,
+    detail,
+  });
+}
+
+export function logSupabaseError(context, error, detail) {
+  const message = error?.message || String(error);
+  const payload = detail || {};
+  if (error?.status) payload.status = error.status;
+  if (error?.code) payload.code = error.code;
+  if (error?.stack) payload.stack = error.stack;
+  logSupabaseEvent('error', context, message, payload);
+}
+
+export function logSupabaseWarning(context, message, detail) {
+  logSupabaseEvent('warn', context, message, detail);
+}
+
+export function logSupabaseInfo(context, message, detail) {
+  logSupabaseEvent('info', context, message, detail);
+}
+
+export function getSupabaseLogs() {
+  return logs.slice();
+}
+
+function createProxy(target, context) {
+  if (!target || typeof target !== 'object' && typeof target !== 'function') {
+    return target;
+  }
+  if (proxyCache.has(target)) {
+    return proxyCache.get(target);
+  }
+  const proxy = new Proxy(target, {
+    get(original, prop, receiver) {
+      const value = Reflect.get(original, prop, receiver);
+      if (value && (typeof value === 'object' || typeof value === 'function')) {
+        if (typeof value === 'function') {
+          return async (...args) => {
+            try {
+              const result = await value.apply(original, args);
+              if (result?.error) {
+                logSupabaseError(`${context}.${String(prop)}`, result.error, {
+                  args,
+                  data: result.data,
+                });
+              }
+              return result;
+            } catch (error) {
+              logSupabaseError(`${context}.${String(prop)}`, error, {
+                args,
+              });
+              throw error;
+            }
+          };
+        }
+        return createProxy(value, `${context}.${String(prop)}`);
+      }
+      return value;
+    },
+  });
+  proxyCache.set(target, proxy);
+  return proxy;
+}
+
+export function bindSupabaseClient(client, context = 'client') {
+  if (!client) return client;
+  return createProxy(client, context);
+}
+
+function resolveElement(target) {
+  if (!target) return null;
+  if (typeof target === 'string') {
+    return document.querySelector(target);
+  }
+  if (typeof Element !== 'undefined' && target instanceof Element) {
+    return target;
+  }
+  return null;
+}
+
+function resolvePanelHost() {
+  if (!panelHost || !panelHost.isConnected) {
+    panelHost = null;
+  }
+  return panelHost || document.body;
+}
+
+function resolveBadgeHost() {
+  if (!badgeHost || !badgeHost.isConnected) {
+    badgeHost = null;
+  }
+  return badgeHost || document.body;
+}
+
+function handleDebugShortcut(event) {
+  if (!debugActive || !panel) return;
+  if ((event.ctrlKey || event.metaKey) && event.altKey && event.key.toLowerCase() === 'l') {
+    event.preventDefault();
+    togglePanel(panel.hidden);
+  }
+}
+
+function getStoredDebugPreference() {
+  const storage = safeStorage();
+  if (!storage) return false;
+  return storage.getItem('supabaseDebug') === '1';
+}
+
+function setStoredDebugPreference(enabled) {
+  const storage = safeStorage();
+  if (!storage) return;
+  if (enabled) {
+    storage.setItem('supabaseDebug', '1');
+  } else {
+    storage.removeItem('supabaseDebug');
+  }
+}
+
+function activateDebug({ persist = null, open = true } = {}) {
+  if (!isBrowser()) return;
+  if (!debugActive) {
+    debugActive = true;
+    ensurePanel();
+    renderLogs();
+  }
+  if (persist === true) {
+    setStoredDebugPreference(true);
+  }
+  if (persist === false) {
+    setStoredDebugPreference(false);
+  }
+  updateBadge();
+  if (open) {
+    togglePanel(true);
+  } else if (panel) {
+    panel.hidden = true;
+  }
+}
+
+function deactivateDebug() {
+  if (!debugActive) return;
+  debugActive = false;
+  setStoredDebugPreference(false);
+  if (panel) {
+    panel.hidden = true;
+  }
+  updateBadge();
+}

--- a/reset-password.html
+++ b/reset-password.html
@@ -61,7 +61,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script type="module">
     import { initPasswordStrength, passwordsValid, resetPasswordStrength } from './js/password-strength.js';
-    import { getSupabase } from './js/supabase-helper.js';
+    import { getSupabase, SUPABASE_SETUP_MESSAGE } from './js/supabase-helper.js';
     const form = document.getElementById('reset-form');
     const messageEl = document.querySelector('.status-message');
     const submitBtn = document.querySelector('.js-submit');
@@ -69,8 +69,9 @@
     document.addEventListener('DOMContentLoaded', async () => {
       initPasswordStrength(submitBtn);
       resetPasswordStrength(submitBtn);
-      supabaseClient = getSupabase(() => {
-        messageEl.textContent = 'Supabase is not configured. Password reset is unavailable until deployment variables load.';
+      supabaseClient = getSupabase((message) => {
+        const notice = `${message || SUPABASE_SETUP_MESSAGE} Password reset is unavailable until deployment variables load.`;
+        messageEl.textContent = notice;
         submitBtn.disabled = true;
         document.getElementById('password').disabled = true;
         document.getElementById('confirm-password').disabled = true;
@@ -99,7 +100,7 @@
       }
       const password = document.getElementById('password').value;
       if (!supabaseClient) {
-        messageEl.textContent = 'Supabase is not configured. Password reset is unavailable.';
+        messageEl.textContent = `${SUPABASE_SETUP_MESSAGE} Password reset is unavailable.`;
         return;
       }
       const { error } = await supabaseClient.auth.updateUser({ password });

--- a/supabase/client.js
+++ b/supabase/client.js
@@ -1,10 +1,14 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { resolveSupabaseConfig } from './env.js';
+import { logSupabaseWarning } from '../js/supabase-logger.js';
 
 const { url, key } = await resolveSupabaseConfig();
 
 if (!url || !key) {
-  console.warn('Supabase client not configured. Check SUPABASE_DATABASE_URL and SUPABASE_ANON_KEY.');
+  logSupabaseWarning(
+    'supabase.client',
+    'Supabase client not configured. Check SUPABASE_DATABASE_URL and SUPABASE_ANON_KEY.',
+  );
 }
 
 const supabase = url && key ? createClient(url, key) : null;

--- a/verify-email.html
+++ b/verify-email.html
@@ -41,15 +41,15 @@
   </main>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script type="module">
-    import { getSupabase } from './js/supabase-helper.js';
+    import { getSupabase, SUPABASE_SETUP_MESSAGE } from './js/supabase-helper.js';
     const messageEl = document.querySelector('.status-message');
     const hashParams = new URLSearchParams(window.location.hash.slice(1));
     const searchParams = new URLSearchParams(window.location.search);
     const tokenHash = hashParams.get('token_hash') || searchParams.get('token_hash');
     const email = hashParams.get('email') || searchParams.get('email');
     const type = hashParams.get('type') || searchParams.get('type');
-    const supabaseClient = getSupabase(() => {
-      messageEl.textContent = 'Supabase is not configured. Verification will complete after deployment injects credentials.';
+    const supabaseClient = getSupabase((message) => {
+      messageEl.textContent = `${message || SUPABASE_SETUP_MESSAGE} Email verification will complete after deployment injects credentials.`;
     });
     if (!supabaseClient) {
       return;


### PR DESCRIPTION
## Summary
- make the Supabase debug console opt-in so the panel and badge only mount when explicitly enabled
- add APIs to programmatically show, hide, or remount the logger UI and honor keyboard toggles only while debugging is active
- persist the client-side Supabase log buffer in localStorage so history survives reloads for easier sharing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc2c700fc083259bb7c4a4f5f63c47