### PR TITLE
Fix generated icon transparency

### DIFF
--- a/All-heroes-demos.html
+++ b/All-heroes-demos.html
@@ -63,7 +63,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -180,4 +180,5 @@
   <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>
+
 

--- a/Picdetective/analysis.html
+++ b/Picdetective/analysis.html
@@ -64,7 +64,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -1213,4 +1213,5 @@
 <script src="script.js"></script>
 </body>
 </html>
+
 

--- a/Picdetective/index.html
+++ b/Picdetective/index.html
@@ -64,7 +64,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -1213,4 +1213,5 @@
 <script src="script.js"></script>
 </body>
 </html>
+
 

--- a/Picdetective/privacy.html
+++ b/Picdetective/privacy.html
@@ -63,7 +63,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -77,4 +77,5 @@
 <p>&copy; 2025 Daren Prince</p>
 </body>
 </html>
+
 

--- a/Picdetective/reset.html
+++ b/Picdetective/reset.html
@@ -63,7 +63,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -94,4 +94,5 @@
 </script>
 </body>
 </html>
+
 

--- a/Picdetective/summary.html
+++ b/Picdetective/summary.html
@@ -64,7 +64,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -203,4 +203,5 @@
 <script src="script.js"></script>
 </body>
 </html>
+
 

--- a/References-ignore/MegaMenu/index.html
+++ b/References-ignore/MegaMenu/index.html
@@ -66,7 +66,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -315,3 +315,4 @@
 <script src="js/main.js"></script> <!-- Resource jQuery -->
 </body>
 </html>
+

--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -87,7 +87,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -315,4 +315,5 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
 

--- a/assets/images/index.html
+++ b/assets/images/index.html
@@ -62,7 +62,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -89,3 +89,4 @@
   </div>
 </body>
 </html>
+

--- a/book.html
+++ b/book.html
@@ -97,7 +97,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -371,4 +371,5 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
 

--- a/brandon.html
+++ b/brandon.html
@@ -63,7 +63,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -112,4 +112,5 @@
   <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>
+
 

--- a/components.html
+++ b/components.html
@@ -64,7 +64,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -816,4 +816,5 @@
   </script>
 </body>
 </html>
+
 

--- a/components/book-details-tab-demo.html
+++ b/components/book-details-tab-demo.html
@@ -64,7 +64,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -150,4 +150,5 @@
 
 </body>
 </html>
+
 

--- a/contact.html
+++ b/contact.html
@@ -89,7 +89,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -212,4 +212,5 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -64,7 +64,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -248,4 +248,5 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
 

--- a/docs/style-guide.html
+++ b/docs/style-guide.html
@@ -72,7 +72,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -341,4 +341,5 @@
   <script src="../js/style-guide.js" type="module"></script>
 </body>
 </html>
+
 

--- a/home.html
+++ b/home.html
@@ -64,7 +64,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -233,4 +233,5 @@
   <script type="module" src="./js/main.js"></script>
   </body>
   </html>
+
 

--- a/image-index.html
+++ b/image-index.html
@@ -100,7 +100,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -195,4 +195,5 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
 

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
       <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
       <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
       <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-      <meta name="msapplication-TileColor" content="#111217">
+      <meta name="msapplication-TileColor" content="transparent">
       <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
       <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
       <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -829,4 +829,5 @@
     <script type="module" src="./js/main.js"></script>
   </body>
 </html>
+
 

--- a/login.html
+++ b/login.html
@@ -64,7 +64,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -223,4 +223,5 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
 

--- a/meet-daren-prince.html
+++ b/meet-daren-prince.html
@@ -125,7 +125,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -424,4 +424,5 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
 

--- a/member/index.html
+++ b/member/index.html
@@ -62,7 +62,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -87,4 +87,5 @@
   <script type="module" src="../js/seo-indexing.js"></script>
 </body>
 </html>
+
 

--- a/pages/search.html
+++ b/pages/search.html
@@ -62,7 +62,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -144,4 +144,5 @@
   <script type="module" src="../src/js/search-results.js"></script>
 </body>
 </html>
+
 

--- a/press.html
+++ b/press.html
@@ -94,7 +94,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -320,4 +320,5 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
 

--- a/reset-password.html
+++ b/reset-password.html
@@ -64,7 +64,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -182,4 +182,5 @@
   <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>
+
 

--- a/scripts/generate-icons.mjs
+++ b/scripts/generate-icons.mjs
@@ -32,7 +32,7 @@ function buildFaviconsConfig() {
     developerURL: 'https://darenprince.com',
     dir: 'auto',
     lang: 'en-US',
-    background: '#111217',
+    background: 'transparent',
     theme_color: '#111217',
     display: 'standalone',
     orientation: 'any',

--- a/shhh.html
+++ b/shhh.html
@@ -69,7 +69,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -179,4 +179,5 @@ document.addEventListener('keydown', e => {
   <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>
+
 

--- a/sitemap.html
+++ b/sitemap.html
@@ -62,7 +62,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -141,4 +141,5 @@
   <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>
+
 

--- a/style-classes.html
+++ b/style-classes.html
@@ -64,7 +64,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -157,4 +157,5 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
 

--- a/test/layout-debug.html
+++ b/test/layout-debug.html
@@ -66,7 +66,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -81,4 +81,5 @@
   </main>
 </body>
 </html>
+
 

--- a/test/test.html
+++ b/test/test.html
@@ -65,7 +65,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -173,4 +173,5 @@
 
 </body>
 </html>
+
 

--- a/themes.html
+++ b/themes.html
@@ -267,7 +267,7 @@ body{
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -439,4 +439,5 @@ body{
 <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>
+
 

--- a/verify-email.html
+++ b/verify-email.html
@@ -64,7 +64,7 @@
     <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
     <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
-    <meta name="msapplication-TileColor" content="#111217">
+    <meta name="msapplication-TileColor" content="transparent">
     <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
     <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
     <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
@@ -139,4 +139,5 @@
   <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>
+
 


### PR DESCRIPTION
## Summary
- set the favicon generation config to use a transparent background so PNG icons keep their alpha channel
- regenerate the `msapplication-TileColor` meta tag across HTML documents to match the transparent background

## Testing
- npm run generate:icons

------
https://chatgpt.com/codex/tasks/task_e_68d0d3bda81883259a09e588dd78ddf8