### PR TITLE
Add secure keypad gate and hero visual to CCAI page

### DIFF
--- a/CCAI.html
+++ b/CCAI.html
@@ -8,6 +8,182 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="assets/styles.css" />
+  <link rel="icon" type="image/png" href="assets/images/Crowncode/crowncode-fav.png" />
+  <style>
+    .hero-visual {
+      margin-top: 2.5rem;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+
+    .hero-visual img {
+      max-width: min(460px, 90vw);
+      width: 100%;
+      filter: drop-shadow(0 25px 50px rgba(12, 18, 10, 0.55));
+      border-radius: 28px;
+      border: 1px solid rgba(135, 189, 114, 0.22);
+      background: radial-gradient(circle at 20% 20%, rgba(111, 167, 103, 0.2), transparent 65%);
+      padding: 1.5rem;
+    }
+
+    .access-gate-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(7, 10, 6, 0.96);
+      backdrop-filter: blur(10px);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+      transition: opacity 0.45s ease, visibility 0.45s ease;
+      z-index: 999;
+    }
+
+    .access-gate-overlay.active {
+      opacity: 1;
+      visibility: visible;
+      pointer-events: auto;
+    }
+
+    .access-gate-panel {
+      width: min(420px, 92vw);
+      background: rgba(10, 16, 12, 0.92);
+      border: 1px solid rgba(135, 189, 114, 0.35);
+      border-radius: 32px;
+      padding: 2.5rem 2rem;
+      box-shadow: 0 30px 55px rgba(0, 0, 0, 0.55);
+      text-align: center;
+      position: relative;
+      overflow: hidden;
+      transition: transform 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease;
+      transform: translateY(12px);
+    }
+
+    .access-gate-overlay.active .access-gate-panel {
+      transform: translateY(0);
+    }
+
+    .gate-header {
+      font-size: 1.55rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-bottom: 1.25rem;
+      color: #c2e9c1;
+    }
+
+    .gate-display {
+      font-family: "League Spartan", sans-serif;
+      font-size: 1.9rem;
+      letter-spacing: 0.28em;
+      color: rgba(194, 233, 193, 0.85);
+      background: rgba(8, 12, 9, 0.9);
+      border: 1px solid rgba(111, 167, 103, 0.55);
+      border-radius: 16px;
+      padding: 1rem 1.5rem;
+      margin-bottom: 1.75rem;
+      min-height: 3.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .gate-keypad {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 0.85rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .keypad-key {
+      font-size: 1.4rem;
+      font-family: "League Spartan", sans-serif;
+      letter-spacing: 0.08em;
+      padding: 0.85rem 0;
+      border-radius: 18px;
+      border: 1px solid rgba(111, 167, 103, 0.45);
+      background: radial-gradient(circle at 50% -10%, rgba(194, 233, 193, 0.24), rgba(7, 10, 6, 0.92));
+      color: #e5f4e4;
+      cursor: pointer;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+    }
+
+    .keypad-key:focus-visible,
+    .keypad-key:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 12px 24px rgba(12, 18, 10, 0.45);
+      outline: none;
+    }
+
+    .keypad-key[data-keypad="submit"] {
+      background: linear-gradient(135deg, rgba(109, 166, 103, 0.85), rgba(69, 111, 58, 0.95));
+      border-color: rgba(194, 233, 193, 0.6);
+    }
+
+    .keypad-key[data-keypad="clear"] {
+      font-size: 1.05rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+    }
+
+    .gate-status {
+      font-size: 0.95rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: rgba(255, 119, 119, 0.78);
+      min-height: 1.4rem;
+    }
+
+    .access-gate-overlay.error .access-gate-panel {
+      border-color: rgba(255, 119, 119, 0.65);
+      box-shadow: 0 35px 65px rgba(255, 84, 84, 0.28);
+    }
+
+    .access-gate-overlay.error .gate-display {
+      border-color: rgba(255, 119, 119, 0.5);
+      color: rgba(255, 199, 199, 0.8);
+    }
+
+    .access-gate-overlay.success .access-gate-panel {
+      border-color: rgba(135, 189, 114, 0.95);
+      background: linear-gradient(155deg, rgba(16, 28, 21, 0.95), rgba(69, 111, 58, 0.92));
+      box-shadow: 0 45px 80px rgba(60, 110, 60, 0.45);
+    }
+
+    .access-gate-overlay.success .gate-display {
+      border-color: rgba(194, 233, 193, 0.9);
+      color: #e6ffe6;
+    }
+
+    .access-gate-overlay.success .gate-status {
+      color: #c2e9c1;
+      animation: accessPulse 1.2s ease infinite;
+    }
+
+    .access-gate-overlay.success .keypad-key {
+      background: linear-gradient(145deg, rgba(135, 189, 114, 0.95), rgba(69, 111, 58, 0.95));
+      border-color: rgba(226, 255, 219, 0.85);
+      color: #050805;
+      pointer-events: none;
+    }
+
+    @keyframes accessPulse {
+      0% {
+        opacity: 0.4;
+        letter-spacing: 0.12em;
+      }
+      50% {
+        opacity: 1;
+        letter-spacing: 0.26em;
+      }
+      100% {
+        opacity: 0.4;
+        letter-spacing: 0.12em;
+      }
+    }
+  </style>
 </head>
 <body class="ccai-page grid-background">
   <div class="page-loader" id="pageLoader" aria-hidden="true">
@@ -20,6 +196,28 @@
     <div class="loader-ring" aria-hidden="true"></div>
     <img src="assets/images/Crowncode/Crowncode-OG.png.PNG" alt="CrownCode.ai clearance loader" class="loader-logo" />
     <div class="loader-text">Authorizing Token</div>
+  </div>
+
+  <div class="access-gate-overlay" id="accessGate" role="dialog" aria-modal="true" aria-labelledby="gateTitle" aria-hidden="true">
+    <div class="access-gate-panel">
+      <div class="gate-header" id="gateTitle">Enter Access Code</div>
+      <div class="gate-display" id="gateDisplay">ENTER CODE</div>
+      <div class="gate-keypad" role="group" aria-label="Secure numeric keypad">
+        <button type="button" class="keypad-key" data-keypad="1">1</button>
+        <button type="button" class="keypad-key" data-keypad="2">2</button>
+        <button type="button" class="keypad-key" data-keypad="3">3</button>
+        <button type="button" class="keypad-key" data-keypad="4">4</button>
+        <button type="button" class="keypad-key" data-keypad="5">5</button>
+        <button type="button" class="keypad-key" data-keypad="6">6</button>
+        <button type="button" class="keypad-key" data-keypad="7">7</button>
+        <button type="button" class="keypad-key" data-keypad="8">8</button>
+        <button type="button" class="keypad-key" data-keypad="9">9</button>
+        <button type="button" class="keypad-key" data-keypad="clear" aria-label="Clear access code">CLR</button>
+        <button type="button" class="keypad-key" data-keypad="0">0</button>
+        <button type="button" class="keypad-key" data-keypad="submit" aria-label="Submit access code">#</button>
+      </div>
+      <div class="gate-status" id="gateStatus" role="status" aria-live="polite"></div>
+    </div>
   </div>
 
   <img src="assets/images/Crowncode/905437AD-6656-4AD8-B5A6-CF08F6199F27.png" alt="CrownCode.ai chain badge" class="badge-watermark" />
@@ -46,6 +244,9 @@
           Contact Sales
         </a>
       </div>
+    </div>
+    <div class="hero-visual" aria-hidden="true">
+      <img src="assets/images/Crowncode/Crowncode-OG.png.PNG" alt="CrownCode.ai hero insignia" />
     </div>
   </header>
 
@@ -220,6 +421,7 @@
   <script>
     const ACCESS_TOKEN = "jagvov-8wyngy-sobpoK";
     const ACCESS_STORAGE_KEY = "ccai-brief-clearance";
+    const NUMERIC_PASSCODE = "640161869";
     const pageLoader = document.getElementById("pageLoader");
     const briefLoader = document.getElementById("briefLoader");
     const accessModal = document.getElementById("accessModal");
@@ -232,11 +434,102 @@
     const reportBreachBtn = document.getElementById("reportBreach");
     const proceedBriefBtn = document.getElementById("proceedBrief");
     const accessTriggers = document.querySelectorAll("[data-access-trigger]");
+    const accessGate = document.getElementById("accessGate");
+    const gateDisplay = document.getElementById("gateDisplay");
+    const gateStatus = document.getElementById("gateStatus");
+    const gateButtons = accessGate ? accessGate.querySelectorAll("[data-keypad]") : [];
     let toastTimer;
+    let gateInput = "";
+    let gateUnlocked = false;
+
+    function updateGateDisplay() {
+      if (!gateDisplay) return;
+      gateDisplay.textContent = gateInput ? gateInput.replace(/./g, "•") : "ENTER CODE";
+    }
+
+    function resetGateState() {
+      gateInput = "";
+      gateUnlocked = false;
+      if (gateStatus) {
+        gateStatus.textContent = "";
+      }
+      updateGateDisplay();
+      accessGate?.classList.remove("error", "success");
+    }
+
+    function grantGateAccess() {
+      gateUnlocked = true;
+      if (gateStatus) {
+        gateStatus.textContent = "Access Granted";
+      }
+      if (gateDisplay) {
+        gateDisplay.textContent = "ACCESS GRANTED";
+      }
+      if (accessGate) {
+        accessGate.classList.remove("error");
+        accessGate.classList.add("success");
+      }
+      setTimeout(() => {
+        if (accessGate) {
+          accessGate.classList.remove("active");
+          accessGate.setAttribute("aria-hidden", "true");
+        }
+        setBodyScrollLock(false);
+        setTimeout(() => {
+          if (accessGate) {
+            accessGate.classList.remove("success");
+          }
+          resetGateState();
+        }, 600);
+      }, 1100);
+    }
+
+    function handleGateInput(value) {
+      if (!accessGate || gateUnlocked) {
+        return;
+      }
+      accessGate.classList.remove("error");
+
+      if (value === "clear") {
+        resetGateState();
+        return;
+      }
+
+      if (value === "submit") {
+        if (gateInput === NUMERIC_PASSCODE) {
+          grantGateAccess();
+        } else {
+          accessGate.classList.add("error");
+          if (gateStatus) {
+            gateStatus.textContent = "Access Code Denied";
+          }
+          triggerSecurityNotice("Invalid access code");
+          setTimeout(() => accessGate && accessGate.classList.remove("error"), 900);
+        }
+        return;
+      }
+
+      if (gateInput.length < NUMERIC_PASSCODE.length) {
+        gateInput += value;
+        updateGateDisplay();
+      }
+    }
+
+    if (gateButtons.length) {
+      gateButtons.forEach((button) => {
+        button.addEventListener("click", () => handleGateInput(button.dataset.keypad));
+      });
+    }
 
     window.addEventListener("load", () => {
       setTimeout(() => {
         pageLoader.classList.add("hidden");
+        if (accessGate) {
+          updateGateDisplay();
+          accessGate.classList.add("active");
+          accessGate.setAttribute("aria-hidden", "false");
+          setBodyScrollLock(true);
+        }
       }, 650);
     });
 


### PR DESCRIPTION
## Summary
- add inline styles and hero visual featuring the CrownCode insignia on the CCAI landing header
- update the page favicon to use the dedicated CrownCode mark
- introduce a post-loader numeric access gate overlay with keypad handling and success animation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d425018724832597f26d5c8a5c7cff