### PR TITLE
Prioritize runtime Supabase config overrides

### DIFF
--- a/supabase/env.js
+++ b/supabase/env.js
@@ -128,6 +128,12 @@ const resolveFromGlobalEnv = () => {
 
 const resolveFromBrowserEnv = async () => {
   const configs = []
+
+  const storageConfig = resolveFromRuntimeStorage()
+  if (storageConfig) {
+    configs.push(storageConfig)
+  }
+
   try {
     const envModule = await import('../assets/js/env.js')
     const env = (envModule && envModule.default) || envModule
@@ -145,14 +151,12 @@ const resolveFromBrowserEnv = async () => {
       console.warn('Supabase env.js lookup failed', error)
     }
   }
-  const storageConfig = resolveFromRuntimeStorage()
-  if (storageConfig) {
-    configs.push(storageConfig)
-  }
+
   const globalConfig = resolveFromGlobalEnv()
   if (globalConfig) {
     configs.push(globalConfig)
   }
+
   return combineConfigs(...configs)
 }
 


### PR DESCRIPTION
## Summary
- ensure resolveFromBrowserEnv reads localStorage-driven runtime config before bundled env.js values
- preserve env.js and global env fallbacks while allowing QA overrides to take precedence

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1158271948325a6bba4c14a30b062