### PR TITLE
Add branded loader showcase and disable admin gating

### DIFF
--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -94,10 +94,6 @@
   <!-- End Apple PWA + Safari enhancements -->
 </head>
 <body class="theme-dark">
-<script type="module">
-  import { enforceAuthGuard } from './js/auth-guard.js';
-  enforceAuthGuard({ requireElevated: true, loadFolderAccess: true });
-</script>
   <nav class="mega-menu js-mega-menu" aria-label="Mega menu">
     <button class="icon-btn menu-close menu-close-btn js-menu-close" aria-label="Close"><i class="ti ti-x"></i></button>
     <img src="assets/logos/logo-footer-white.png" alt="Daren Prince" class="mega-menu-logo">
@@ -121,7 +117,7 @@
     </ul>
   </nav>
   <div class="menu-overlay js-menu-overlay"></div>
-  <div class="site-wrap" hidden>
+  <div class="site-wrap">
     <header class="site-header padding-y-sm js-sticky-nav">
       <div class="container max-width-adaptive-lg flex items-center justify-between">
         <a href="index.html" class="logo">

--- a/admin-user-management.html
+++ b/admin-user-management.html
@@ -68,7 +68,7 @@
   </style>
 </head>
 <body>
-  <div class="site-wrap" hidden data-console-root>
+  <div class="site-wrap" data-console-root>
     <header class="console-header">
       <h1 class="console-header__title">Supabase Command Center</h1>
       <p class="console-header__subtitle">Review every authenticated profile, elevate roles, toggle folder access, and trigger recovery workflows without leaving the dashboard.</p>

--- a/components.html
+++ b/components.html
@@ -71,10 +71,6 @@
   <!-- End Apple PWA + Safari enhancements -->
 </head>
 <body class="theme-dark">
-  <script type="module">
-    import { enforceAuthGuard } from './js/auth-guard.js';
-    enforceAuthGuard({ requiredFolders: ['components'], loadFolderAccess: true });
-  </script>
   <nav class="mega-menu js-mega-menu" aria-label="Mega menu">
     <button class="icon-btn menu-close menu-close-btn js-menu-close" aria-label="Close"><i class="ti ti-x"></i></button>
     <img src="assets/logos/logo-footer-white.png" alt="Daren Prince" class="mega-menu-logo">
@@ -98,7 +94,7 @@
     </ul>
   </nav>
   <div class="menu-overlay js-menu-overlay"></div>
-  <div class="site-wrap" hidden>
+  <div class="site-wrap">
     <header class="site-header padding-y-sm js-sticky-nav">
     <div class="container max-width-adaptive-lg flex items-center justify-between">
       <a href="index.html" class="logo">

--- a/components/book-details-tab-demo.html
+++ b/components/book-details-tab-demo.html
@@ -71,12 +71,8 @@
   <!-- End Apple PWA + Safari enhancements -->
 </head>
 <body class="dark">
-  <script type="module">
-    import { enforceAuthGuard } from '../js/auth-guard.js';
-    enforceAuthGuard({ requiredFolders: ['components/book-details'], loadFolderAccess: true });
-  </script>
 
-  <div class="site-wrap" hidden>
+  <div class="site-wrap">
 
     <section class="book-details">
 

--- a/image-index.html
+++ b/image-index.html
@@ -107,10 +107,6 @@
   <!-- End Apple PWA + Safari enhancements -->
 </head>
 <body class="theme-dark">
-<script type="module">
-  import { enforceAuthGuard } from './js/auth-guard.js';
-  enforceAuthGuard({ requiredFolders: ['image-index'], loadFolderAccess: true });
-</script>
   <nav class="mega-menu js-mega-menu" aria-label="Mega menu">
     <button class="icon-btn menu-close menu-close-btn js-menu-close" aria-label="Close"><i class="ti ti-x"></i></button>
     <img src="assets/logos/logo-footer-white.png" alt="Daren Prince" class="mega-menu-logo">
@@ -121,7 +117,7 @@
     </ul>
   </nav>
   <div class="menu-overlay js-menu-overlay"></div>
-  <div class="site-wrap" hidden>
+  <div class="site-wrap">
     <header class="site-header padding-y-sm js-sticky-nav">
       <div class="container max-width-adaptive-lg flex items-center justify-between">
         <a href="index.html" class="logo">

--- a/loaders.html
+++ b/loaders.html
@@ -220,6 +220,175 @@
       mix-blend-mode: screen;
     }
 
