### PR TITLE
Handle empty Supabase env aliases

### DIFF
--- a/supabase/env.js
+++ b/supabase/env.js
@@ -23,6 +23,9 @@ const readFirstDefined = (reader, keys) => {
   for (const key of keys) {
     const value = reader(key)
     if (value !== undefined && value !== null) {
+      if (typeof value === 'string' && value.trim() === '') {
+        continue
+      }
       return value
     }
   }

--- a/tests/supabase-env.spec.ts
+++ b/tests/supabase-env.spec.ts
@@ -112,6 +112,17 @@ describe('resolveSupabaseConfigSync', () => {
     expect(config.key).toBe('netlify-anon')
   })
 
+  it('ignores empty primary aliases in favor of populated fallbacks', () => {
+    process.env.SUPABASE_DATABASE_URL = '   '
+    process.env.SUPABASE_URL = 'https://fallback.supabase.co'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = ''
+    process.env.SUPABASE_SERVICE_KEY = 'fallback-service'
+
+    const config = resolveSupabaseConfigSync()
+    expect(config.url).toBe('https://fallback.supabase.co')
+    expect(config.key).toBe('fallback-service')
+  })
+
   it('supports legacy SUPABASE_KEY alias for anon credentials', () => {
     process.env.SUPABASE_DATABASE_URL = 'https://legacy.supabase.co'
     process.env.SUPABASE_KEY = 'legacy-anon'


### PR DESCRIPTION
## Summary
- treat empty or whitespace-only Supabase alias values as missing so resolution can fall back to later keys
- add regression coverage ensuring empty primary aliases yield populated fallback credentials

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d126806c448325857b6794d4c1eb92