### PR TITLE
docs: cover supabase http queue and storage metadata

### DIFF
--- a/docs/CHANGELOG_DOC_SYNC.md
+++ b/docs/CHANGELOG_DOC_SYNC.md
@@ -2,7 +2,14 @@
 
 > Tracks documentation updates made during the 2025-02-14 audit.
 
+## 2025-02-16 — Supabase background job coverage
+
+- Documented Supabase-managed HTTP queue + response tables across integration docs.
+- Captured storage analytics/multipart metadata tables in quick reference + playbook.
+- Refreshed timestamps on Supabase docs to reflect new capabilities.
+
 ## 2025-02-14 — Full documentation realignment
+
 - Rebuilt the site audit report with fresh metrics, mismatch matrix, and backlog checkpoints.
 - Rewrote README, site structure, file map, style guide, and component catalog to reflect the current Sass, JS, and page inventory.
 - Updated build pipeline, Supabase guides (root + playbook), navigation overview, and indexing strategy with accurate scripts and environment expectations.
@@ -10,12 +17,14 @@
 - Added quick-reference notes to `docs/supabase.md` and aligned duplicate guides to the new canonical sources.
 
 ## 2025-02-13 — Audit refresh & doc corrections
+
 - Re-ran full repo scan; updated `docs/REPORT_SITE_DOC_AUDIT.md` with current metrics, citations, and refreshed backlog.
 - Synced `docs/SITE_STRUCTURE.md` + `docs/UI_COMPONENTS.md` to reference `js/main.js` as the component nav controller.
 - Updated style, build, and Supabase guides with the 2025-02-13 timestamp to reflect latest audit.
 - Extended mismatch tracking for stale README guidance (`.container--dark`, `npm run build`) and legacy Supabase project IDs.
 
 ## 2025-09-18 — Repo & docs realignment
+
 - Added `docs/REPORT_SITE_DOC_AUDIT.md` with scan metrics, mismatch catalog, and next-step backlog.
 - Authored `docs/SITE_STRUCTURE.md` to document the actual directory tree, page inventory, and module map.
 - Published `docs/STYLE_GUIDE.md` consolidating tokens, typography, spacing, and heading usage reality checks.

--- a/docs/supabase.md
+++ b/docs/supabase.md
@@ -5,7 +5,8 @@ The canonical integration guide lives in [`docs/SUPABASE_INTEGRATION.md`](SUPABA
 - **Project:** Configure via env vars (`SUPABASE_DATABASE_URL`, `SUPABASE_ANON_KEY`); no IDs are hard-coded.
 - **Key surfaces:** `js/auth-guard.js`, `admin-user-management.html`, `dashboard.html`, `supabase/functions/*`.
 - **Edge functions:** `admin-users` (user admin API) and `secure-storage` (uploads).
-- **Buckets:** `avatars` (public) and `user-data` (private) with per-user RLS.
+- **Buckets:** `avatars` (public) and `user-data` (private) with per-user RLS; analytics + multipart metadata available via `storage.*` tables for diagnostics.
+- **Background jobs:** `net.http_request_queue` + `net._http_response` now enabled for async webhooks (enqueue via `net.http_enqueue`).
 - **Latest schema upgrades:** profile sync trigger refresh, folder access policies, `private.admin_action_log`.
 - **Troubleshooting:** Use `js/supabase-logger.js` (Konami/tap overlay) and run `npm test` for env coverage.
 

--- a/docs/supabase/README.md
+++ b/docs/supabase/README.md
@@ -1,6 +1,6 @@
 # 🔐 Supabase Control Playbook
 
-_Last updated: 2025-02-14_
+_Last updated: 2025-02-16_
 
 This playbook expands on the quick reference with schema details, access model, and operational steps. It assumes credentials are supplied via environment variables (no project IDs are hard-coded).
 
@@ -52,6 +52,19 @@ Aliases (`SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_
 
 - `avatars` (public) — stores `<user_id>.jpg`; policies restrict CRUD to the owner.
 - `user-data` (private) — stores `<user_id>/<filename>` tree; policies enforce prefix-based ownership.
+
+### Storage metadata tables
+
+- `storage.objects`, `storage.prefixes`, and `storage.buckets_analytics` expose bucket structure for tooling and analytics.
+- Multipart uploads land in `storage.s3_multipart_uploads` + `storage.s3_multipart_uploads_parts`; Supabase manages lifecycle—query for diagnostics only.
+- `storage.migrations` tracks Supabase storage engine upgrades; do not edit manually.
+
+### HTTP request queue & responses
+
+- `net.http_request_queue` is now enabled for background webhooks (email, CRM, analytics) without custom workers.
+- Enqueue jobs from SQL or PostgREST via `net.http_enqueue` and let Supabase execute them asynchronously.
+- Delivery metadata persists in `net._http_response` (status code, headers, body, error messages, timeout flag).
+- Join queue rows with responses to build dashboards, retries, or alerting.
 
 ### Validation checklist
 


### PR DESCRIPTION
## Summary
- highlight the newly enabled Supabase HTTP request queue and response catalog across integration docs
- document Supabase storage metadata tables for analytics and multipart upload diagnostics
- log the doc refresh in the documentation changelog with a 2025-02-16 entry

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d0d044713c8325bc78578053b44dc9