+    /* Wordmark spectrum loader */
+    .wordmark-loader {
+      position: relative;
+      width: clamp(240px, 48vw, 340px);
+      aspect-ratio: 3.2 / 1;
+      display: grid;
+      place-items: center;
+    }
+
+    .wordmark-loader::before,
+    .wordmark-loader::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      mask: url('assets/logos/logo-hires-white-for-dark-bg.svg') center / contain no-repeat;
+      -webkit-mask: url('assets/logos/logo-hires-white-for-dark-bg.svg') center / contain no-repeat;
+    }
+
+    .wordmark-loader::before {
+      background: linear-gradient(120deg, rgba(84, 255, 229, 0.9), rgba(127, 140, 255, 0.95), rgba(249, 247, 247, 0.9));
+      background-size: 220%;
+      animation: wordmark-sweep 2.8s ease-in-out infinite;
+      filter: drop-shadow(0 0 22px rgba(127, 140, 255, 0.45));
+    }
+
+    .wordmark-loader::after {
+      background: linear-gradient(120deg, rgba(84, 255, 229, 0.5), rgba(127, 140, 255, 0.3), rgba(125, 222, 91, 0.4));
+      filter: blur(18px);
+      opacity: 0.55;
+      animation: wordmark-glow 3.6s ease-in-out infinite;
+    }
+
+    .wordmark-loader__progress {
+      position: absolute;
+      bottom: -18%;
+      left: 12%;
+      width: 76%;
+      height: 6px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.1);
+      overflow: hidden;
+    }
+
+    .wordmark-loader__progress::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(90deg, rgba(84, 255, 229, 0), rgba(84, 255, 229, 0.9), rgba(127, 140, 255, 0));
+      transform: translateX(-100%);
+      animation: bar-sweep 2s ease-in-out infinite;
+    }
+
+    /* Icon orbit loader */
+    .icon-orbit-loader {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.25rem;
+    }
+
+    .icon-orbit {
+      position: relative;
+      width: 160px;
+      aspect-ratio: 1 / 1;
+    }
+
+    .icon-orbit__core {
+      position: absolute;
+      inset: 26%;
+      background: linear-gradient(135deg, rgba(84, 255, 229, 0.9), rgba(127, 140, 255, 0.95));
+      mask: url('assets/icons/darenprince-icon.svg') center / contain no-repeat;
+      -webkit-mask: url('assets/icons/darenprince-icon.svg') center / contain no-repeat;
+      filter: drop-shadow(0 0 25px rgba(127, 140, 255, 0.55));
+      animation: icon-pulse 2.6s ease-in-out infinite;
+    }
+
+    .orbit-ring {
+      position: absolute;
+      inset: 0;
+      border-radius: 50%;
+      border: 2px solid rgba(84, 255, 229, 0.4);
+      animation: orbit-spin 6s linear infinite;
+      box-shadow: 0 0 35px rgba(84, 255, 229, 0.2);
+    }
+
+    .orbit-ring::after {
+      content: '';
+      position: absolute;
+      top: -6px;
+      left: 50%;
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, rgba(84, 255, 229, 1), rgba(127, 140, 255, 1));
+      transform: translateX(-50%);
+      box-shadow: 0 0 18px rgba(84, 255, 229, 0.65);
+    }
+
+    .orbit-ring--lag {
+      inset: 12%;
+      border-color: rgba(127, 140, 255, 0.35);
+      animation-duration: 4s;
+      animation-direction: reverse;
+      opacity: 0.75;
+    }
+
+    .icon-orbit__label {
+      font-size: 0.85rem;
+      letter-spacing: 0.4em;
+      text-transform: uppercase;
+      color: rgba(232, 241, 255, 0.62);
+    }
+
+    /* Game On ignite loader */
+    .gameon-loader {
+      position: relative;
+      width: clamp(240px, 48vw, 360px);
+      aspect-ratio: 3 / 1.2;
+      border-radius: 20px;
+      overflow: hidden;
+      background: radial-gradient(circle at 15% 20%, rgba(125, 222, 91, 0.1), transparent 65%);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .gameon-logo {
+      position: absolute;
+      inset: 10% 12%;
+      background: linear-gradient(120deg, rgba(125, 222, 91, 0.92), rgba(84, 255, 229, 0.85), rgba(127, 140, 255, 0.65));
+      mask: url('assets/images/game-on-logo-limewhite-neon.png') center / contain no-repeat;
+      -webkit-mask: url('assets/images/game-on-logo-limewhite-neon.png') center / contain no-repeat;
+      animation: gameon-glow 2.8s ease-in-out infinite;
+      filter: drop-shadow(0 0 24px rgba(125, 222, 91, 0.5));
+    }
+
+    .gameon-scan {
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(180deg, rgba(84, 255, 229, 0) 0%, rgba(84, 255, 229, 0.35) 45%, rgba(84, 255, 229, 0) 100%);
+      mix-blend-mode: screen;
+      animation: gameon-scan 1.8s ease-in-out infinite;
+    }
+
+    .gameon-dots {
+      position: absolute;
+      bottom: 12%;
+      left: 50%;
+      transform: translateX(-50%);
+      display: flex;
+      gap: 0.35rem;
+    }
+
+    .gameon-dots span {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: rgba(84, 255, 229, 0.55);
+      animation: gameon-dots 1.2s ease-in-out infinite;
+    }
+
+    .gameon-dots span:nth-child(2) {
+      animation-delay: 0.15s;
+    }
+
+    .gameon-dots span:nth-child(3) {
+      animation-delay: 0.3s;
+    }
+
     /* Controls */
     .actions {
       margin: clamp(2.5rem, 6vw, 4rem) auto 0;
@@ -328,6 +497,82 @@
       }
     }
 
