### PR TITLE
Implement autoplaying Vimeo hero trailer with interactive controls

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1852,33 +1852,225 @@ input:checked + .toggle-slider::before {
   overflow: hidden;
 }
 .hero .container {
-  z-index: 1;
+  position: relative;
+  z-index: 2;
 }
-.hero .hero-video {
+.hero.hero--video {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.hero.hero--video .hero-content {
+  position: relative;
+  z-index: 5;
+}
+.hero.hero--video .hero-media {
   position: absolute;
-  top: 0;
-  left: 0;
+  inset: 0;
   width: 100%;
   height: 100%;
+  overflow: hidden;
   z-index: 0;
 }
-.hero .hero-video iframe {
+.hero.hero--video .hero-image-layer,
+.hero.hero--video .hero-video-layer {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  transition: opacity 0.6s ease, visibility 0.6s ease;
+}
+.hero.hero--video .hero-image-layer {
+  z-index: 1;
+  opacity: 1;
+}
+.hero.hero--video .hero-image-layer img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  display: block;
+  transform: scale(var(--hero-scale, 1.05));
+  transition: transform 0.6s ease;
+}
+.hero.hero--video .hero-video-layer {
+  z-index: 2;
+  opacity: 0;
   pointer-events: none;
 }
-.hero .hero-mute-btn {
+.hero.hero--video .hero-video-layer__frame,
+.hero.hero--video .hero-video-layer iframe {
+  width: 100%;
+  height: 100%;
+}
+.hero.hero--video .hero-video-layer iframe {
+  border: 0;
+  object-fit: cover;
+  pointer-events: none;
+}
+.hero.hero--video.is-video-ready .hero-video-layer {
+  pointer-events: auto;
+}
+.hero.hero--video.is-video-active .hero-image-layer {
+  opacity: 0;
+}
+.hero.hero--video.is-video-active .hero-image-layer img {
+  transform: scale(1);
+}
+.hero.hero--video.is-video-active .hero-video-layer {
+  opacity: 1;
+  cursor: pointer;
+}
+.hero.hero--video.is-video-paused .hero-video-layer {
+  cursor: default;
+}
+.hero.hero--video .hero-play-overlay {
   position: absolute;
-  bottom: 1rem;
-  right: 1rem;
-  background: rgba(var(--color-black), 0.4);
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 5rem;
+  height: 5rem;
+  border-radius: 50%;
+  border: 2px solid color-mix(in srgb, var(--color-white) 80%, transparent);
+  background: rgba(0, 0, 0, 0.45);
+  color: var(--color-white);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  cursor: pointer;
+  z-index: 6;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+.hero.hero--video .hero-play-overlay:hover,
+.hero.hero--video .hero-play-overlay:focus {
+  transform: translate(-50%, -50%) scale(1.04);
+}
+.hero.hero--video .hero-play-overlay__icon {
+  font-size: 2rem;
+}
+.hero.hero--video .hero-play-overlay__spinner {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 3px solid transparent;
+  border-top-color: var(--color-lime);
+  animation: hero-spinner 1.1s linear infinite;
+  opacity: 0;
+}
+.hero.hero--video.is-loading .hero-play-overlay__spinner {
+  opacity: 1;
+}
+.hero.hero--video .hero-play-overlay.is-hidden,
+.hero.hero--video.is-video-active .hero-play-overlay {
+  opacity: 0;
+  pointer-events: none;
+}
+.hero.hero--video .hero-mute-btn {
+  position: absolute;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(0, 0, 0, 0.55);
   border: none;
   color: var(--color-white);
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.6875rem;
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
   cursor: pointer;
-  z-index: 2;
+  z-index: 6;
+  font-size: 0.875rem;
+  letter-spacing: 0.02em;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+.hero.hero--video .hero-mute-btn i {
+  font-size: 1.1rem;
+}
+.hero.hero--video:not(.is-muted) .hero-mute-btn {
+  opacity: 0;
+  pointer-events: none;
+}
+.hero.hero--video .hero-mute-btn.is-attention {
+  animation: hero-mute-pulse 0.9s ease-in-out infinite;
+}
+.hero.hero--video .hero-video-pause-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: rgba(0, 0, 0, 0.15);
+  color: var(--color-white);
+  z-index: 6;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+.hero.hero--video .hero-video-pause-overlay__center {
+  display: flex;
+  gap: 1rem;
+}
+.hero.hero--video .hero-video-pause-overlay__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+.hero.hero--video .hero-video-pause-overlay.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+.hero.hero--video .hero-video-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.65rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(0, 0, 0, 0.55);
+  color: var(--color-white);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+.hero.hero--video .hero-video-btn i {
+  font-size: 1.1rem;
+}
+.hero.hero--video .hero-video-btn:hover,
+.hero.hero--video .hero-video-btn:focus {
+  transform: translateY(-2px);
+  background: rgba(0, 0, 0, 0.75);
+}
+.hero.hero--video .hero-video-btn--primary {
+  background: var(--color-lime);
+  color: var(--gray-900);
+  border-color: transparent;
+}
+.hero.hero--video .hero-video-btn--primary:hover,
+.hero.hero--video .hero-video-btn--primary:focus {
+  background: color-mix(in srgb, var(--color-lime) 85%, var(--gray-900));
+  color: var(--gray-900);
+}
+.hero.hero--video .hero-video-icon-btn {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  background: rgba(0, 0, 0, 0.55);
+  color: var(--color-white);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+.hero.hero--video .hero-video-icon-btn:hover,
+.hero.hero--video .hero-video-icon-btn:focus {
+  transform: translateY(-2px);
+  background: rgba(0, 0, 0, 0.75);
+}
+.hero.hero--video h1 {
+  display: none;
 }
 .hero h1 {
   font-size: 2.5rem;
@@ -1900,8 +2092,10 @@ input:checked + .toggle-slider::before {
   left: 50%;
   transform: translate(-50%, -50%);
   color: var(--gray-800);
+  z-index: 7;
 }
-.hero .hero-cta:hover, .hero .hero-cta:focus {
+.hero .hero-cta:hover,
+.hero .hero-cta:focus {
   color: var(--gray-800);
 }
 .hero .hero-cta.throb {
@@ -1910,8 +2104,17 @@ input:checked + .toggle-slider::before {
 .hero.hero-auto-zoom {
   cursor: pointer;
 }
-.hero.hero--video h1 {
-  display: none;
+.hero.hero--video.hero-auto-zoom {
+  cursor: default;
+}
+.hero.hero--video.is-paused-overlay {
+  cursor: default;
+}
+.hero.hero--video.is-video-paused .hero-video-layer {
+  filter: saturate(0.9);
+}
+.hero.hero--video.is-image-active .hero-image-layer {
+  opacity: 1;
 }
 
 @keyframes fade-in {
@@ -1927,6 +2130,24 @@ input:checked + .toggle-slider::before {
   to {
     transform: translateY(0);
     opacity: 1;
+  }
+}
+
+@keyframes hero-spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes hero-mute-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(141, 214, 121, 0.45);
+  }
+  50% {
+    transform: scale(1.06);
+    box-shadow: 0 0 0 0.8rem rgba(141, 214, 121, 0);
   }
 }
 @keyframes cta-throb {

--- a/index.html
+++ b/index.html
@@ -113,7 +113,55 @@
     <!-- ⚙️ Site Maintenance Landing Page for DarenPrince.com -->
 
     <!-- 1. Hero Section -->
-    <section id="autoZoomHero" class="hero hero-auto-zoom text-center">
+    <section
+      id="autoZoomHero"
+      class="hero hero-auto-zoom hero--video text-center is-loading is-image-active"
+      data-video-id="1120030283"
+    >
+      <div class="hero-media">
+        <div class="hero-image-layer js-hero-image" role="presentation">
+          <img
+            src="assets/images/heroposter1.png"
+            alt="Cover art for the Game On! trailer"
+            loading="lazy"
+          />
+        </div>
+        <div class="hero-video-layer js-hero-video" aria-hidden="true">
+          <div class="hero-video-layer__frame" id="heroVideoFrame"></div>
+        </div>
+        <button class="hero-play-overlay js-hero-play" type="button" aria-label="Play the Game On! book trailer">
+          <span class="hero-play-overlay__spinner" aria-hidden="true"></span>
+          <span class="hero-play-overlay__icon ti ti-player-play-filled" aria-hidden="true"></span>
+          <span class="visually-hidden">Play trailer</span>
+        </button>
+        <button class="hero-mute-btn js-hero-mute" type="button" aria-label="Unmute trailer audio">
+          <i class="ti ti-volume"></i>
+          <span>Sound On</span>
+        </button>
+        <div class="hero-video-pause-overlay js-hero-pause-overlay" hidden>
+          <div class="hero-video-pause-overlay__center">
+            <button class="hero-video-btn hero-video-btn--primary js-hero-resume" type="button">
+              <i class="ti ti-player-play-filled" aria-hidden="true"></i>
+              <span>Resume</span>
+            </button>
+            <button class="hero-video-btn js-hero-restart" type="button">
+              <i class="ti ti-rotate-clockwise" aria-hidden="true"></i>
+              <span>Restart</span>
+            </button>
+          </div>
+          <div class="hero-video-pause-overlay__actions">
+            <button class="hero-video-icon-btn js-hero-fullscreen" type="button" aria-label="Fullscreen trailer">
+              <i class="ti ti-maximize" aria-hidden="true"></i>
+            </button>
+            <button class="hero-video-icon-btn js-hero-airplay" type="button" aria-label="AirPlay trailer">
+              <i class="ti ti-brand-airplay" aria-hidden="true"></i>
+            </button>
+            <button class="hero-video-icon-btn js-hero-close" type="button" aria-label="Close trailer">
+              <i class="ti ti-x" aria-hidden="true"></i>
+            </button>
+          </div>
+        </div>
+      </div>
       <div class="container max-width-adaptive-lg hero-content">
         <h1 style="display:none;">Daren Prince | Author. Strategist. Storyteller.</h1>
         <a href="#book-3d-viewer" class="btn grad-kelly-green hero-cta throb"><strong>Get The Book</strong></a>
@@ -378,6 +426,8 @@
   <script src="./js/theme-toggle.js"></script>
   <script type="module" src="./js/book-3d-viewer.js"></script>
   <script src="./js/book-details.js"></script>
+  <script src="https://player.vimeo.com/api/player.js" defer></script>
+  <script src="./js/hero-video-controller.js" defer></script>
   <script src="./js/hero-auto-zoom.js"></script>
   <script type="module" src="./js/main.js"></script>
   </body>

--- a/js/hero-auto-zoom.js
+++ b/js/hero-auto-zoom.js
@@ -23,10 +23,11 @@ document.addEventListener('DOMContentLoaded', () => {
   window.addEventListener('scroll', onScroll);
   onScroll();
 
+  const isVideoHero = hero.classList.contains('hero--video');
   const cta = hero.querySelector('.hero-cta');
   const targetSelector = cta ? cta.getAttribute('href') : null;
   const targetEl = targetSelector ? document.querySelector(targetSelector) : null;
-  if (targetEl) {
+  if (targetEl && !isVideoHero) {
     hero.addEventListener('click', (e) => {
       e.preventDefault();
       targetEl.scrollIntoView({ behavior: 'smooth' });

--- a/js/hero-video-controller.js
+++ b/js/hero-video-controller.js
@@ -1,0 +1,237 @@
+(() => {
+  const initHeroVideo = () => {
+    const hero = document.querySelector('#autoZoomHero.hero--video');
+    if (!hero) return;
+    if (typeof window.Vimeo === 'undefined' || !window.Vimeo.Player) return;
+
+    const videoId = parseInt(hero.dataset.videoId || '', 10);
+    if (!videoId) return;
+
+    const frame = hero.querySelector('.hero-video-layer__frame');
+    if (!frame) return;
+
+    const videoLayer = hero.querySelector('.js-hero-video');
+    const playOverlay = hero.querySelector('.js-hero-play');
+    const muteButton = hero.querySelector('.js-hero-mute');
+    const pauseOverlay = hero.querySelector('.js-hero-pause-overlay');
+    const resumeBtn = hero.querySelector('.js-hero-resume');
+    const restartBtn = hero.querySelector('.js-hero-restart');
+    const closeBtn = hero.querySelector('.js-hero-close');
+    const fullscreenBtn = hero.querySelector('.js-hero-fullscreen');
+    const airplayBtn = hero.querySelector('.js-hero-airplay');
+
+    const player = new window.Vimeo.Player(frame, {
+      id: videoId,
+      autopause: false,
+      autoplay: true,
+      background: false,
+      controls: false,
+      muted: true,
+      loop: false,
+      responsive: true,
+      portrait: false,
+      title: false,
+      byline: false,
+      playsinline: true
+    });
+
+    let pauseReason = null;
+    let muteAttentionTimer;
+
+    const setLoading = (isLoading) => {
+      hero.classList.toggle('is-loading', Boolean(isLoading));
+    };
+
+    const showPlayOverlay = () => {
+      if (playOverlay) {
+        playOverlay.classList.remove('is-hidden');
+      }
+    };
+
+    const hidePlayOverlay = () => {
+      if (playOverlay) {
+        playOverlay.classList.add('is-hidden');
+      }
+    };
+
+    const showPauseOverlay = () => {
+      if (!pauseOverlay) return;
+      pauseOverlay.hidden = false;
+      requestAnimationFrame(() => {
+        pauseOverlay.classList.add('is-visible');
+      });
+      hero.classList.add('is-paused-overlay');
+    };
+
+    const hidePauseOverlay = () => {
+      if (!pauseOverlay) return;
+      pauseOverlay.classList.remove('is-visible');
+      pauseOverlay.hidden = true;
+      hero.classList.remove('is-paused-overlay');
+    };
+
+    const updateMuteState = () => {
+      if (!muteButton) return;
+      player
+        .getMuted()
+        .then((muted) => {
+          hero.classList.toggle('is-muted', muted);
+          if (muted) {
+            muteButton.classList.add('is-attention');
+            clearTimeout(muteAttentionTimer);
+            muteAttentionTimer = window.setTimeout(() => {
+              muteButton.classList.remove('is-attention');
+            }, 6000);
+          } else {
+            muteButton.classList.remove('is-attention');
+          }
+        })
+        .catch(() => {});
+    };
+
+    player
+      .ready()
+      .then(() => {
+        hero.classList.add('is-video-ready');
+        return player.play();
+      })
+      .catch(() => {
+        setLoading(false);
+        showPlayOverlay();
+      });
+
+    player.on('loaded', () => {
+      hero.classList.add('is-video-ready');
+    });
+
+    player.on('bufferstart', () => setLoading(true));
+    player.on('bufferend', () => setLoading(false));
+
+    player.on('play', () => {
+      hidePauseOverlay();
+      hero.classList.add('is-video-active', 'is-video-playing');
+      hero.classList.remove('is-video-paused', 'is-image-active');
+      setLoading(false);
+      hidePlayOverlay();
+      updateMuteState();
+    });
+
+    player.on('pause', () => {
+      hero.classList.remove('is-video-playing');
+      hero.classList.add('is-video-paused');
+      if (pauseReason === 'overlay') {
+        showPauseOverlay();
+      } else if (pauseReason === 'close') {
+        hero.classList.remove('is-video-active');
+        hero.classList.add('is-image-active');
+        showPlayOverlay();
+      }
+      pauseReason = null;
+    });
+
+    player.on('ended', () => {
+      pauseReason = null;
+      hidePauseOverlay();
+      hero.classList.remove('is-video-active', 'is-video-playing', 'is-video-paused');
+      hero.classList.add('is-image-active');
+      showPlayOverlay();
+      player.setCurrentTime(0).catch(() => {});
+    });
+
+    player.on('volumechange', updateMuteState);
+
+    if (videoLayer) {
+      videoLayer.addEventListener('click', (event) => {
+        if (!hero.classList.contains('is-video-active')) return;
+        if (hero.classList.contains('is-video-paused')) return;
+        if (pauseOverlay && pauseOverlay.contains(event.target)) return;
+        pauseReason = 'overlay';
+        player.pause();
+      });
+    }
+
+    if (playOverlay) {
+      playOverlay.addEventListener('click', () => {
+        hero.classList.remove('is-image-active');
+        pauseReason = null;
+        setLoading(true);
+        hidePlayOverlay();
+        player.play().catch(() => {
+          setLoading(false);
+          showPlayOverlay();
+        });
+      });
+    }
+
+    if (resumeBtn) {
+      resumeBtn.addEventListener('click', () => {
+        hidePauseOverlay();
+        pauseReason = null;
+        player.play();
+      });
+    }
+
+    if (restartBtn) {
+      restartBtn.addEventListener('click', () => {
+        player
+          .setCurrentTime(0)
+          .then(() => player.play())
+          .catch(() => {});
+      });
+    }
+
+    if (closeBtn) {
+      closeBtn.addEventListener('click', () => {
+        hidePauseOverlay();
+        pauseReason = 'close';
+        player
+          .pause()
+          .then(() => player.setCurrentTime(0))
+          .catch(() => {});
+      });
+    }
+
+    if (fullscreenBtn) {
+      fullscreenBtn.addEventListener('click', () => {
+        if (typeof player.requestFullscreen === 'function') {
+          player.requestFullscreen().catch(() => {});
+        }
+      });
+    }
+
+    if (airplayBtn) {
+      airplayBtn.addEventListener('click', () => {
+        if (typeof player.requestAirplay === 'function') {
+          player.requestAirplay().catch(() => {});
+        } else if (typeof player.requestPictureInPicture === 'function') {
+          player.requestPictureInPicture().catch(() => {});
+        }
+      });
+    }
+
+    if (muteButton) {
+      muteButton.addEventListener('click', () => {
+        player
+          .setMuted(false)
+          .then(() => player.setVolume(1))
+          .then(() => {
+            hero.classList.remove('is-muted');
+            muteButton.classList.remove('is-attention');
+            muteButton.setAttribute('aria-pressed', 'true');
+            setTimeout(() => {
+              if (muteButton) {
+                muteButton.blur();
+              }
+            }, 200);
+          })
+          .catch(() => {});
+      });
+    }
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initHeroVideo, { once: true });
+  } else {
+    initHeroVideo();
+  }
+})();


### PR DESCRIPTION
## Summary
- replace the hero masthead markup with a dual-state image/video layout that hosts the Vimeo trailer and new overlay controls
- expand the hero styling to handle fades, loading animation, pause overlay actions, and persistent CTA placement
- add a dedicated Vimeo player controller script and update the auto-zoom helper to coexist with the interactive hero

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cd05c6f09c83259b19b68cfb5d50df