### PR TITLE
Add Apple Smart App Banner meta tag

### DIFF
--- a/All-heroes-demos.html
+++ b/All-heroes-demos.html
@@ -7,6 +7,9 @@
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/styles.css">
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -180,5 +183,7 @@
   <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>
+
+
 
 

--- a/Picdetective/analysis.html
+++ b/Picdetective/analysis.html
@@ -8,6 +8,9 @@
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -1213,5 +1216,7 @@
 <script src="script.js"></script>
 </body>
 </html>
+
+
 
 

--- a/Picdetective/index.html
+++ b/Picdetective/index.html
@@ -8,6 +8,9 @@
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -1213,5 +1216,7 @@
 <script src="script.js"></script>
 </body>
 </html>
+
+
 
 

--- a/Picdetective/privacy.html
+++ b/Picdetective/privacy.html
@@ -7,6 +7,9 @@
   <title>Privacy Policy</title>
   <link rel="stylesheet" href="style.css">
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -77,5 +80,7 @@
 <p>&copy; 2025 Daren Prince</p>
 </body>
 </html>
+
+
 
 

--- a/Picdetective/reset.html
+++ b/Picdetective/reset.html
@@ -7,6 +7,9 @@
   <title>Password Reset</title>
   <link rel="stylesheet" href="style.css">
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -94,5 +97,7 @@
 </script>
 </body>
 </html>
+
+
 
 

--- a/Picdetective/summary.html
+++ b/Picdetective/summary.html
@@ -8,6 +8,9 @@
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -203,5 +206,7 @@
 <script src="script.js"></script>
 </body>
 </html>
+
+
 
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ _Adding a new token_
 
 ---
 
+## Smart App Banner
+
+- Test in Safari on iPhone and iPad
+- Confirm the native banner appears
+- Tapping opens Apple Books directly to the Game On book
+- Banner does not appear inside the installed PWA view
+
+---
+
 ## 🧩 Component & Page Highlights
 
 Consult [`docs/SITE_STRUCTURE.md`](./docs/SITE_STRUCTURE.md) and [`docs/UI_COMPONENTS.md`](./docs/UI_COMPONENTS.md) for full coverage. Key surfaces include:

--- a/References-ignore/MegaMenu/index.html
+++ b/References-ignore/MegaMenu/index.html
@@ -10,6 +10,9 @@
   	
 	<title>Mega-Site Navigation | CodyHouse</title>
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -315,4 +318,6 @@
 <script src="js/main.js"></script> <!-- Resource jQuery -->
 </body>
 </html>
+
+
 

--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -31,6 +31,9 @@
     }
   </style>
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -315,5 +318,7 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
+
 
 

--- a/assets/images/index.html
+++ b/assets/images/index.html
@@ -6,6 +6,9 @@
   <link rel="stylesheet" href="book.css">
   <script type="module" src="book.js"></script>
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -89,4 +92,6 @@
   </div>
 </body>
 </html>
+
+
 

--- a/book.html
+++ b/book.html
@@ -41,6 +41,9 @@
   }
   </script>
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -371,5 +374,7 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
+
 
 

--- a/brandon.html
+++ b/brandon.html
@@ -7,6 +7,9 @@
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/styles.css">
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -112,5 +115,7 @@
   <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>
+
+
 
 

--- a/components.html
+++ b/components.html
@@ -8,6 +8,9 @@
   <link rel="stylesheet" href="assets/styles.css">
   <link rel="stylesheet" href="https://unpkg.com/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -816,5 +819,7 @@
   </script>
 </body>
 </html>
+
+
 
 

--- a/components/book-details-tab-demo.html
+++ b/components/book-details-tab-demo.html
@@ -8,6 +8,9 @@
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../assets/styles.css" />
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -150,5 +153,7 @@
 
 </body>
 </html>
+
+
 
 

--- a/contact.html
+++ b/contact.html
@@ -33,6 +33,9 @@
   }
   </script>
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -212,5 +215,7 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
+
 
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -8,6 +8,9 @@
   <link rel="stylesheet" href="assets/styles.css">
   <link rel="stylesheet" href="https://unpkg.com/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -248,5 +251,7 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
+
 
 

--- a/docs/style-guide.html
+++ b/docs/style-guide.html
@@ -16,6 +16,9 @@
     nav.style-guide-nav { display:flex; flex-wrap:wrap; gap:1rem; }
   </style>
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -341,5 +344,7 @@
   <script src="../js/style-guide.js" type="module"></script>
 </body>
 </html>
+
+
 
 

--- a/home.html
+++ b/home.html
@@ -8,6 +8,9 @@
   <link rel="stylesheet" href="assets/styles.css">
   <link rel="stylesheet" href="https://unpkg.com/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -233,5 +236,7 @@
   <script type="module" src="./js/main.js"></script>
   </body>
   </html>
+
+
 
 

--- a/image-index.html
+++ b/image-index.html
@@ -44,6 +44,9 @@
     .img-modal .close { position:absolute; top:1rem; right:1rem; font-size:2rem; color:#fff; cursor:pointer; }
   </style>
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -195,5 +198,7 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
+
 
 

--- a/index.html
+++ b/index.html
@@ -54,6 +54,9 @@
       }
     </script>
     <!-- Apple PWA + Safari enhancements -->