+    @keyframes wordmark-sweep {
+      0%,
+      100% {
+        background-position: 0% 50%;
+      }
+      50% {
+        background-position: 100% 50%;
+      }
+    }
+
+    @keyframes wordmark-glow {
+      0%,
+      100% {
+        opacity: 0.4;
+      }
+      50% {
+        opacity: 0.8;
+      }
+    }
+
+    @keyframes icon-pulse {
+      0%,
+      100% {
+        transform: scale(0.96);
+        filter: drop-shadow(0 0 20px rgba(127, 140, 255, 0.45));
+      }
+      50% {
+        transform: scale(1.05);
+        filter: drop-shadow(0 0 35px rgba(84, 255, 229, 0.7));
+      }
+    }
+
+    @keyframes orbit-spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
+
+    @keyframes gameon-glow {
+      0%,
+      100% {
+        filter: drop-shadow(0 0 16px rgba(125, 222, 91, 0.4));
+        opacity: 0.85;
+      }
+      50% {
+        filter: drop-shadow(0 0 32px rgba(125, 222, 91, 0.65));
+        opacity: 1;
+      }
+    }
+
+    @keyframes gameon-scan {
+      0% {
+        transform: translateY(-60%);
+        opacity: 0;
+      }
+      40% {
+        opacity: 0.55;
+      }
+      100% {
+        transform: translateY(60%);
+        opacity: 0;
+      }
+    }
+
+    @keyframes gameon-dots {
+      0%,
+      100% {
+        opacity: 0.3;
+        transform: translateY(0);
+      }
+      50% {
+        opacity: 1;
+        transform: translateY(-4px);
+      }
+    }
+
     @media (max-width: 640px) {
       .loader-demo {
         min-height: 150px;
@@ -372,6 +617,47 @@ rfect for page-level transitions or splash screens.</p>
               <span class="loading-crown"></span>
             </div>
             <div class="loading-bar"></div>
+          </div>
+        </div>
+      </article>
+
+      <article class="loader-card">
+        <h2>Wordmark Spectrum Loader</h2>
+        <p>The full Daren Prince wordmark becomes a light rail, sweeping gradients through the logotype before finishing with a precise progress beam underneath.</p>
+        <div class="loader-demo">
+          <div class="loading-screen">
+            <div class="wordmark-loader">
+              <div class="wordmark-loader__progress"></div>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="loader-card">
+        <h2>Icon Orbit Loader</h2>
+        <p>The DP icon anchors a pair of orbits, emitting pulses as each ring sweeps past. Drop this in modals, dashboards, or anywhere precision signals are needed.</p>
+        <div class="loader-demo">
+          <div class="loading-screen icon-orbit-loader">
+            <div class="icon-orbit">
+              <div class="orbit-ring"></div>
+              <div class="orbit-ring orbit-ring--lag"></div>
+              <div class="icon-orbit__core"></div>
+            </div>
+            <p class="icon-orbit__label">Calibrating reach</p>
+          </div>
+        </div>
+      </article>
+
+      <article class="loader-card">
+        <h2>Game On Ignite Loader</h2>
+        <p>Game On gets a neon revival with a vertical energy scan and cadence dots that count down to the drop. Perfect for sports activations and hype reels.</p>
+        <div class="loader-demo">
+          <div class="loading-screen">
+            <div class="gameon-loader">
+              <div class="gameon-logo"></div>
+              <div class="gameon-scan"></div>
+              <div class="gameon-dots"><span></span><span></span><span></span></div>
+            </div>
           </div>
         </div>
       </article>

--- a/style-classes.html
+++ b/style-classes.html
@@ -71,10 +71,6 @@
   <!-- End Apple PWA + Safari enhancements -->
 </head>
 <body class="theme-dark">
-  <script type="module">
-    import { enforceAuthGuard } from './js/auth-guard.js';
-    enforceAuthGuard({ requiredFolders: ['style-classes'], loadFolderAccess: true });
-  </script>
   <nav class="mega-menu js-mega-menu" aria-label="Mega menu">
     <button class="icon-btn menu-close menu-close-btn js-menu-close" aria-label="Close"><i class="ti ti-x"></i></button>
     <img src="assets/logos/logo-footer-white.png" alt="Daren Prince" class="mega-menu-logo">
@@ -85,7 +81,7 @@
     </ul>
   </nav>
   <div class="menu-overlay js-menu-overlay"></div>
-  <div class="site-wrap" hidden>
+  <div class="site-wrap">
     <header class="site-header padding-y-sm js-sticky-nav">
       <div class="container max-width-adaptive-lg flex items-center justify-between">
         <a href="index.html" class="logo">


### PR DESCRIPTION
## Summary
- add three brand-driven loader concepts built around the wordmark, icon, and Game On artwork
- display the new motion studies on the loaders lab page alongside existing treatments
- remove Supabase auth gating from developer/admin surfaces while keeping consoles interactive

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1927b93d083259e75a2a758003b11