### PR TITLE
Support runtime Supabase env overrides

### DIFF
--- a/membership-troubleshooting.md
+++ b/membership-troubleshooting.md
@@ -25,13 +25,19 @@ Run `npm run build` whenever you change these values so the generated `assets/js
 ### Direct browser overrides
 
 If you prefer to commit a checked-in configuration for staging, create `assets/js/env.js` with a default export that exposes the
-same keys:
+same keys (or provide a runtime object on `window._env_`, which the resolver now inspects automatically):
 
 ```js
 export default {
   SUPABASE_DATABASE_URL: 'https://your-project.supabase.co',
   SUPABASE_ANON_KEY: 'your-anon-key',
-};
+}
+
+// Runtime-only alternative (e.g., injected before other scripts run)
+window._env_ = {
+  SUPABASE_DATABASE_URL: 'https://your-project.supabase.co',
+  SUPABASE_ANON_KEY: 'your-anon-key',
+}
 ```
 
 Keep real production secrets out of the repo—reserve this pattern for disposable testing environments.
@@ -86,12 +92,12 @@ against your live project. Skip or adjust this file if you need to avoid touchin
 
 ## 5. Common troubleshooting steps
 
-| Symptom | Likely cause | Fix |
-| --- | --- | --- |
-| Buttons stay disabled and "Supabase is not configured" message appears | Missing URL/key or build step not run | Double-check environment variables and rerun `npm run build` |
-| Sign up button never enables even with valid passwords | Confirmation field mismatch or missing symbol/number | Follow the checklist until every icon switches to a checkmark |
-| Successful login but redirect feels wrong | `redirect` query param points to a protected admin page | Confirm the target page is allowed for the signed-in role |
-| Logger never shows | Debug mode not enabled | Use any activation method in section 3 or check that `localStorage` is writable |
+| Symptom                                                                | Likely cause                                            | Fix                                                                             |
+| ---------------------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Buttons stay disabled and "Supabase is not configured" message appears | Missing URL/key or build step not run                   | Double-check environment variables and rerun `npm run build`                    |
+| Sign up button never enables even with valid passwords                 | Confirmation field mismatch or missing symbol/number    | Follow the checklist until every icon switches to a checkmark                   |
+| Successful login but redirect feels wrong                              | `redirect` query param points to a protected admin page | Confirm the target page is allowed for the signed-in role                       |
+| Logger never shows                                                     | Debug mode not enabled                                  | Use any activation method in section 3 or check that `localStorage` is writable |
 
 Following the steps above ensures the membership experience works as designed and gives you a repeatable procedure for validating
 future changes.

--- a/tests/supabase-env.spec.ts
+++ b/tests/supabase-env.spec.ts
@@ -1,82 +1,109 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { resolveSupabaseConfigSync } from '../supabase/env.js';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { resolveSupabaseConfig, resolveSupabaseConfigSync } from '../supabase/env.js'
 
 const SUPABASE_URL_KEYS = [
   'SUPABASE_DATABASE_URL',
   'NEXT_PUBLIC_SUPABASE_URL',
   'NEXT_PUBLIC_SUPABASE_DATABASE_URL',
-];
+]
 
 const SUPABASE_KEY_KEYS = [
   'SUPABASE_SERVICE_ROLE_KEY',
   'SUPABASE_ANON_KEY',
   'SUPABASE_PUBLIC_ANON_KEY',
   'NEXT_PUBLIC_SUPABASE_ANON_KEY',
-];
+]
 
-const originalEnv = { ...process.env };
+const originalEnv = { ...process.env }
 
 function resetEnv() {
   for (const key of Object.keys(process.env)) {
     if (!(key in originalEnv)) {
-      delete process.env[key];
+      delete process.env[key]
     }
   }
   for (const [key, value] of Object.entries(originalEnv)) {
     if (value === undefined) {
-      delete process.env[key];
+      delete process.env[key]
     } else {
-      process.env[key] = value;
+      process.env[key] = value
     }
+  }
+  if (typeof globalThis !== 'undefined') {
+    delete globalThis._env_
   }
 }
 
 function clearSupabaseKeys() {
   for (const key of [...SUPABASE_URL_KEYS, ...SUPABASE_KEY_KEYS]) {
-    delete process.env[key];
+    delete process.env[key]
   }
 }
 
 beforeEach(() => {
-  resetEnv();
-  clearSupabaseKeys();
-});
+  resetEnv()
+  clearSupabaseKeys()
+})
 
 afterEach(() => {
-  resetEnv();
-});
+  resetEnv()
+})
 
 describe('resolveSupabaseConfigSync', () => {
   it('returns empty strings when env vars are missing', () => {
-    const config = resolveSupabaseConfigSync();
-    expect(config.url).toBe('');
-    expect(config.key).toBe('');
-  });
+    const config = resolveSupabaseConfigSync()
+    expect(config.url).toBe('')
+    expect(config.key).toBe('')
+  })
 
   it('prefers service role keys over anon', () => {
-    process.env.SUPABASE_DATABASE_URL = 'https://example.supabase.co';
-    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
-    process.env.SUPABASE_ANON_KEY = 'anon-key';
+    process.env.SUPABASE_DATABASE_URL = 'https://example.supabase.co'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key'
+    process.env.SUPABASE_ANON_KEY = 'anon-key'
 
-    const config = resolveSupabaseConfigSync();
-    expect(config.url).toBe('https://example.supabase.co');
-    expect(config.key).toBe('service-key');
-  });
+    const config = resolveSupabaseConfigSync()
+    expect(config.url).toBe('https://example.supabase.co')
+    expect(config.key).toBe('service-key')
+  })
 
   it('falls back to anon key when service role is missing', () => {
-    process.env.SUPABASE_DATABASE_URL = 'https://example.supabase.co';
-    process.env.SUPABASE_ANON_KEY = 'anon-key';
+    process.env.SUPABASE_DATABASE_URL = 'https://example.supabase.co'
+    process.env.SUPABASE_ANON_KEY = 'anon-key'
 
-    const config = resolveSupabaseConfigSync();
-    expect(config.key).toBe('anon-key');
-  });
+    const config = resolveSupabaseConfigSync()
+    expect(config.key).toBe('anon-key')
+  })
 
   it('supports NEXT_PUBLIC aliases when primary keys are absent', () => {
-    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://alias.supabase.co';
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'alias-anon';
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://alias.supabase.co'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'alias-anon'
 
-    const config = resolveSupabaseConfigSync();
-    expect(config.url).toBe('https://alias.supabase.co');
-    expect(config.key).toBe('alias-anon');
-  });
-});
+    const config = resolveSupabaseConfigSync()
+    expect(config.url).toBe('https://alias.supabase.co')
+    expect(config.key).toBe('alias-anon')
+  })
+
+  it('reads credentials from global runtime overrides', () => {
+    globalThis._env_ = {
+      SUPABASE_DATABASE_URL: 'https://runtime.supabase.co',
+      SUPABASE_ANON_KEY: 'runtime-anon',
+    }
+
+    const config = resolveSupabaseConfigSync()
+    expect(config.url).toBe('https://runtime.supabase.co')
+    expect(config.key).toBe('runtime-anon')
+  })
+})
+
+describe('resolveSupabaseConfig (async)', () => {
+  it('merges browser env module with global overrides', async () => {
+    globalThis._env_ = {
+      NEXT_PUBLIC_SUPABASE_URL: 'https://global.supabase.co',
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: 'global-anon',
+    }
+
+    const config = await resolveSupabaseConfig()
+    expect(config.url).toBe('https://global.supabase.co')
+    expect(config.key).toBe('global-anon')
+  })
+})


### PR DESCRIPTION
## Summary
- merge Supabase env resolution from node/deno, generated env.js, and runtime window._env_ overrides
- cover the new runtime fallback in the env resolver vitest suite
- document the window._env_ option in the membership troubleshooting guide

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d0446541088325b57d00740f6bf11e