### PR TITLE
Add CLI helper to bootstrap admin access

### DIFF
--- a/docs/supabase/README.md
+++ b/docs/supabase/README.md
@@ -129,6 +129,32 @@ Deploy via Supabase CLI (`supabase functions deploy admin-users`).
 
 ---
 
+## 6. Bootstrap your own admin access
+
+If you cannot reach any protected pages yet, elevate your account with the bundled helper script. It uses the Supabase service
+role key so run it locally (or from a secure CI job) after exporting your credentials:
+
+```bash
+export SUPABASE_DATABASE_URL="https://<project>.supabase.co"
+export SUPABASE_SERVICE_ROLE_KEY="<service-role-key>"
+
+# Creates or updates the admin user. Add --password to set a known password.
+node scripts/bootstrap-admin.js --email you@example.com --name "Daren Prince"
+```
+
+What the script handles for you:
+
+- Creates the user (with a generated password when `--password` is omitted) and confirms the account so you can sign in
+  immediately.
+- Syncs `user_metadata` and `app_metadata` with the `admin` role so the auth guard unlocks elevated views.
+- Upserts the profile row to match, ensuring the admin console lists you with the correct role and name.
+
+After the script runs it prints the login email plus either your supplied password or the generated one. Sign in at
+`login.html` and you should land on the dashboard with the admin menus available. Rotate the password from the Supabase
+dashboard once you are in if you used the generated value.
+
+---
+
 ## 6. Testing & observability
 
 - `npm test` runs Vitest suites, including new coverage for env resolution.

--- a/js/auth.js
+++ b/js/auth.js
@@ -2,9 +2,11 @@ import {
   initPasswordStrength,
   passwordsValid,
   resetPasswordStrength,
+  evaluate as evaluatePasswordStrength,
 } from './password-strength.js';
-import { getSupabase } from './supabase-helper.js';
+import { getSupabase, SUPABASE_SETUP_MESSAGE } from './supabase-helper.js';
 import { getUserRole, isElevatedRole } from './user-role.js';
+import { logSupabaseError, logSupabaseWarning } from './supabase-logger.js';
 
 function resolveRedirectTarget(role) {
   try {
@@ -19,7 +21,9 @@ function resolveRedirectTarget(role) {
     }
     return `${target.pathname}${target.search}${target.hash}` || target.pathname;
   } catch (error) {
-    console.warn('Invalid redirect parameter, ignoring', error);
+    logSupabaseWarning('auth.resolveRedirect', 'Invalid redirect parameter, ignoring', {
+      message: error?.message,
+    });
     return null;
   }
 }
@@ -36,7 +40,9 @@ async function redirectToDashboard(sb, user) {
     const destination = isElevatedRole(role) ? 'admin-dashboard.html' : 'dashboard.html';
     window.location.href = destination;
   } catch (error) {
-    console.warn('Role-based redirect failed, sending to member dashboard', error);
+    logSupabaseWarning('auth.redirect', 'Role-based redirect failed, sending to member dashboard', {
+      message: error?.message,
+    });
     window.location.href = 'dashboard.html';
   }
 }
@@ -48,60 +54,136 @@ async function checkSession(sb) {
   }
 }
 
-const signupFields = document.querySelectorAll('.signup-only');
-const signinFields = document.querySelectorAll('.signin-only');
-const titleEl = document.querySelector('.login-container h1');
-
-function toggleMode() {
-  mode = mode === 'signin' ? 'signup' : 'signin';
-  submitBtn.textContent = mode === 'signin' ? 'Sign In' : 'Sign Up';
-  toggleLink.textContent =
-    mode === 'signin' ? 'Need an account? Sign Up' : 'Already have an account? Sign In';
-  signupFields.forEach((el) => (el.hidden = mode !== 'signup'));
-  signinFields.forEach((el) => (el.hidden = mode !== 'signin'));
-  if (mode === 'signup') {
-    resetPasswordStrength(submitBtn);
-  } else {
-    submitBtn.disabled = false;
-  }
-  if (titleEl) titleEl.textContent = mode === 'signin' ? 'Member Login' : 'Create Account';
-  errorEl.textContent = '';
-}
-
 let mode = 'signin';
+let supabaseReady = false;
+let supabaseMessage = SUPABASE_SETUP_MESSAGE;
 const form = document.getElementById('auth-form');
 const submitBtn = document.querySelector('.js-submit');
 const toggleLink = document.querySelector('.js-toggle-auth');
 const errorEl = document.querySelector('.auth-error');
 const resetLink = document.querySelector('.js-reset-password');
