### PR TITLE
Align loader page with brand colors

### DIFF
--- a/loaders.html
+++ b/loaders.html
@@ -14,7 +14,11 @@
 
     body.theme-dark {
       font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      background: radial-gradient(circle at top, rgba(25, 28, 41, 0.9), #07070d 70%);
+      background: radial-gradient(
+        circle at 15% -10%,
+        color-mix(in srgb, var(--brand-green-600) 45%, rgba(5, 8, 5, 0.35)) 0%,
+        rgba(5, 8, 5, 0.92) 65%
+      );
       color: #f5f7ff;
       min-height: 100vh;
     }
@@ -39,7 +43,7 @@
     }
 
     .page-header p {
-      color: rgba(232, 241, 255, 0.72);
+      color: color-mix(in srgb, #f5f7ff 78%, var(--brand-green-200) 22%);
       font-size: clamp(1rem, 2vw, 1.125rem);
       line-height: 1.7;
     }
@@ -53,10 +57,14 @@
     }
 
     .loader-card {
-      background: rgba(12, 14, 24, 0.85);
-      border: 1px solid rgba(118, 130, 199, 0.1);
+      background: linear-gradient(
+        155deg,
+        color-mix(in srgb, rgba(5, 9, 5, 0.92) 85%, var(--brand-green-700) 15%),
+        color-mix(in srgb, rgba(5, 8, 5, 0.92) 60%, var(--brand-green-500) 40%)
+      );
+      border: 1px solid color-mix(in srgb, rgba(255, 255, 255, 0.05) 60%, var(--brand-green-600) 40%);
       border-radius: 24px;
-      box-shadow: 0 35px 60px -35px rgba(0, 0, 0, 0.65);
+      box-shadow: 0 35px 60px -35px rgba(12, 23, 14, 0.75);
       padding: clamp(1.75rem, 3vw, 2.5rem);
       display: flex;
       flex-direction: column;
@@ -71,7 +79,7 @@
     }
 
     .loader-card p {
-      color: rgba(232, 241, 255, 0.65);
+      color: color-mix(in srgb, #f5f7ff 70%, var(--brand-green-200) 30%);
       font-size: 0.95rem;
       line-height: 1.6;
     }
@@ -83,7 +91,11 @@
       min-height: 180px;
       padding: 1rem;
       border-radius: 18px;
-      background: linear-gradient(135deg, rgba(26, 31, 47, 0.95), rgba(11, 14, 24, 0.9));
+      background: linear-gradient(
+        135deg,
+        color-mix(in srgb, rgba(6, 12, 6, 0.95) 60%, var(--brand-green-700) 40%),
+        color-mix(in srgb, rgba(5, 10, 5, 0.92) 40%, var(--brand-green-400) 60%)
+      );
       position: relative;
       overflow: hidden;
     }
@@ -110,7 +122,11 @@
       width: 100%;
       height: 100%;
       z-index: 9999;
-      background: radial-gradient(circle at top, rgba(40, 48, 80, 0.7), rgba(5, 6, 12, 0.96));
+      background: radial-gradient(
+        circle at 25% -10%,
+        color-mix(in srgb, var(--brand-green-500) 55%, rgba(5, 8, 5, 0.4)) 0%,
+        rgba(5, 8, 5, 0.96) 70%
+      );
       transition: opacity 0.5s ease-out;
     }
 