+      <!-- Example with affiliate:
+      <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+      <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
       <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
       <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
       <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -829,5 +832,7 @@
     <script type="module" src="./js/main.js"></script>
   </body>
 </html>
+
+
 
 

--- a/login.html
+++ b/login.html
@@ -8,6 +8,9 @@
   <link rel="stylesheet" href="assets/styles.css">
   <link rel="stylesheet" href="https://unpkg.com/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -224,5 +227,7 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
+
 
 

--- a/meet-daren-prince.html
+++ b/meet-daren-prince.html
@@ -69,6 +69,9 @@
   }
   </script>
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -424,5 +427,7 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
+
 
 

--- a/member/index.html
+++ b/member/index.html
@@ -6,6 +6,9 @@
   <title>Member Area</title>
   <link rel="stylesheet" href="../assets/styles.css">
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -87,5 +90,7 @@
   <script type="module" src="../js/seo-indexing.js"></script>
 </body>
 </html>
+
+
 
 

--- a/pages/search.html
+++ b/pages/search.html
@@ -6,6 +6,9 @@
   <title>Search</title>
   <link rel="stylesheet" href="../assets/styles.css" />
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -144,5 +147,7 @@
   <script type="module" src="../src/js/search-results.js"></script>
 </body>
 </html>
+
+
 
 

--- a/press.html
+++ b/press.html
@@ -38,6 +38,9 @@
   }
   </script>
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -320,5 +323,7 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
+
 
 

--- a/reset-password.html
+++ b/reset-password.html
@@ -8,6 +8,9 @@
   <link rel="stylesheet" href="assets/styles.css">
   <link rel="stylesheet" href="https://unpkg.com/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -182,5 +185,7 @@
   <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>
+
+
 
 

--- a/scripts/generate-icons.mjs
+++ b/scripts/generate-icons.mjs
@@ -57,9 +57,13 @@ function buildFaviconsConfig() {
 
 function createBlock(htmlSnippet, indent) {
   const innerIndent = `${indent}  `;
-  const formatted = htmlSnippet
-    .trim()
-    .split('\n')
+  const snippetLines = htmlSnippet.trim().split('\n');
+  const smartBannerLines = [
+    '<!-- Example with affiliate:',
+    '<meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->',
+    '<meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">',
+  ];
+  const formatted = [...smartBannerLines, ...snippetLines]
     .map((line) => `${innerIndent}${line}`)
     .join('\n');
   return `${indent}${START_MARKER}\n${formatted}\n${indent}${END_MARKER}`;

--- a/shhh.html
+++ b/shhh.html
@@ -13,6 +13,9 @@
   @keyframes fadeout { from { opacity: 1; } to { opacity: 0; } }
 </style>
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -179,5 +182,7 @@ document.addEventListener('keydown', e => {
   <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>
+
+
 
 

--- a/sitemap.html
+++ b/sitemap.html
@@ -6,6 +6,9 @@
   <title>Site Map | Daren Prince</title>
   <link rel="stylesheet" href="/assets/styles.css" />
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -141,5 +144,7 @@
   <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>
+
+
 
 

--- a/style-classes.html
+++ b/style-classes.html
@@ -8,6 +8,9 @@
   <link rel="stylesheet" href="assets/styles.css">
   <link rel="stylesheet" href="https://unpkg.com/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -157,5 +160,7 @@
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>
+
+
 
 

--- a/test/layout-debug.html
+++ b/test/layout-debug.html
@@ -10,6 +10,9 @@
     .debug-grid div { background: #456F3A; color: #FDFDFD; padding: 1rem; text-align: center; }
   </style>
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -81,5 +84,7 @@
   </main>
 </body>
 </html>
+
+
 
 

--- a/test/test.html
+++ b/test/test.html
@@ -9,6 +9,9 @@
   <link rel="stylesheet" href="../assets/styles.css" />
   <link rel="icon" href="assets/icons/favicon.png" type="image/png" />
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -173,5 +176,7 @@
 
 </body>
 </html>
+
+
 
 

--- a/themes.html
+++ b/themes.html
@@ -211,6 +211,9 @@ body{
 @media (max-width:840px){ .grid{grid-template-columns:repeat(5,var(--tile))} }
 </style>
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -439,5 +442,7 @@ body{
 <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>
+
+
 
 

--- a/verify-email.html
+++ b/verify-email.html
@@ -8,6 +8,9 @@
   <link rel="stylesheet" href="assets/styles.css">
   <link rel="stylesheet" href="https://unpkg.com/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
   <!-- Apple PWA + Safari enhancements -->
+    <!-- Example with affiliate:
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900, affiliate-data=partnerId=XXXXXXXX"> -->
+    <meta name="apple-itunes-app" content="app-id=364709193, app-argument=https://books.apple.com/us/book/game-on-master-the-conversation-win-her-heart/id6745466900">
     <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
@@ -139,5 +142,7 @@
   <script type="module" src="./js/seo-indexing.js"></script>
 </body>
 </html>
+
+
 
 


### PR DESCRIPTION
## Summary
- insert the Apple Smart App Banner meta tag and reference comment into the shared head snippet so every page promotes the Game On Apple Books listing
- regenerate the HTML documents so each page includes the new native Smart App Banner markup once
- document the manual QA steps for the banner under a new Smart App Banner section in the README

## Testing
- npm run generate:icons

------
https://chatgpt.com/codex/tasks/task_e_68d194532388832595304c994217c52d