+const signupFields = document.querySelectorAll('.signup-only');
+const signinFields = document.querySelectorAll('.signin-only');
+const titleEl = document.querySelector('.login-container h1');
+const signinPasswordInput = document.getElementById('signin-password');
+const signupPasswordInput = document.getElementById('password');
+const signupConfirmInput = document.getElementById('confirm-password');
+
+function disableSubmitForSupabase() {
+  if (!submitBtn) return;
+  submitBtn.disabled = true;
+  submitBtn.dataset.supabaseDisabled = 'true';
+}
+
+function enableSubmitForSupabase() {
+  if (!submitBtn) return;
+  delete submitBtn.dataset.supabaseDisabled;
+  if (mode === 'signin') {
+    submitBtn.disabled = false;
+  } else if (mode === 'signup') {
+    evaluatePasswordStrength();
+  }
+}
+
+function handleMissingSupabase(message) {
+  supabaseReady = false;
+  supabaseMessage = message || SUPABASE_SETUP_MESSAGE;
+  disableSubmitForSupabase();
+  if (errorEl) errorEl.textContent = supabaseMessage;
+  logSupabaseWarning('auth.missingSupabase', supabaseMessage);
+}
+
+function setRequired(field, isRequired) {
+  if (!field) return;
+  field.required = Boolean(isRequired);
+  if (isRequired) {
+    field.setAttribute('aria-required', 'true');
+  } else {
+    field.removeAttribute('aria-required');
+  }
+}
+
+function updateSubmitLabel() {
+  if (!submitBtn) return;
+  const isSignin = mode === 'signin';
+  const label = isSignin ? 'Sign In' : 'Create Account';
+  const icon = isSignin ? 'ti ti-key' : 'ti ti-user-plus';
+  submitBtn.innerHTML = `<i class="${icon}"></i> ${label}`;
+}
+
+function applyMode(nextMode) {
+  mode = nextMode;
+  const isSignin = mode === 'signin';
+  signupFields.forEach((el) => {
+    el.hidden = isSignin;
+    el.setAttribute('aria-hidden', String(isSignin));
+  });
+  signinFields.forEach((el) => {
+    el.hidden = !isSignin;
+    el.setAttribute('aria-hidden', String(!isSignin));
+  });
+  setRequired(signinPasswordInput, isSignin);
+  setRequired(signupPasswordInput, !isSignin);
+  setRequired(signupConfirmInput, !isSignin);
+  if (submitBtn) {
+    if (!supabaseReady) {
+      disableSubmitForSupabase();
+    } else if (isSignin) {
+      submitBtn.disabled = false;
+    }
+  }
+  if (!isSignin) {
+    if (signinPasswordInput) {
+      signinPasswordInput.value = '';
+    }
+    resetPasswordStrength(submitBtn);
+    signupPasswordInput?.focus({ preventScroll: true });
+  } else {
+    if (submitBtn) submitBtn.disabled = false;
+    if (signupPasswordInput) signupPasswordInput.value = '';
+    if (signupConfirmInput) signupConfirmInput.value = '';
+  }
+  updateSubmitLabel();
+  if (toggleLink) {
+    toggleLink.textContent = isSignin
+      ? 'Need an account? Sign Up'
+      : 'Already have an account? Sign In';
+  }
+  if (titleEl) titleEl.textContent = isSignin ? 'Member Login' : 'Create Account';
+  if (errorEl) errorEl.textContent = supabaseReady ? '' : supabaseMessage;
+}
+
+function toggleMode() {
+  applyMode(mode === 'signin' ? 'signup' : 'signin');
+}
 
 document.addEventListener('DOMContentLoaded', () => {
-  const sb = getSupabase(() => {
-    submitBtn.disabled = true;
-    errorEl.textContent = 'Supabase is not configured.';
-  });
-  if (!sb) return;
-  checkSession(sb).catch((error) => {
-    console.warn('Session check failed', error);
-  });
-  signupFields.forEach((el) => (el.hidden = true));
-  signinFields.forEach((el) => (el.hidden = false));
+  applyMode(mode);
   initPasswordStrength(submitBtn);
+
+  const sb = getSupabase(handleMissingSupabase);
+  if (!sb) return;
+  supabaseReady = true;
+  supabaseMessage = '';
+  enableSubmitForSupabase();
+  if (errorEl) errorEl.textContent = '';
+  checkSession(sb).catch((error) => {
+    logSupabaseError('auth.sessionCheck', error);
+  });
+  // applyMode already ran above to ensure UI defaults
 });
 if (toggleLink) toggleLink.addEventListener('click', (e) => { e.preventDefault(); toggleMode(); });
 if (resetLink)
   resetLink.addEventListener('click', async (e) => {
     e.preventDefault();
-    const sb = getSupabase(() => {
-      errorEl.textContent = 'Supabase is not configured.';
-    });
+    const sb = getSupabase(handleMissingSupabase);
     if (!sb) return;
     const email = document.getElementById('email').value;
     const { error } = await sb.auth.resetPasswordForEmail(email, {
       redirectTo: `${location.origin}/reset-password.html`,
     });
     if (error) {
-      errorEl.textContent = error.message;
+      if (errorEl) errorEl.textContent = error.message;
     } else {
       window.location.href = `verify-email.html?mode=reset`;
     }
@@ -110,14 +192,11 @@ if (resetLink)
 if (form) {
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
-    const sb = getSupabase(() => {
-      errorEl.textContent = 'Supabase is not configured.';
-      submitBtn.disabled = true;
-    });
+    const sb = getSupabase(handleMissingSupabase);
     if (!sb) return;
     const email = document.getElementById('email').value;
-    const loginPassword = document.getElementById('signin-password')?.value;
-    const password = document.getElementById('password')?.value;
+    const loginPassword = signinPasswordInput?.value;
+    const password = signupPasswordInput?.value;
     const firstName = document.getElementById('first-name')?.value;
     const lastName = document.getElementById('last-name')?.value;
     const phone = document.getElementById('phone')?.value;
@@ -126,7 +205,7 @@ if (form) {
     if (mode === 'signin') {
       result = await sb.auth.signInWithPassword({ email, password: loginPassword });
       if (result.error) {
-        errorEl.textContent = result.error.message;
+        if (errorEl) errorEl.textContent = result.error.message;
       } else if (result.data?.user) {
         await redirectToDashboard(sb, result.data.user);
       }
@@ -134,7 +213,7 @@ if (form) {
     }
 
     if (!passwordsValid()) {
-      errorEl.textContent = 'Please meet password requirements.';
+      if (errorEl) errorEl.textContent = 'Please meet password requirements.';
       return;
     }
 
@@ -152,7 +231,7 @@ if (form) {
       },
     });
     if (result.error) {
-      errorEl.textContent = result.error.message;
+      if (errorEl) errorEl.textContent = result.error.message;
     } else {
       window.location.href = `verify-email.html?mode=signup`;
     }

--- a/js/password-strength.js
+++ b/js/password-strength.js
@@ -41,6 +41,10 @@ const reqEls = {
 };
 let submitBtn;
 
+function submitGuardDisabled() {
+  return Boolean(submitBtn?.dataset?.supabaseDisabled === 'true');
+}
+
 function setReqState(name, valid) {
   const el = reqEls[name];
   if (!el) return;
@@ -77,7 +81,7 @@ function evaluate() {
   passwordInput.classList.toggle('invalid', !Object.values(checks).every(Boolean) && val.length > 0);
 
   const allValid = Object.values(checks).every(Boolean) && match;
-  if (submitBtn) submitBtn.disabled = !allValid;
+  if (submitBtn) submitBtn.disabled = !allValid || submitGuardDisabled();
   return allValid;
 }
 

--- a/js/supabase-helper.js
+++ b/js/supabase-helper.js
@@ -1,4 +1,10 @@
 import supabaseClient from '../supabase/client.js';
+import { bindSupabaseClient, logSupabaseWarning } from './supabase-logger.js';
+
+export const SUPABASE_SETUP_MESSAGE =
+  'Supabase is not configured. Add your project URL and anon key to .env (or assets/js/env.js) and run "npm run build" so the client can initialize. See docs/supabase/README.md for full setup steps.';
+
+const boundClient = bindSupabaseClient(supabaseClient, 'supabase');
 
 /**
  * Retrieves the Supabase client if it is configured.
@@ -9,17 +15,20 @@ import supabaseClient from '../supabase/client.js';
  * @returns {import('@supabase/supabase-js').SupabaseClient|null}
  */
 export function getSupabase(onMissing) {
-  if (!supabaseClient) {
+  if (!boundClient) {
+    logSupabaseWarning('supabase.init', SUPABASE_SETUP_MESSAGE);
     if (typeof onMissing === 'function') {
       try {
-        onMissing();
-      } catch (_) {
-        // ignore errors from callbacks
+        onMissing(SUPABASE_SETUP_MESSAGE);
+      } catch (error) {
+        logSupabaseWarning('supabase.init', 'Supabase fallback handler threw an error', {
+          message: error?.message,
+        });
       }
     } else {
-      alert('Supabase is not configured.');
+      alert(SUPABASE_SETUP_MESSAGE);
     }
     return null;
   }
-  return supabaseClient;
+  return boundClient;
 }

--- a/js/supabase-logger.js
+++ b/js/supabase-logger.js
@@ -1,0 +1,685 @@
+const MAX_LOGS = 200;
+const STORAGE_KEY = 'supabaseLogBuffer';
+const STORAGE_VERSION = 1;
+const logs = [];
+let panel;
+let badge;
+let autoScroll = true;
+let panelInitialized = false;
+let debugActive = false;
+let panelHost = null;
+let badgeHost = null;
+const proxyCache = new WeakMap();
+let keyboardListenerAttached = false;
+let storageWarningLogged = false;
+const SECRET_TAP_SELECTORS = [
+  '[data-supabase-debug-target]',
+  '.mega-menu-logo',
+  '.logo img',
+  '.footer-logo',
+  '.logo',
+];
+const SECRET_TAP_THRESHOLD = 7;
+const SECRET_TAP_WINDOW = 3000;
+const KONAMI_SEQUENCE = [
+  'arrowup',
+  'arrowup',
+  'arrowdown',
+  'arrowdown',
+  'arrowleft',
+  'arrowright',
+  'arrowleft',
+  'arrowright',
+  'b',
+  'a',
+];
+let secretGesturesInitialized = false;
+let secretTapTarget = null;
+let secretTapCount = 0;
+let secretTapTimer = null;
+let konamiIndex = 0;
+let konamiListenerAttached = false;
+let secretTapObserver = null;
+
+function isBrowser() {
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
+}
+
+function safeStorage() {
+  if (!isBrowser()) return null;
+  try {
+    return window.localStorage;
+  } catch (error) {
+    if (!storageWarningLogged) {
+      console.warn('[Supabase]', 'client.storage', 'Unable to access localStorage for debug logs', error);
+      storageWarningLogged = true;
+    }
+    return null;
+  }
+}
+
+function loadPersistedLogs() {
+  const storage = safeStorage();
+  if (!storage) return;
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const payload = JSON.parse(raw);
+    if (!payload || payload.version !== STORAGE_VERSION || !Array.isArray(payload.logs)) return;
+    payload.logs.slice(-MAX_LOGS).forEach((entry) => {
+      logs.push({ ...entry });
+    });
+  } catch (error) {
+    console.warn('[Supabase]', 'client.storage', 'Unable to restore persisted Supabase logs', error);
+  }
+}
+
+function persistLogs() {
+  const storage = safeStorage();
+  if (!storage) return;
+  try {
+    const payload = {
+      version: STORAGE_VERSION,
+      logs: logs.map((entry) => ({
+        ...entry,
+        detail: serializeDetail(entry.detail),
+      })),
+    };
+    storage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    if (error?.name === 'QuotaExceededError') {
+      console.warn('[Supabase]', 'client.storage', 'Supabase log persistence quota exceeded');
+    } else {
+      console.warn('[Supabase]', 'client.storage', 'Unable to persist Supabase logs', error);
+    }
+  }
+}
+
+function serializeDetail(detail) {
+  if (!detail) return undefined;
+  try {
+    if (typeof detail === 'string') return detail;
+    return JSON.stringify(detail, null, 2);
+  } catch (error) {
+    return String(detail);
+  }
+}
+
+function pushLog(entry) {
+  logs.push(entry);
+  if (logs.length > MAX_LOGS) {
+    logs.shift();
+  }
+  persistLogs();
+  if (entry.level === 'error') {
+    console.error('[Supabase]', entry.context, entry.message, entry.detail);
+  } else if (entry.level === 'warn') {
+    console.warn('[Supabase]', entry.context, entry.message, entry.detail);
+  } else {
+    console.info('[Supabase]', entry.context, entry.message, entry.detail);
+  }
+  if (isBrowser()) {
+    renderLogs();
+    if (!panel || panel.hidden) {
+      updateBadge();
+    }
+    const event = new CustomEvent('supabase:log', { detail: entry });
+    window.dispatchEvent(event);
+  }
+}
+
+function ensurePanel() {
+  if (!isBrowser()) return;
+  if (!panelInitialized) {
+    panelInitialized = true;
+    panel = document.createElement('section');
+    panel.className = 'supabase-log-panel';
+    panel.setAttribute('role', 'log');
+    panel.hidden = true;
+    panel.innerHTML = `
+      <header>
+        <div>
+          <h2>Supabase Debug Logs</h2>
+          <p>Latest client-side authentication and database activity</p>
+        </div>
+        <div class="actions">
+          <label><input type="checkbox" class="js-autoscroll" checked> Auto-scroll</label>
+          <button type="button" class="js-clear">Clear</button>
+          <button type="button" class="js-close" aria-label="Close">×</button>
+        </div>
+      </header>
+      <ol class="entries" aria-live="polite"></ol>
+    `;
+    const styles = document.createElement('style');
+    styles.textContent = `
+      .supabase-log-panel {
+        position: fixed;
+        inset: 4rem 2rem auto;
+        background: rgba(12, 12, 14, 0.94);
+        color: #f6f6f7;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 1rem;
+        max-height: calc(100vh - 8rem);
+        width: min(40rem, calc(100% - 4rem));
+        display: flex;
+        flex-direction: column;
+        z-index: 9999;
+        box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.35);
+        font-family: 'Inter', 'Segoe UI', system-ui, sans-serif;
+      }
+      .supabase-log-panel header {
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+        padding: 1rem 1.25rem;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        background: rgba(0, 0, 0, 0.5);
+      }
+      .supabase-log-panel header h2 {
+        margin: 0;
+        font-size: 1.1rem;
+      }
+      .supabase-log-panel header p {
+        margin: 0.15rem 0 0;
+        font-size: 0.85rem;
+        color: rgba(255, 255, 255, 0.65);
+      }
+      .supabase-log-panel header .actions {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+      }
+      .supabase-log-panel header button,
+      .supabase-log-panel header label {
+        font-size: 0.85rem;
+        background: rgba(255, 255, 255, 0.08);
+        color: inherit;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        padding: 0.35rem 0.65rem;
+        border-radius: 0.5rem;
+        cursor: pointer;
+      }
+      .supabase-log-panel header button:hover,
+      .supabase-log-panel header label:hover {
+        border-color: rgba(255, 255, 255, 0.3);
+      }
+      .supabase-log-panel header button.js-close {
+        font-size: 1.1rem;
+        line-height: 1;
+        padding: 0.1rem 0.55rem;
+        background: rgba(255, 255, 255, 0.15);
+      }
+      .supabase-log-panel .entries {
+        flex: 1;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        overflow: auto;
+        font-size: 0.9rem;
+      }
+      .supabase-log-panel .entries li {
+        padding: 0.9rem 1.25rem;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+        display: grid;
+        gap: 0.35rem;
+      }
+      .supabase-log-panel .entries li:last-child {
+        border-bottom: none;
+      }
+      .supabase-log-panel .meta {
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: rgba(255, 255, 255, 0.6);
+      }
+      .supabase-log-panel .message {
+        font-weight: 600;
+      }
+      .supabase-log-panel .detail {
+        white-space: pre-wrap;
+        word-break: break-word;
+        font-family: 'JetBrains Mono', 'Fira Code', monospace;
+        font-size: 0.78rem;
+        color: rgba(255, 255, 255, 0.8);
+      }
+      .supabase-log-panel .level-error {
+        border-left: 0.25rem solid #ff6b6b;
+        padding-left: 1rem;
+      }
+      .supabase-log-panel .level-warn {
+        border-left: 0.25rem solid #ffa94d;
+        padding-left: 1rem;
+      }
+      .supabase-log-panel .level-info {
+        border-left: 0.25rem solid #4dabf7;
+        padding-left: 1rem;
+      }
+      .supabase-log-badge {
+        position: fixed;
+        right: 1.5rem;
+        bottom: 1.5rem;
+        background: rgba(0, 0, 0, 0.82);
+        color: #fff;
+        border-radius: 999px;
+        padding: 0.55rem 0.9rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-family: 'Inter', 'Segoe UI', system-ui, sans-serif;
+        font-size: 0.85rem;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        cursor: pointer;
+        z-index: 9998;
+        box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.3);
+      }
+      .supabase-log-badge.hidden {
+        display: none;
+      }
+    `;
+    document.head.appendChild(styles);
+    badge = document.createElement('button');
+    badge.type = 'button';
+    badge.className = 'supabase-log-badge hidden';
+    badge.innerHTML = '<span class="dot"></span><span>Supabase Logs</span>';
+    badge.addEventListener('click', () => togglePanel(true));
+    panel.querySelector('.js-close').addEventListener('click', () => togglePanel(false));
+    panel.querySelector('.js-clear').addEventListener('click', clearLogs);
+    panel.querySelector('.js-autoscroll').addEventListener('change', (event) => {
+      autoScroll = event.target.checked;
+    });
+  }
+
+  const targetPanelHost = resolvePanelHost();
+  if (panel && targetPanelHost && panel.parentElement !== targetPanelHost) {
+    targetPanelHost.appendChild(panel);
+  }
+
+  const targetBadgeHost = resolveBadgeHost();
+  if (badge && targetBadgeHost && badge.parentElement !== targetBadgeHost) {
+    targetBadgeHost.appendChild(badge);
+  }
+
+  if (!keyboardListenerAttached) {
+    document.addEventListener('keydown', handleDebugShortcut);
+    keyboardListenerAttached = true;
+  }
+}
+
+function clearLogs() {
+  logs.splice(0, logs.length);
+  renderLogs();
+  updateBadge();
+  const storage = safeStorage();
+  if (storage) {
+    storage.removeItem(STORAGE_KEY);
+  }
+}
+
+function updateBadge() {
+  if (!badge) return;
+  if (!debugActive) {
+    badge.classList.add('hidden');
+    badge.innerHTML = '<span>Supabase Logs</span>';
+    return;
+  }
+  const unreadErrors = logs.filter((entry) => entry.level === 'error').length;
+  if (unreadErrors === 0) {
+    badge.classList.add('hidden');
+    badge.innerHTML = '<span>Supabase Logs</span>';
+    return;
+  }
+  badge.classList.remove('hidden');
+  badge.innerHTML = `<strong>${unreadErrors}</strong> Supabase ${unreadErrors === 1 ? 'issue' : 'issues'}`;
+}
+
+function togglePanel(forceOpen) {
+  if (!debugActive) return;
+  if (!panel) return;
+  const shouldOpen = typeof forceOpen === 'boolean' ? forceOpen : panel.hidden;
+  panel.hidden = !shouldOpen;
+  if (shouldOpen) {
+    if (autoScroll) {
+      const entriesEl = panel.querySelector('.entries');
+      entriesEl.scrollTop = entriesEl.scrollHeight;
+    }
+  }
+  updateBadge();
+}
+
+function renderLogs() {
+  if (!panel || !debugActive) return;
+  const list = panel.querySelector('.entries');
+  if (!list) return;
+  list.innerHTML = logs
+    .map((entry) => {
+      const time = new Date(entry.timestamp).toLocaleTimeString();
+      const detail = serializeDetail(entry.detail);
+      return `
+        <li class="level-${entry.level}">
+          <div class="meta">
+            <span>${time}</span>
+            <span>${entry.context}</span>
+            <span>${entry.level.toUpperCase()}</span>
+          </div>
+          <div class="message">${entry.message}</div>
+          ${detail ? `<pre class="detail">${detail}</pre>` : ''}
+        </li>
+      `;
+    })
+    .join('');
+  if (autoScroll) {
+    list.scrollTop = list.scrollHeight;
+  }
+}
+
+function initDebugPanel() {
+  if (!isBrowser()) return;
+  initSecretGestures();
+  const params = new URLSearchParams(window.location.search);
+  const storedPreference = getStoredDebugPreference();
+  if (storedPreference) {
+    activateDebug({ persist: true, open: false });
+  }
+  if (params.has('supabaseDebug')) {
+    const value = params.get('supabaseDebug');
+    const shouldPersist = value === 'persist' || value === '1';
+    const shouldOpen = value !== 'hidden';
+    activateDebug({ persist: shouldPersist ? true : null, open: shouldOpen });
+  }
+  window.supabaseDebug = {
+    toggle: () => {
+      if (!debugActive) {
+        activateDebug({ persist: null, open: true });
+      } else {
+        togglePanel();
+      }
+    },
+    show: () => {
+      if (!debugActive) {
+        activateDebug({ persist: null, open: true });
+      } else {
+        togglePanel(true);
+      }
+    },
+    hide: () => togglePanel(false),
+    enable: (options = {}) => activateDebug({ persist: options.persist ?? true, open: options.open ?? true }),
+    disable: () => deactivateDebug(),
+    export: () => logs.slice(),
+    clear: () => clearLogs(),
+    mount: (panelContainer, badgeContainer) => {
+      if (!isBrowser()) return;
+      panelHost = resolveElement(panelContainer) || null;
+      badgeHost = resolveElement(badgeContainer) || panelHost || null;
+      if (debugActive) {
+        ensurePanel();
+      }
+    },
+    isEnabled: () => debugActive,
+  };
+}
+
+if (isBrowser()) {
+  loadPersistedLogs();
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initDebugPanel);
+  } else {
+    initDebugPanel();
+  }
+}
+
+export function logSupabaseEvent(level, context, message, detail) {
+  const hasUUID = typeof globalThis !== 'undefined' && globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function';
+  pushLog({
+    id: hasUUID ? globalThis.crypto.randomUUID() : `${Date.now()}-${Math.random()}`,
+    timestamp: Date.now(),
+    level,
+    context,
+    message,
+    detail,
+  });
+}
+
+export function logSupabaseError(context, error, detail) {
+  const message = error?.message || String(error);
+  const payload = detail || {};
+  if (error?.status) payload.status = error.status;
+  if (error?.code) payload.code = error.code;
+  if (error?.stack) payload.stack = error.stack;
+  logSupabaseEvent('error', context, message, payload);
+}
+
+export function logSupabaseWarning(context, message, detail) {
+  logSupabaseEvent('warn', context, message, detail);
+}
+
+export function logSupabaseInfo(context, message, detail) {
+  logSupabaseEvent('info', context, message, detail);
+}
+
+export function getSupabaseLogs() {
+  return logs.slice();
+}
+
+function createProxy(target, context) {
+  if (!target || typeof target !== 'object' && typeof target !== 'function') {
+    return target;
+  }
+  if (proxyCache.has(target)) {
+    return proxyCache.get(target);
+  }
+  const proxy = new Proxy(target, {
+    get(original, prop, receiver) {
+      const value = Reflect.get(original, prop, receiver);
+      if (value && (typeof value === 'object' || typeof value === 'function')) {
+        if (typeof value === 'function') {
+          return async (...args) => {
+            try {
+              const result = await value.apply(original, args);
+              if (result?.error) {
+                logSupabaseError(`${context}.${String(prop)}`, result.error, {
+                  args,
+                  data: result.data,
+                });
+              }
+              return result;
+            } catch (error) {
+              logSupabaseError(`${context}.${String(prop)}`, error, {
+                args,
+              });
+              throw error;
+            }
+          };
+        }
+        return createProxy(value, `${context}.${String(prop)}`);
+      }
+      return value;
+    },
+  });
+  proxyCache.set(target, proxy);
+  return proxy;
+}
+
+export function bindSupabaseClient(client, context = 'client') {
+  if (!client) return client;
+  return createProxy(client, context);
+}
+
+function resolveElement(target) {
+  if (!target) return null;
+  if (typeof target === 'string') {
+    return document.querySelector(target);
+  }
+  if (typeof Element !== 'undefined' && target instanceof Element) {
+    return target;
+  }
+  return null;
+}
+
+function resolvePanelHost() {
+  if (!panelHost || !panelHost.isConnected) {
+    panelHost = null;
+  }
+  return panelHost || document.body;
+}
+
+function resolveBadgeHost() {
+  if (!badgeHost || !badgeHost.isConnected) {
+    badgeHost = null;
+  }
+  return badgeHost || document.body;
+}
+
+function handleDebugShortcut(event) {
+  if (!debugActive || !panel) return;
+  if ((event.ctrlKey || event.metaKey) && event.altKey && event.key.toLowerCase() === 'l') {
+    event.preventDefault();
+    togglePanel(panel.hidden);
+  }
+}
+
+function initSecretGestures() {
+  if (!isBrowser() || secretGesturesInitialized) return;
+  secretGesturesInitialized = true;
+  setupSecretTapTarget();
+  setupKonamiShortcut();
+}
+
+function setupSecretTapTarget() {
+  if (secretTapTarget && secretTapTarget.isConnected) return;
+  const target = findSecretTapTarget();
+  if (target) {
+    attachSecretTapTarget(target);
+    return;
+  }
+  if (secretTapObserver) return;
+  secretTapObserver = new MutationObserver(() => {
+    const candidate = findSecretTapTarget();
+    if (candidate) {
+      attachSecretTapTarget(candidate);
+      if (secretTapObserver) {
+        secretTapObserver.disconnect();
+        secretTapObserver = null;
+      }
+    }
+  });
+  secretTapObserver.observe(document.documentElement, { childList: true, subtree: true });
+}
+
+function findSecretTapTarget() {
+  for (const selector of SECRET_TAP_SELECTORS) {
+    const element = document.querySelector(selector);
+    if (element) return element;
+  }
+  return document.body || null;
+}
+
+function attachSecretTapTarget(target) {
+  secretTapTarget = target;
+  secretTapTarget.addEventListener('click', handleSecretTap);
+}
+
+function handleSecretTap(event) {
+  if (!secretTapTarget) return;
+  secretTapCount += 1;
+  if (secretTapTimer) {
+    clearTimeout(secretTapTimer);
+  }
+  secretTapTimer = setTimeout(resetSecretTapSequence, SECRET_TAP_WINDOW);
+  if (secretTapCount < SECRET_TAP_THRESHOLD) {
+    return;
+  }
+  resetSecretTapSequence();
+  if (!debugActive) {
+    activateDebug({ persist: null, open: true });
+  } else if (panel) {
+    togglePanel(panel.hidden);
+  }
+  event.preventDefault();
+}
+
+function resetSecretTapSequence() {
+  secretTapCount = 0;
+  if (secretTapTimer) {
+    clearTimeout(secretTapTimer);
+    secretTapTimer = null;
+  }
+}
+
+function setupKonamiShortcut() {
+  if (konamiListenerAttached) return;
+  document.addEventListener('keydown', handleKonamiShortcut, true);
+  konamiListenerAttached = true;
+}
+
+function handleKonamiShortcut(event) {
+  const key = event.key?.toLowerCase();
+  if (!key) return;
+  if (key === KONAMI_SEQUENCE[konamiIndex]) {
+    konamiIndex += 1;
+    if (konamiIndex === KONAMI_SEQUENCE.length) {
+      konamiIndex = 0;
+      if (!debugActive) {
+        activateDebug({ persist: null, open: true });
+      } else if (panel) {
+        togglePanel(panel.hidden);
+      }
+      event.preventDefault();
+    }
+    return;
+  }
+  if (key === KONAMI_SEQUENCE[0]) {
+    konamiIndex = 1;
+  } else {
+    konamiIndex = 0;
+  }
+}
+
+function getStoredDebugPreference() {
+  const storage = safeStorage();
+  if (!storage) return false;
+  return storage.getItem('supabaseDebug') === '1';
+}
+
+function setStoredDebugPreference(enabled) {
+  const storage = safeStorage();
+  if (!storage) return;
+  if (enabled) {
+    storage.setItem('supabaseDebug', '1');
+  } else {
+    storage.removeItem('supabaseDebug');
+  }
+}
+
+function activateDebug({ persist = null, open = true } = {}) {
+  if (!isBrowser()) return;
+  if (!debugActive) {
+    debugActive = true;
+    ensurePanel();
+    renderLogs();
+  }
+  if (persist === true) {
+    setStoredDebugPreference(true);
+  }
+  if (persist === false) {
+    setStoredDebugPreference(false);
+  }
+  updateBadge();
+  if (open) {
+    togglePanel(true);
+  } else if (panel) {
+    panel.hidden = true;
+  }
+}
+
+function deactivateDebug() {
+  if (!debugActive) return;
+  debugActive = false;
+  setStoredDebugPreference(false);
+  if (panel) {
+    panel.hidden = true;
+  }
+  updateBadge();
+}

--- a/membership-troubleshooting.md
+++ b/membership-troubleshooting.md
@@ -1,0 +1,97 @@
+# Membership access checklist
+
+This guide walks you through verifying that the Daren Prince membership UI is wired up correctly and explains what you need to
+configure on your end so login, registration, and logout flows are fully functional.
+
+## 1. Supply Supabase credentials
+
+The auth screens are powered entirely by your Supabase project. If the public URL and anon key are missing, the UI now keeps the
+submit buttons disabled and shows a configuration warning so visitors never see a broken flow.
+
+You can satisfy the requirement in either environment:
+
+### Local development / Netlify builds
+
+Create (or update) a `.env` file at the project root with the following keys. Netlify's build environment accepts these same
+variables directly.
+
+```bash
+SUPABASE_DATABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+```
+
+Run `npm run build` whenever you change these values so the generated `assets/js/env.js` bundle picks them up for the browser.
+
+### Direct browser overrides
+
+If you prefer to commit a checked-in configuration for staging, create `assets/js/env.js` with a default export that exposes the
+same keys:
+
+```js
+export default {
+  SUPABASE_DATABASE_URL: 'https://your-project.supabase.co',
+  SUPABASE_ANON_KEY: 'your-anon-key',
+};
+```
+
+Keep real production secrets out of the repo—reserve this pattern for disposable testing environments.
+
+### Quickly bootstrap an admin login
+
+Once credentials are in place, run the helper script to create (or elevate) your own admin account so you can reach the gated
+pages:
+
+```bash
+export SUPABASE_DATABASE_URL="https://<project>.supabase.co"
+export SUPABASE_SERVICE_ROLE_KEY="<service-role-key>"
+node scripts/bootstrap-admin.js --email you@example.com --name "Daren Prince"
+```
+
+The script confirms the account, sets your role to `admin`, and prints the password (generated when `--password` is omitted)
+so you can sign in immediately.
+
+## 2. Verify the UI states
+
+With credentials present, load `login.html` and confirm the following:
+
+- **Sign in mode** – The button is enabled immediately, and submitting with valid Supabase credentials redirects to the dashboard
+  (or the `redirect` query string target when present).
+- **Sign up mode** – The password checklist controls the button; once every requirement is green, the button activates and submits.
+- **Missing credentials** – If you intentionally remove the Supabase URL or key, the warning returns and the buttons stay disabled
+  no matter how the form is filled, preventing false positives.
+- **Logout** – The profile dropdown exposes the logout action on every page where `js/profile-dropdown.js` is loaded; it continues to
+  function independently of the admin helper classes.
+
+## 3. Review logs when something fails
+
+The Supabase logger runs silently until you opt in. Use whichever approach is most convenient when you need client-side insight:
+
+- Append `?supabaseDebug=1` to any page URL.
+- Call `window.supabaseDebug.enable()` from the console (optionally `{ persist: true }` to keep it on).
+- Multi-tap the site logo seven times or enter the Konami code (↑ ↑ ↓ ↓ ← → ← → B A) when you have access to a keyboard.
+
+Logs persist in `localStorage` under the `supabaseLogBuffer` key so you can reload, copy them via `window.supabaseDebug.export()`, and
+share them with support.
+
+## 4. Automated confidence checks
+
+Once Supabase credentials are available in the environment, run the Vitest suite to make sure real API calls succeed end-to-end:
+
+```bash
+npm test
+```
+
+The `tests/auth.spec.ts` script signs up a throwaway user, signs in, resends the verification email, and triggers a password reset
+against your live project. Skip or adjust this file if you need to avoid touching production data.
+
+## 5. Common troubleshooting steps
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Buttons stay disabled and "Supabase is not configured" message appears | Missing URL/key or build step not run | Double-check environment variables and rerun `npm run build` |
+| Sign up button never enables even with valid passwords | Confirmation field mismatch or missing symbol/number | Follow the checklist until every icon switches to a checkmark |
+| Successful login but redirect feels wrong | `redirect` query param points to a protected admin page | Confirm the target page is allowed for the signed-in role |
+| Logger never shows | Debug mode not enabled | Use any activation method in section 3 or check that `localStorage` is writable |
+
+Following the steps above ensures the membership experience works as designed and gives you a repeatable procedure for validating
+future changes.

--- a/reset-password.html
+++ b/reset-password.html
@@ -61,7 +61,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script type="module">
     import { initPasswordStrength, passwordsValid, resetPasswordStrength } from './js/password-strength.js';
-    import { getSupabase } from './js/supabase-helper.js';
+    import { getSupabase, SUPABASE_SETUP_MESSAGE } from './js/supabase-helper.js';
     const form = document.getElementById('reset-form');
     const messageEl = document.querySelector('.status-message');
     const submitBtn = document.querySelector('.js-submit');
@@ -69,8 +69,9 @@
     document.addEventListener('DOMContentLoaded', async () => {
       initPasswordStrength(submitBtn);
       resetPasswordStrength(submitBtn);
-      supabaseClient = getSupabase(() => {
-        messageEl.textContent = 'Supabase is not configured. Password reset is unavailable until deployment variables load.';
+      supabaseClient = getSupabase((message) => {
+        const notice = `${message || SUPABASE_SETUP_MESSAGE} Password reset is unavailable until deployment variables load.`;
+        messageEl.textContent = notice;
         submitBtn.disabled = true;
         document.getElementById('password').disabled = true;
         document.getElementById('confirm-password').disabled = true;
@@ -99,7 +100,7 @@
       }
       const password = document.getElementById('password').value;
       if (!supabaseClient) {
-        messageEl.textContent = 'Supabase is not configured. Password reset is unavailable.';
+        messageEl.textContent = `${SUPABASE_SETUP_MESSAGE} Password reset is unavailable.`;
         return;
       }
       const { error } = await supabaseClient.auth.updateUser({ password });

--- a/scripts/bootstrap-admin.js
+++ b/scripts/bootstrap-admin.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+import { createClient } from '@supabase/supabase-js';
+import { resolveSupabaseConfigSync } from '../supabase/env.js';
+
+function printUsage(message) {
+  if (message) {
+    console.error(`\n${message}\n`);
+  }
+  console.log(`Usage: node scripts/bootstrap-admin.js --email you@example.com [--password newpass] [--name "First Last"]`);
+  console.log('Options:');
+  console.log('  --email       Email address for the admin user (required)');
+  console.log('  --password    Password to assign (optional, random if omitted for new users)');
+  console.log('  --name        Full name to store in profile metadata (optional)');
+  console.log('  --first-name  Explicit first name override (optional)');
+  console.log('  --last-name   Explicit last name override (optional)');
+  process.exit(message ? 1 : 0);
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) continue;
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+      continue;
+    }
+    args[key] = next;
+    i += 1;
+  }
+  return args;
+}
+
+const cli = parseArgs(process.argv.slice(2));
+const email = cli.email || cli.e;
+if (!email) {
+  printUsage('Missing required --email option.');
+}
+
+const rawName = cli.name;
+const firstName = cli['first-name'] || (rawName ? rawName.split(' ')[0] : undefined);
+const lastName = cli['last-name'] || (rawName ? rawName.split(' ').slice(1).join(' ') || undefined : undefined);
+const password = cli.password === true ? undefined : cli.password;
+
+const { url } = resolveSupabaseConfigSync();
+const serviceKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.SUPABASE_SERVICE_KEY ||
+  process.env.SUPABASE_SERVICE_ROLE ||
+  process.env.SUPABASE_SERVICE_API_KEY;
+
+if (!url) {
+  printUsage('Supabase URL not found. Set SUPABASE_DATABASE_URL or NEXT_PUBLIC_SUPABASE_URL.');
+}
+
+if (!serviceKey) {
+  printUsage(
+    'Supabase service role key not found. Set SUPABASE_SERVICE_ROLE_KEY (or SUPABASE_SERVICE_KEY) before running.',
+  );
+}
+
+const adminClient = createClient(url, serviceKey, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+  },
+});
+
+async function ensureProfile(userId, names) {
+  const { data: profile } = await adminClient
+    .from('profiles')
+    .select('id, first_name, last_name, role')
+    .eq('id', userId)
+    .maybeSingle();
+
+  const payload = {
+    id: userId,
+    role: 'admin',
+    first_name: names.firstName ?? profile?.first_name ?? null,
+    last_name: names.lastName ?? profile?.last_name ?? null,
+  };
+
+  const { error } = await adminClient.from('profiles').upsert(payload, { onConflict: 'id' });
+  if (error) {
+    throw new Error(`Failed to upsert profile: ${error.message}`);
+  }
+  return payload;
+}
+
+async function main() {
+  console.log('Connecting to Supabase project:', url);
+
+  const { data: listResult, error: listError } = await adminClient.auth.admin.listUsers({
+    page: 1,
+    perPage: 200,
+    email,
+  });
+  if (listError) {
+    throw new Error(`Failed to look up user: ${listError.message}`);
+  }
+
+  const existing = listResult?.users?.find((user) => user.email?.toLowerCase() === email.toLowerCase()) || null;
+  let user = existing;
+  let generatedPassword = null;
+
+  if (!user) {
+    generatedPassword = password || `Admin-${Math.random().toString(36).slice(2, 10)}`;
+    console.log('No user found. Creating a confirmed account…');
+    const { data, error } = await adminClient.auth.admin.createUser({
+      email,
+      password: generatedPassword,
+      email_confirm: true,
+      user_metadata: {
+        role: 'admin',
+        ...(firstName ? { first_name: firstName } : {}),
+        ...(lastName ? { last_name: lastName } : {}),
+      },
+      app_metadata: {
+        role: 'admin',
+      },
+    });
+    if (error) {
+      throw new Error(`Failed to create user: ${error.message}`);
+    }
+    user = data.user;
+  } else {
+    console.log('User already exists. Updating metadata and role…');
+    const updatePayload = {
+      app_metadata: {
+        ...(user.app_metadata || {}),
+        role: 'admin',
+      },
+      user_metadata: {
+        ...(user.user_metadata || {}),
+        role: 'admin',
+        ...(firstName ? { first_name: firstName } : {}),
+        ...(lastName ? { last_name: lastName } : {}),
+      },
+    };
+    if (password) {
+      updatePayload.password = password;
+    }
+
+    const { data, error } = await adminClient.auth.admin.updateUserById(user.id, updatePayload);
+    if (error) {
+      throw new Error(`Failed to elevate user: ${error.message}`);
+    }
+    user = data.user;
+  }
+
+  const profile = await ensureProfile(user.id, { firstName, lastName });
+
+  console.log('\nAdmin bootstrap complete. Current state:');
+  console.table([
+    {
+      id: user.id,
+      email: user.email,
+      first_name: profile.first_name,
+      last_name: profile.last_name,
+      role: profile.role,
+    },
+  ]);
+
+  if (password) {
+    console.log('\nLogin with the password you supplied.');
+  } else if (generatedPassword) {
+    console.log(`\nTemporary password generated: ${generatedPassword}`);
+    console.log('Please store it securely or update the password from the Supabase dashboard.');
+  } else {
+    console.log('\nExisting password preserved.');
+  }
+
+  console.log('\nYou can now sign in at login.html and should see admin-only areas.');
+}
+
+main().catch((error) => {
+  console.error('\nAdmin bootstrap failed:', error.message);
+  process.exit(1);
+});

--- a/supabase/client.js
+++ b/supabase/client.js
@@ -1,10 +1,14 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { resolveSupabaseConfig } from './env.js';
+import { logSupabaseWarning } from '../js/supabase-logger.js';
 
 const { url, key } = await resolveSupabaseConfig();
 
 if (!url || !key) {
-  console.warn('Supabase client not configured. Check SUPABASE_DATABASE_URL and SUPABASE_ANON_KEY.');
+  logSupabaseWarning(
+    'supabase.client',
+    'Supabase client not configured. Check SUPABASE_DATABASE_URL and SUPABASE_ANON_KEY.',
+  );
 }
 
 const supabase = url && key ? createClient(url, key) : null;

--- a/verify-email.html
+++ b/verify-email.html
@@ -41,15 +41,15 @@
   </main>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script type="module">
-    import { getSupabase } from './js/supabase-helper.js';
+    import { getSupabase, SUPABASE_SETUP_MESSAGE } from './js/supabase-helper.js';
     const messageEl = document.querySelector('.status-message');
     const hashParams = new URLSearchParams(window.location.hash.slice(1));
     const searchParams = new URLSearchParams(window.location.search);
     const tokenHash = hashParams.get('token_hash') || searchParams.get('token_hash');
     const email = hashParams.get('email') || searchParams.get('email');
     const type = hashParams.get('type') || searchParams.get('type');
-    const supabaseClient = getSupabase(() => {
-      messageEl.textContent = 'Supabase is not configured. Verification will complete after deployment injects credentials.';
+    const supabaseClient = getSupabase((message) => {
+      messageEl.textContent = `${message || SUPABASE_SETUP_MESSAGE} Email verification will complete after deployment injects credentials.`;
     });
     if (!supabaseClient) {
       return;


### PR DESCRIPTION
## Summary
- add a Supabase service-key bootstrap script that can create or elevate an admin account and sync its profile row
- document how to run the helper so you can unlock admin pages immediately after supplying Supabase credentials
- surface the quick-start command in the membership troubleshooting guide for faster onboarding

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc2c700fc083259bb7c4a4f5f63c47