@@ -125,7 +141,7 @@
 
     .loading-logo span {
       display: inline-block;
-      background: linear-gradient(120deg, #f9f7f7 0%, #7f8cff 40%, #54ffe5 100%);
+      background: linear-gradient(120deg, #f4fff0 0%, var(--brand-green-200) 35%, var(--brand-green-500) 65%, var(--brand-green-700) 100%);
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
       animation: pulse 1.6s infinite;
@@ -142,16 +158,16 @@
       width: 1.75em;
       height: 1em;
       transform: translateX(-50%);
-      background: linear-gradient(135deg, #ffd166, #ff6f61);
+      background: linear-gradient(135deg, var(--brand-green-400), color-mix(in srgb, var(--brand-green-200) 35%, var(--brand-green-700) 65%));
       clip-path: polygon(10% 100%, 18% 40%, 35% 85%, 50% 20%, 65% 85%, 82% 40%, 90% 100%);
-      box-shadow: 0 8px 25px rgba(255, 166, 0, 0.35);
+      box-shadow: 0 8px 25px color-mix(in srgb, var(--brand-green-500) 35%, rgba(0, 0, 0, 0.65));
       animation: crown-sparkle 1.8s ease-in-out infinite;
     }
 
     .loading-bar {
       width: clamp(220px, 40vw, 320px);
       height: 6px;
-      background: rgba(255, 255, 255, 0.12);
+      background: color-mix(in srgb, rgba(255, 255, 255, 0.14) 70%, rgba(0, 0, 0, 0.6) 30%);
       border-radius: 999px;
       overflow: hidden;
       position: relative;
@@ -161,7 +177,7 @@
       content: '';
       position: absolute;
       inset: 0;
-      background: linear-gradient(90deg, transparent, #7f8cff, #54ffe5, transparent);
+      background: linear-gradient(90deg, transparent, var(--brand-green-400), var(--brand-green-200), transparent);
       transform: translateX(-100%);
       animation: bar-sweep 1.35s ease-in-out infinite;
     }
@@ -177,17 +193,17 @@
       position: absolute;
       width: 100%;
       height: 100%;
-      border: 2px solid rgba(84, 255, 229, 0.4);
+      border: 2px solid color-mix(in srgb, var(--brand-green-400) 70%, transparent);
       border-radius: 18px;
-      box-shadow: 0 0 25px rgba(84, 255, 229, 0.35);
+      box-shadow: 0 0 25px color-mix(in srgb, var(--brand-green-400) 55%, rgba(0, 0, 0, 0.35));
       transform: scale(0.2) rotate(0deg);
       opacity: 0;
       animation: geo-expand 2.8s ease-in-out infinite;
     }
 
     .line-segment.line-2 {
-      border-color: rgba(127, 140, 255, 0.45);
-      box-shadow: 0 0 35px rgba(127, 140, 255, 0.4);
+      border-color: color-mix(in srgb, var(--brand-green-200) 75%, transparent);
+      box-shadow: 0 0 35px color-mix(in srgb, var(--brand-green-200) 60%, rgba(0, 0, 0, 0.35));
       animation-delay: 1.4s;
     }
 
@@ -206,16 +222,17 @@
     .loading-text text {
       font-size: 64px;
       font-family: 'League Spartan', sans-serif;
+      stroke: var(--brand-green-200);
       stroke-dasharray: 260;
       stroke-dashoffset: 260;
       animation: text-trace 3s ease-in-out infinite;
-      filter: drop-shadow(0 0 14px rgba(84, 255, 229, 0.55));
+      filter: drop-shadow(0 0 18px color-mix(in srgb, var(--brand-green-400) 70%, rgba(0, 0, 0, 0.25)));
     }
 
     .glow-sweep {
       position: absolute;
       inset: 0;
-      background: radial-gradient(circle at 0% 50%, rgba(127, 140, 255, 0.3), transparent 55%);
+      background: radial-gradient(circle at 0% 50%, color-mix(in srgb, var(--brand-green-200) 40%, transparent), transparent 55%);
       animation: glow-slide 3s ease-in-out infinite;
       mix-blend-mode: screen;
     }
@@ -227,30 +244,30 @@
     }
 
     .actions button {
-      background: linear-gradient(135deg, #7f8cff, #54ffe5);
+      background: linear-gradient(135deg, var(--brand-green-700), var(--brand-green-400));
       border: none;
-      color: #05060a;
+      color: var(--color-white);
       font-weight: 600;
       padding: 0.9rem 1.75rem;
       border-radius: 999px;
       cursor: pointer;
       transition: transform 0.3s ease, box-shadow 0.3s ease;
-      box-shadow: 0 18px 30px -18px rgba(84, 255, 229, 0.6);
+      box-shadow: 0 18px 30px -18px color-mix(in srgb, var(--brand-green-500) 70%, rgba(0, 0, 0, 0.65));
     }
 
     .actions button:hover {
       transform: translateY(-2px);
-      box-shadow: 0 26px 45px -22px rgba(84, 255, 229, 0.75);
+      box-shadow: 0 26px 45px -22px color-mix(in srgb, var(--brand-green-200) 65%, rgba(0, 0, 0, 0.55));
     }
 
     @keyframes pulse {
       0%, 100% {
         transform: translateY(0);
-        filter: drop-shadow(0 0 15px rgba(127, 140, 255, 0.6));
+        filter: drop-shadow(0 0 15px color-mix(in srgb, var(--brand-green-400) 65%, rgba(0, 0, 0, 0.35)));
       }
       50% {
         transform: translateY(-6px);
-        filter: drop-shadow(0 0 30px rgba(84, 255, 229, 0.75));
+        filter: drop-shadow(0 0 30px color-mix(in srgb, var(--brand-green-200) 70%, rgba(0, 0, 0, 0.2)));
       }
     }
 
@@ -302,10 +319,10 @@
       }
       45% {
         stroke-dashoffset: 0;
-        fill: rgba(84, 255, 229, 0.25);
+        fill: color-mix(in srgb, var(--brand-green-200) 45%, transparent);
       }
       60% {
-        fill: rgba(84, 255, 229, 0.65);
+        fill: color-mix(in srgb, var(--brand-green-200) 45%, var(--brand-green-500) 55%);
       }
       100% {
         stroke-dashoffset: -260;
@@ -398,7 +415,7 @@ iggers that deserve an extra hit of drama.</p>
           <div class="loading-screen">
             <div class="neon-loader">
               <svg class="loading-text" viewBox="0 0 200 100">
-                <text x="10" y="70" fill="none" stroke="#54ffe5" stroke-width="2">DP</text>
+                <text x="10" y="70" fill="none" stroke-width="2">DP</text>
               </svg>
               <div class="glow-sweep"></div>
             </div>


### PR DESCRIPTION
## Summary
- restyle the loaders landing page with brand-first backgrounds and content treatments that reference existing green tokens
- refresh each loader animation and control element to use branded gradients, lighting, and glow effects instead of the previous cyan/blue palette

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0441095e483258846f6ef152a2e8e