### PR TITLE
Refresh CCAI landing hero and access flow

### DIFF
--- a/CCAI.html
+++ b/CCAI.html
@@ -6,140 +6,445 @@
   <title>CrownCode.ai Intelligence Systems</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="assets/styles.css" />
-  <link rel="icon" type="image/png" href="assets/images/Crowncode/crowncode-fav.png" />
+  <link rel="icon" type="image/png" href="assets/images/Crowncode/icons/favicon.ico" />
   <style>
     body.ccai-page {
-      --bg: linear-gradient(160deg, #17181a 0%, #242223 55%, #17181a 100%);
-      --grid: rgba(2, 72, 115, 0.18);
-      --panel: rgba(23, 24, 26, 0.94);
-      --outline: rgba(2, 72, 115, 0.45);
-      --accent: #024873;
-      --accent-strong: #024873;
-      --accent-dark: #012a46;
-      --accent-soft: rgba(2, 72, 115, 0.18);
-      --text-main: #e4e4e4;
-      --text-muted: rgba(228, 228, 228, 0.72);
-      --input-bg: rgba(23, 24, 26, 0.92);
-      --input-border: rgba(2, 72, 115, 0.55);
-      --cta-bg: #024873;
-      --cta-outline: rgba(2, 72, 115, 0.5);
-      --cta-text: #e4e4e4;
-      --shadow: 0 28px 48px rgba(1, 42, 70, 0.42);
-      --border-strong: rgba(2, 72, 115, 0.45);
-      --border-soft: rgba(1, 42, 70, 0.28);
-      --border-card: rgba(2, 72, 115, 0.32);
-      --border-glow: rgba(2, 72, 115, 0.48);
-      --panel-glass: rgba(23, 24, 26, 0.78);
-      --panel-soft: rgba(23, 24, 26, 0.86);
-      --glow-strong: rgba(2, 72, 115, 0.6);
-      --glow-soft: rgba(2, 72, 115, 0.18);
-      --toast-text: rgba(228, 228, 228, 0.85);
-      --color-primary: #012a46;
-      --color-primary-hover: #024873;
-      --color-bright: #024873;
-      --color-mint: rgba(2, 72, 115, 0.65);
-      --color-lime: rgba(2, 72, 115, 0.4);
-      --color-accent: #024873;
-      --color-border: rgba(2, 72, 115, 0.24);
-      --color-surface: rgba(23, 24, 26, 0.92);
-      --focus-ring: 0 0 0 3px rgba(2, 72, 115, 0.35);
+      --bg: linear-gradient(160deg, #000000 0%, #070a06 45%, #102015 100%);
+      --grid: rgba(69, 111, 58, 0.18);
+      --panel: rgba(7, 10, 6, 0.94);
+      --outline: rgba(109, 166, 103, 0.45);
+      --accent: #6da667;
+      --accent-strong: #456f3a;
+      --accent-dark: #1c3c23;
+      --accent-soft: rgba(135, 189, 114, 0.18);
+      --text-main: #f3f7f1;
+      --text-muted: rgba(194, 233, 193, 0.75);
+      --input-bg: rgba(7, 10, 6, 0.92);
+      --input-border: rgba(135, 189, 114, 0.55);
+      --cta-bg: #6da667;
+      --cta-outline: rgba(135, 189, 114, 0.55);
+      --cta-text: #070a06;
+      --shadow: 0 28px 48px rgba(12, 28, 16, 0.55);
+      --border-strong: rgba(135, 189, 114, 0.48);
+      --border-soft: rgba(35, 63, 38, 0.28);
+      --border-card: rgba(135, 189, 114, 0.32);
+      --border-glow: rgba(135, 189, 114, 0.48);
+      --panel-glass: rgba(7, 10, 6, 0.78);
+      --panel-soft: rgba(7, 10, 6, 0.86);
+      --glow-strong: rgba(135, 189, 114, 0.6);
+      --glow-soft: rgba(135, 189, 114, 0.18);
+      --toast-text: rgba(194, 233, 193, 0.85);
+      --color-primary: #456f3a;
+      --color-primary-hover: #6da667;
+      --color-bright: #87bd72;
+      --color-mint: rgba(135, 189, 114, 0.65);
+      --color-lime: rgba(194, 233, 193, 0.4);
+      --color-accent: #6da667;
+      --color-border: rgba(135, 189, 114, 0.24);
+      --color-surface: rgba(7, 10, 6, 0.92);
+      --focus-ring: 0 0 0 3px rgba(135, 189, 114, 0.35);
+      font-family: "Rubik", sans-serif;
+      background-color: #000000;
     }
 
     .ccai-page .page-loader,
     .ccai-page .brief-loader {
-      background: rgba(23, 24, 26, 0.94);
+      background: rgba(0, 0, 0, 0.96);
+      backdrop-filter: blur(8px);
     }
 
-    .ccai-page .loader-ring {
-      border: 2px solid rgba(2, 72, 115, 0.25);
-      border-top-color: #024873;
+    .ccai-page .brief-loader {
+      background: rgba(7, 10, 6, 0.94);
+    }
+
+    .flip-loader {
+      width: 64px;
+      height: 64px;
+      display: inline-block;
+      position: relative;
+      box-sizing: border-box;
+      border-radius: 18px;
+      background: linear-gradient(135deg, rgba(69, 111, 58, 0.95), rgba(135, 189, 114, 0.85));
+      box-shadow: 0 20px 45px rgba(12, 28, 16, 0.55);
+      animation: flipX 1.15s linear infinite;
+    }
+
+    @keyframes flipX {
+      0% {
+        transform: perspective(260px) rotateX(0deg) rotateY(0deg);
+      }
+      50% {
+        transform: perspective(260px) rotateX(-180deg) rotateY(0deg);
+      }
+      100% {
+        transform: perspective(260px) rotateX(-180deg) rotateY(-180deg);
+      }
+    }
+
+    .lock-loader {
+      width: 64px;
+      height: 44px;
+      position: relative;
+      border: 5px solid #c2e9c1;
+      border-radius: 8px;
+      display: inline-block;
+    }
+
+    .lock-loader::before {
+      content: "";
+      position: absolute;
+      border: 5px solid #c2e9c1;
+      width: 32px;
+      height: 28px;
+      border-radius: 50% 50% 0 0;
+      left: 50%;
+      top: 0;
+      transform: translate(-50%, -100%);
+    }
+
+    .lock-loader::after {
+      content: "";
+      position: absolute;
+      transform: translate(-50%, -50%);
+      left: 50%;
+      top: 50%;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background-color: #c2e9c1;
+      box-shadow: 16px 0 #c2e9c1, -16px 0 #c2e9c1;
+      animation: lockFlash 0.5s ease-out infinite alternate;
+    }
+
+    @keyframes lockFlash {
+      0% {
+        background-color: rgba(194, 233, 193, 0.25);
+        box-shadow: 16px 0 rgba(194, 233, 193, 0.25), -16px 0 rgba(194, 233, 193, 1);
+      }
+      50% {
+        background-color: rgba(194, 233, 193, 1);
+        box-shadow: 16px 0 rgba(194, 233, 193, 0.25), -16px 0 rgba(194, 233, 193, 0.25);
+      }
+      100% {
+        background-color: rgba(194, 233, 193, 0.25);
+        box-shadow: 16px 0 rgba(194, 233, 193, 1), -16px 0 rgba(194, 233, 193, 0.25);
+      }
     }
 
     .ccai-page.grid-background::before {
       background-image:
-        radial-gradient(circle at 20% 20%, rgba(2, 72, 115, 0.18), transparent 55%),
-        radial-gradient(circle at 80% 10%, rgba(1, 42, 70, 0.16), transparent 50%),
+        radial-gradient(circle at 20% 20%, rgba(135, 189, 114, 0.18), transparent 55%),
+        radial-gradient(circle at 80% 10%, rgba(69, 111, 58, 0.16), transparent 50%),
         linear-gradient(var(--grid) 1px, transparent 1px),
         linear-gradient(90deg, var(--grid) 1px, transparent 1px);
     }
 
     .ccai-page.grid-background::after {
-      background: radial-gradient(circle at center, rgba(23, 24, 26, 0) 0%, rgba(23, 24, 26, 0.85) 70%);
+      background: radial-gradient(circle at center, rgba(7, 10, 6, 0) 0%, rgba(7, 10, 6, 0.86) 70%);
+    }
+
+    .ccai-page .btn-primary {
+      background: var(--cta-bg);
+      color: var(--cta-text);
+      border: 1px solid rgba(135, 189, 114, 0.65);
+      box-shadow: 0 18px 40px rgba(16, 32, 21, 0.65);
     }
 
     .ccai-page .btn-primary:hover {
-      box-shadow: 0 26px 46px rgba(2, 72, 115, 0.38);
+      box-shadow: 0 26px 46px rgba(16, 32, 21, 0.78);
+      background: #87bd72;
     }
 
     .ccai-page .btn-secondary {
-      background: rgba(23, 24, 26, 0.75);
-      border-color: rgba(2, 72, 115, 0.45);
-      color: #e4e4e4;
+      background: rgba(7, 10, 6, 0.75);
+      border-color: rgba(135, 189, 114, 0.35);
+      color: #c2e9c1;
     }
 
     .ccai-page .btn-secondary:hover {
-      background: rgba(2, 72, 115, 0.2);
-      border-color: rgba(2, 72, 115, 0.55);
-      color: #e4e4e4;
+      background: rgba(135, 189, 114, 0.18);
+      border-color: rgba(135, 189, 114, 0.65);
+      color: #070a06;
     }
 
     .ccai-page input:focus,
     .ccai-page textarea:focus,
     .ccai-page .token-input:focus {
-      box-shadow: 0 0 0 3px rgba(2, 72, 115, 0.28);
+      box-shadow: 0 0 0 3px rgba(135, 189, 114, 0.35);
     }
 
     .ccai-page .cap-card {
-      background: linear-gradient(180deg, rgba(23, 24, 26, 0.92) 0%, rgba(23, 24, 26, 0.85) 100%);
+      background: linear-gradient(180deg, rgba(7, 10, 6, 0.92) 0%, rgba(7, 10, 6, 0.85) 100%);
+      border: 1px solid rgba(135, 189, 114, 0.2);
     }
 
     .ccai-page .brief-header {
-      background: linear-gradient(90deg, rgba(2, 72, 115, 0.6), rgba(23, 24, 26, 0.95));
-      border-bottom: 1px solid rgba(2, 72, 115, 0.45);
+      background: linear-gradient(90deg, rgba(69, 111, 58, 0.7), rgba(7, 10, 6, 0.95));
+      border-bottom: 1px solid rgba(135, 189, 114, 0.45);
     }
 
     .ccai-page .modal-backdrop {
-      background: rgba(23, 24, 26, 0.9);
+      background: rgba(0, 0, 0, 0.88);
     }
 
     .ccai-page .modal-panel {
-      background: rgba(23, 24, 26, 0.94);
-      box-shadow: 0 32px 64px rgba(1, 42, 70, 0.45);
+      background: rgba(7, 10, 6, 0.94);
+      box-shadow: 0 32px 64px rgba(16, 32, 21, 0.55);
     }
 
     .ccai-page .security-toast {
-      background: rgba(23, 24, 26, 0.95);
-      box-shadow: 0 24px 48px rgba(1, 42, 70, 0.38);
+      background: rgba(7, 10, 6, 0.95);
+      box-shadow: 0 24px 48px rgba(16, 32, 21, 0.55);
+      color: rgba(194, 233, 193, 0.85);
     }
 
     .ccai-page .warning-panel .warning-title {
-      color: #e4e4e4;
+      color: #c2e9c1;
+    }
+
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 950;
+      background: #000000;
+      box-shadow: 0 18px 30px rgba(0, 0, 0, 0.45);
+    }
+
+    .nav-container {
+      max-width: 1100px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.85rem 1.5rem;
+      gap: 1rem;
+    }
+
+    .brand-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      text-decoration: none;
+      color: #f3f7f1;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      font-size: 0.82rem;
+    }
+
+    .brand-link img {
+      height: 44px;
+      width: auto;
+      filter: drop-shadow(0 10px 22px rgba(135, 189, 114, 0.45));
+    }
+
+    .nav-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      width: 42px;
+      height: 42px;
+      border-radius: 50%;
+      border: 1px solid rgba(194, 233, 193, 0.35);
+      background: rgba(7, 10, 6, 0.7);
+      color: #f3f7f1;
+      cursor: pointer;
+      transition: background 0.3s ease, border-color 0.3s ease;
+    }
+
+    .nav-toggle:hover {
+      background: rgba(135, 189, 114, 0.18);
+      border-color: rgba(135, 189, 114, 0.65);
+    }
+
+    .nav-menu {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      z-index: 940;
+    }
+
+    .nav-menu a,
+    .nav-menu button {
+      font-family: "Rubik", sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      padding: 0.65rem 1.25rem;
+      border-radius: 999px;
+      border: 1px solid rgba(194, 233, 193, 0.28);
+      background: rgba(7, 10, 6, 0.7);
+      color: #f3f7f1;
+      text-decoration: none;
+      transition: background 0.3s ease, color 0.3s ease, transform 0.3s ease, border-color 0.3s ease;
+    }
+
+    .nav-menu button {
+      cursor: pointer;
+    }
+
+    .nav-menu a:hover,
+    .nav-menu button:hover {
+      background: #6da667;
+      color: #070a06;
+      border-color: rgba(135, 189, 114, 0.75);
+      transform: translateY(-2px);
+    }
+
+    .nav-menu .nav-link-primary {
+      background: #6da667;
+      color: #070a06;
+      border-color: rgba(135, 189, 114, 0.9);
+    }
+
+    .nav-menu .nav-link-primary:hover {
+      background: #87bd72;
+      border-color: rgba(194, 233, 193, 0.85);
+    }
+
+    .hero {
+      padding: clamp(3rem, 7vw, 5rem) 0 3rem;
+      max-width: none;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 2.75rem;
     }
 
     .hero-visual {
-      margin-top: 2.5rem;
-      display: flex;
-      justify-content: center;
-      align-items: center;
+      width: 100vw;
+      max-width: 100vw;
+      position: relative;
+      left: 50%;
+      transform: translateX(-50%);
+      border-radius: 0;
+      overflow: hidden;
+      border: 0;
+      box-shadow: 0 55px 100px rgba(0, 0, 0, 0.55);
+      background: linear-gradient(180deg, rgba(0, 0, 0, 0.85), rgba(28, 60, 35, 0.5));
     }
 
     .hero-visual img {
-      max-width: min(460px, 90vw);
+      display: block;
       width: 100%;
-      filter: drop-shadow(0 25px 50px rgba(1, 42, 70, 0.45));
-      border-radius: 28px;
-      border: 1px solid rgba(2, 72, 115, 0.3);
-      background: radial-gradient(circle at 20% 20%, rgba(2, 72, 115, 0.18), transparent 65%);
-      padding: 1.5rem;
+      height: clamp(320px, 60vh, 640px);
+      object-fit: cover;
+      filter: saturate(1.05) contrast(1.1);
+    }
+
+    .hero-content {
+      display: grid;
+      gap: 1.75rem;
+      width: min(1100px, 100%);
+      margin: 0 auto;
+      padding: 0 1.5rem;
+    }
+
+    .hero-content .classification-tag {
+      width: fit-content;
+      margin-top: 0.35rem;
+    }
+
+    .hero-brand-row {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      align-items: center;
+      gap: 1.5rem;
+    }
+
+    .hero-logo-large {
+      width: clamp(120px, 18vw, 180px);
+      filter: drop-shadow(0 25px 55px rgba(135, 189, 114, 0.45));
+    }
+
+    .hero-kicker {
+      font-weight: 700;
+      font-size: clamp(1.25rem, 2vw, 1.75rem);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #c2e9c1;
+      line-height: 1.45;
+    }
+
+    .hero h1 {
+      margin: 0;
+      font-size: clamp(2.1rem, 4.5vw, 2.85rem);
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: #f3f7f1;
+    }
+
+    .hero-subline {
+      max-width: 640px;
+      font-size: 1rem;
+      line-height: 1.7;
+      color: rgba(194, 233, 193, 0.78);
+    }
+
+    @media (max-width: 900px) {
+      .nav-menu {
+        position: fixed;
+        top: 76px;
+        right: 1.5rem;
+        left: 1.5rem;
+        flex-direction: column;
+        align-items: stretch;
+        background: rgba(0, 0, 0, 0.92);
+        border: 1px solid rgba(135, 189, 114, 0.28);
+        border-radius: 24px;
+        padding: 1.5rem;
+        transform: translateY(-140%);
+        opacity: 0;
+        pointer-events: none;
+        transition: transform 0.35s ease, opacity 0.35s ease;
+      }
+
+      .nav-menu.open {
+        transform: translateY(0);
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      .nav-menu a,
+      .nav-menu button {
+        width: 100%;
+        text-align: center;
+      }
+
+      .nav-toggle {
+        display: inline-flex;
+      }
+
+      .nav-container {
+        padding: 0.75rem 1.25rem;
+      }
+
+      .hero {
+        padding-top: 3.75rem;
+      }
+
+      .hero-brand-row {
+        grid-template-columns: 1fr;
+        justify-items: center;
+        text-align: center;
+      }
+
+      .hero-kicker {
+        font-size: clamp(1.15rem, 4vw, 1.6rem);
+      }
+
+      .hero-content {
+        padding: 0 1.25rem;
+      }
     }
 
     .access-gate-overlay {
       position: fixed;
       inset: 0;
-      background: rgba(23, 24, 26, 0.96);
-      backdrop-filter: blur(10px);
+      background: rgba(0, 0, 0, 0.92);
+      backdrop-filter: blur(14px);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -157,12 +462,12 @@
     }
 
     .access-gate-panel {
-      width: min(420px, 92vw);
-      background: linear-gradient(155deg, rgba(23, 24, 26, 0.95), rgba(1, 42, 70, 0.85));
-      border: 1px solid rgba(2, 72, 115, 0.45);
+      width: min(440px, 92vw);
+      background: linear-gradient(160deg, rgba(7, 10, 6, 0.95), rgba(28, 60, 35, 0.92));
+      border: 1px solid rgba(135, 189, 114, 0.45);
       border-radius: 32px;
-      padding: 2.5rem 2rem;
-      box-shadow: 0 30px 55px rgba(1, 42, 70, 0.45);
+      padding: 2.75rem 2.25rem;
+      box-shadow: 0 36px 75px rgba(0, 0, 0, 0.6);
       text-align: center;
       position: relative;
       overflow: hidden;
@@ -170,112 +475,92 @@
       transform: translateY(12px);
     }
 
+    .access-gate-panel .lock-loader {
+      margin: 0 auto 1.5rem;
+    }
+
     .access-gate-overlay.active .access-gate-panel {
       transform: translateY(0);
     }
 
     .gate-header {
-      font-size: 1.55rem;
-      letter-spacing: 0.08em;
+      font-size: 1.45rem;
+      letter-spacing: 0.16em;
       text-transform: uppercase;
-      margin-bottom: 1.25rem;
-      color: #e4e4e4;
+      margin-bottom: 1.35rem;
+      color: #c2e9c1;
     }
 
-    .gate-display {
-      font-family: "League Spartan", sans-serif;
-      font-size: 1.65rem;
-      letter-spacing: 0.22em;
-      color: rgba(228, 228, 228, 0.85);
-      background: rgba(23, 24, 26, 0.9);
-      border: 1px solid rgba(2, 72, 115, 0.55);
-      border-radius: 16px;
-      padding: 1rem 1.5rem;
-      margin-bottom: 1.75rem;
-      min-height: 3.5rem;
-      display: flex;
-      align-items: center;
-      justify-content: center;
+    .gate-description {
+      font-size: 0.95rem;
+      color: rgba(194, 233, 193, 0.75);
+      margin-bottom: 1.85rem;
+      line-height: 1.6;
     }
 
-    .gate-keypad {
+    .gate-form {
       display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 0.85rem;
-      margin-bottom: 1.5rem;
+      gap: 1.25rem;
     }
 
-    .keypad-key {
-      font-size: 1.35rem;
-      font-family: "League Spartan", sans-serif;
-      letter-spacing: 0.08em;
-      padding: 0.85rem 0;
-      border-radius: 18px;
-      border: 1px solid rgba(2, 72, 115, 0.4);
-      background: radial-gradient(circle at 50% 20%, rgba(72, 72, 76, 0.35), rgba(10, 10, 12, 0.95));
-      color: #e4e4e4;
-      cursor: pointer;
-      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+    .gate-field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.65rem;
     }
 
-    .keypad-key:focus-visible,
-    .keypad-key:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 12px 24px rgba(3, 8, 14, 0.6);
-      outline: none;
-      background: radial-gradient(circle at 50% 10%, rgba(96, 96, 102, 0.4), rgba(8, 8, 10, 0.92));
-    }
-
-    .keypad-key[data-keypad="submit"] {
-      background: radial-gradient(circle at 50% 18%, rgba(92, 92, 98, 0.45), rgba(6, 6, 8, 0.96));
-      border-color: rgba(40, 124, 168, 0.55);
-    }
-
-    .keypad-key[data-keypad="clear"] {
-      font-size: 1.05rem;
+    .gate-field label {
+      font-size: 0.78rem;
+      letter-spacing: 0.18em;
       text-transform: uppercase;
+      color: rgba(194, 233, 193, 0.65);
+    }
+
+    .gate-input {
+      padding: 0.85rem 1.15rem;
+      border-radius: 16px;
+      border: 1px solid rgba(135, 189, 114, 0.45);
+      background: rgba(7, 10, 6, 0.85);
+      color: #f3f7f1;
       letter-spacing: 0.12em;
+      text-align: center;
+      font-size: 1.1rem;
+    }
+
+    .gate-input::placeholder {
+      color: rgba(194, 233, 193, 0.35);
+      letter-spacing: 0.08em;
+    }
+
+    .gate-actions {
+      display: flex;
+      gap: 0.75rem;
+      justify-content: center;
+      flex-wrap: wrap;
     }
 
     .gate-status {
-      font-size: 0.85rem;
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      color: rgba(255, 119, 119, 0.78);
       min-height: 1.4rem;
+      font-size: 0.85rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: rgba(255, 119, 119, 0.8);
+    }
+
+    .access-gate-overlay .gate-status.success {
+      color: #c2e9c1;
+      animation: accessPulse 1.3s ease infinite;
     }
 
     .access-gate-overlay.error .access-gate-panel {
       border-color: rgba(255, 119, 119, 0.65);
-      box-shadow: 0 35px 65px rgba(255, 84, 84, 0.28);
-    }
-
-    .access-gate-overlay.error .gate-display {
-      border-color: rgba(255, 119, 119, 0.5);
-      color: rgba(255, 199, 199, 0.8);
+      box-shadow: 0 45px 85px rgba(255, 84, 84, 0.28);
     }
 
     .access-gate-overlay.success .access-gate-panel {
-      border-color: rgba(2, 72, 115, 0.85);
-      background: linear-gradient(155deg, rgba(1, 42, 70, 0.95), rgba(2, 72, 115, 0.92));
-      box-shadow: 0 45px 80px rgba(1, 42, 70, 0.5);
-    }
-
-    .access-gate-overlay.success .gate-display {
-      border-color: rgba(2, 72, 115, 0.65);
-      color: #e4e4e4;
-    }
-
-    .access-gate-overlay.success .gate-status {
-      color: #e4e4e4;
-      animation: accessPulse 1.2s ease infinite;
-    }
-
-    .access-gate-overlay.success .keypad-key {
-      background: radial-gradient(circle at 50% 18%, rgba(110, 110, 118, 0.45), rgba(12, 14, 18, 0.95));
-      border-color: rgba(40, 124, 168, 0.75);
-      color: #e4e4e4;
-      pointer-events: none;
+      border-color: rgba(135, 189, 114, 0.85);
+      background: linear-gradient(160deg, rgba(28, 60, 35, 0.95), rgba(69, 111, 58, 0.92));
+      box-shadow: 0 45px 80px rgba(31, 70, 40, 0.55);
     }
 
     @keyframes accessPulse {
@@ -296,70 +581,80 @@
 </head>
 <body class="ccai-page grid-background">
   <div class="page-loader" id="pageLoader" aria-hidden="true">
-    <div class="loader-ring" aria-hidden="true"></div>
-    <img src="assets/images/Crowncode/Crowncode-OG.png.PNG" alt="CrownCode.ai animated insignia" class="loader-logo" />
+    <img src="assets/images/Crowncode/Crowncode-OG.png" alt="CrownCode.ai animated insignia" class="loader-logo" />
+    <span class="flip-loader" aria-hidden="true"></span>
     <div class="loader-text">Initializing Secure Node</div>
   </div>
 
   <div class="brief-loader hidden" id="briefLoader" aria-hidden="true">
-    <div class="loader-ring" aria-hidden="true"></div>
-    <img src="assets/images/Crowncode/Crowncode-OG.png.PNG" alt="CrownCode.ai clearance loader" class="loader-logo" />
+    <img src="assets/images/Crowncode/Crowncode-OG.png" alt="CrownCode.ai clearance loader" class="loader-logo" />
+    <span class="lock-loader" aria-hidden="true"></span>
     <div class="loader-text">Authorizing Token</div>
   </div>
 
   <div class="access-gate-overlay" id="accessGate" role="dialog" aria-modal="true" aria-labelledby="gateTitle" aria-hidden="true">
     <div class="access-gate-panel">
-      <div class="gate-header" id="gateTitle">Enter Access Code</div>
-      <div class="gate-display" id="gateDisplay">ENTER CODE</div>
-      <div class="gate-keypad" role="group" aria-label="Secure numeric keypad">
-        <button type="button" class="keypad-key" data-keypad="1">1</button>
-        <button type="button" class="keypad-key" data-keypad="2">2</button>
-        <button type="button" class="keypad-key" data-keypad="3">3</button>
-        <button type="button" class="keypad-key" data-keypad="4">4</button>
-        <button type="button" class="keypad-key" data-keypad="5">5</button>
-        <button type="button" class="keypad-key" data-keypad="6">6</button>
-        <button type="button" class="keypad-key" data-keypad="7">7</button>
-        <button type="button" class="keypad-key" data-keypad="8">8</button>
-        <button type="button" class="keypad-key" data-keypad="9">9</button>
-        <button type="button" class="keypad-key" data-keypad="clear" aria-label="Clear access code">CLR</button>
-        <button type="button" class="keypad-key" data-keypad="0">0</button>
-        <button type="button" class="keypad-key" data-keypad="submit" aria-label="Submit access code">#</button>
-      </div>
-      <div class="gate-status" id="gateStatus" role="status" aria-live="polite"></div>
+      <span class="lock-loader" aria-hidden="true"></span>
+      <div class="gate-header" id="gateTitle">Clearance Password Required</div>
+      <p class="gate-description">Authenticate with the issued CrownCode.ai clearance string to continue.</p>
+      <form class="gate-form" id="gateForm">
+        <div class="gate-field">
+          <label for="gatePassword">Access Password</label>
+          <input type="password" class="gate-input" id="gatePassword" name="gatePassword" autocomplete="off" placeholder="Enter clearance password" required />
+        </div>
+        <div class="gate-actions">
+          <button type="submit" class="btn btn-primary">Unlock Access</button>
+          <button type="button" class="btn btn-secondary" id="gateReset">Reset</button>
+        </div>
+        <div class="gate-status" id="gateStatus" role="status" aria-live="polite"></div>
+      </form>
     </div>
   </div>
 
-  <img src="assets/images/Crowncode/905437AD-6656-4AD8-B5A6-CF08F6199F27.png" alt="CrownCode.ai chain badge" class="badge-watermark" />
-
-  <header id="hero">
-    <div class="top-bar">
-      <div class="top-brand">CrownCode.ai</div>
-      <a class="top-login" href="login.html">Login</a>
-    </div>
-    <div class="hero-topline">
-      <img src="assets/images/Crowncode/Crowncode-OG.png.PNG" alt="CrownCode.ai primary insignia" class="main-logo" />
-      <div class="classification-tag"><span></span> Authorized Access Only</div>
-    </div>
-    <div class="hero-copy">
-      <h1>CrownCode.ai Intelligence Systems</h1>
-      <p class="hero-subline">Advanced Behavioral, Forensic, and OSINT Modules — Authorized Access Only.</p>
-      <div class="cta-group">
-        <button class="btn btn-primary access-trigger" type="button" data-access-trigger>
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5h18"/><path d="M7 5v14a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V5"/><path d="M10 5V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2"/></svg>
-          Access The Brief
-        </button>
-        <a class="btn btn-secondary" href="mailto:sales@crowncode.ai">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10h-6"/><path d="M21 6H11a4 4 0 0 0-4 4v10"/><path d="m3 10 7 7 4-4 7 7"/></svg>
-          Contact Sales
-        </a>
-      </div>
-    </div>
-    <div class="hero-visual" aria-hidden="true">
-      <img src="assets/images/Crowncode/Crowncode-OG.png.PNG" alt="CrownCode.ai hero insignia" />
+  <header class="site-header">
+    <div class="nav-container">
+      <a class="brand-link" href="#hero">
+        <img src="assets/images/NavLogo.PNG" alt="CrownCode.ai navigation logo" />
+        <span>CrownCode.ai</span>
+      </a>
+      <button class="nav-toggle" type="button" id="navToggle" aria-expanded="false" aria-controls="primaryNav" aria-label="Toggle navigation">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </button>
+      <nav class="nav-menu" id="primaryNav">
+        <button class="nav-link-primary access-trigger" type="button" data-access-trigger>Access Brief</button>
+        <a href="#inquiry">Request Access</a>
+        <a href="login.html">Login</a>
+      </nav>
     </div>
   </header>
 
+  <img src="assets/images/Crowncode/905437AD-6656-4AD8-B5A6-CF08F6199F27.png" alt="CrownCode.ai chain badge" class="badge-watermark" />
+
   <main>
+    <section id="hero" class="hero">
+      <div class="hero-visual">
+        <img src="assets/images/Crowncode/desktopui-Nobg.PNG" alt="CrownCode.ai operations interface" />
+      </div>
+      <div class="hero-content">
+        <div class="hero-brand-row">
+          <img src="assets/images/Crowncode/Crowncode-OG.png" alt="CrownCode.ai primary insignia" class="hero-logo-large" />
+          <p class="hero-kicker">Building the future of AI forensics &amp; behavior profiling</p>
+        </div>
+        <div class="classification-tag"><span></span> Authorized Access Only</div>
+        <h1>CrownCode.ai Intelligence Systems</h1>
+        <p class="hero-subline">Advanced Behavioral, Forensic, and OSINT Modules — Authorized Access Only.</p>
+        <div class="cta-group">
+          <button class="btn btn-primary access-trigger" type="button" data-access-trigger>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5h18"/><path d="M7 5v14a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V5"/><path d="M10 5V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2"/></svg>
+            Access The Brief
+          </button>
+          <a class="btn btn-secondary" href="mailto:sales@crowncode.ai">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10h-6"/><path d="M21 6H11a4 4 0 0 0-4 4v10"/><path d="m3 10 7 7 4-4 7 7"/></svg>
+            Contact Sales
+          </a>
+        </div>
+      </div>
+    </section>
     <section id="about">
       <h2>(U) About CrownCode.ai</h2>
       <div class="about-text">
@@ -524,13 +819,14 @@
 
   <footer>
     <div class="contact">Contact: <a href="mailto:sales@crowncode.ai">sales@crowncode.ai</a></div>
-    <img src="assets/images/Crowncode/905437AD-6656-4AD8-B5A6-CF08F6199F27.png" alt="CrownCode.ai badge" class="footer-badge" />
+    <img src="assets/images/Crowncode/Crowncode-OG.png" alt="CrownCode.ai badge" class="footer-badge" />
   </footer>
 
   <script>
-    const ACCESS_TOKEN = "jagvov-8wyngy-sobpoK";
+    const CLEARANCE_PASSWORD = "@cc355D3n13D$$";
+    const ACCESS_TOKEN = CLEARANCE_PASSWORD;
     const ACCESS_STORAGE_KEY = "ccai-brief-clearance";
-    const NUMERIC_PASSCODE = "640161869";
+    const GATE_STORAGE_KEY = "ccai-gate-clearance";
     const pageLoader = document.getElementById("pageLoader");
     const briefLoader = document.getElementById("briefLoader");
     const accessModal = document.getElementById("accessModal");
@@ -544,102 +840,113 @@
     const proceedBriefBtn = document.getElementById("proceedBrief");
     const accessTriggers = document.querySelectorAll("[data-access-trigger]");
     const accessGate = document.getElementById("accessGate");
-    const gateDisplay = document.getElementById("gateDisplay");
+    const gateForm = document.getElementById("gateForm");
+    const gatePasswordInput = document.getElementById("gatePassword");
     const gateStatus = document.getElementById("gateStatus");
-    const gateButtons = accessGate ? accessGate.querySelectorAll("[data-keypad]") : [];
+    const gateReset = document.getElementById("gateReset");
+    const navToggle = document.getElementById("navToggle");
+    const navMenu = document.getElementById("primaryNav");
     let toastTimer;
-    let gateInput = "";
-    let gateUnlocked = false;
+    
+    function setNavState(open) {
+      if (!navMenu || !navToggle) return;
+      navMenu.classList.toggle("open", open);
+      navToggle.setAttribute("aria-expanded", String(open));
+    }
 
-    function updateGateDisplay() {
-      if (!gateDisplay) return;
-      gateDisplay.textContent = gateInput ? gateInput.replace(/./g, "•") : "ENTER CODE";
+    if (navToggle && navMenu) {
+      navToggle.addEventListener("click", () => {
+        const willOpen = !navMenu.classList.contains("open");
+        setNavState(willOpen);
+      });
+
+      navMenu.querySelectorAll("a, button").forEach((item) => {
+        item.addEventListener("click", () => {
+          if (navMenu.classList.contains("open")) {
+            setNavState(false);
+          }
+        });
+      });
     }
 
     function resetGateState() {
-      gateInput = "";
-      gateUnlocked = false;
       if (gateStatus) {
         gateStatus.textContent = "";
+        gateStatus.classList.remove("success");
       }
-      updateGateDisplay();
+      if (gatePasswordInput) {
+        gatePasswordInput.value = "";
+      }
       accessGate?.classList.remove("error", "success");
     }
 
-    function grantGateAccess() {
-      gateUnlocked = true;
-      if (gateStatus) {
-        gateStatus.textContent = "Access Granted";
-      }
-      if (gateDisplay) {
-        gateDisplay.textContent = "ACCESS GRANTED";
-      }
-      if (accessGate) {
-        accessGate.classList.remove("error");
-        accessGate.classList.add("success");
-      }
-      setTimeout(() => {
-        if (accessGate) {
-          accessGate.classList.remove("active");
-          accessGate.setAttribute("aria-hidden", "true");
-        }
+    function openGateOverlay() {
+      if (!accessGate) return;
+      accessGate.classList.add("active");
+      accessGate.setAttribute("aria-hidden", "false");
+      setBodyScrollLock(true);
+      setTimeout(() => gatePasswordInput?.focus(), 150);
+    }
+
+    function closeGateOverlay() {
+      if (!accessGate) return;
+      accessGate.classList.remove("active");
+      accessGate.setAttribute("aria-hidden", "true");
+      resetGateState();
+      if (!accessModal.classList.contains("active") && !warningModal.classList.contains("active")) {
         setBodyScrollLock(false);
-        setTimeout(() => {
-          if (accessGate) {
-            accessGate.classList.remove("success");
-          }
-          resetGateState();
-        }, 600);
+      }
+    }
+
+    function flagGateError() {
+      if (!accessGate || !gateStatus) return;
+      accessGate.classList.add("error");
+      gateStatus.textContent = "Password denied";
+      gateStatus.classList.remove("success");
+      triggerSecurityNotice("Invalid access code");
+      setTimeout(() => accessGate.classList.remove("error"), 900);
+    }
+
+    function handleGateSuccess() {
+      if (!accessGate || !gateStatus) return;
+      accessGate.classList.remove("error");
+      accessGate.classList.add("success");
+      gateStatus.textContent = "Access granted";
+      gateStatus.classList.add("success");
+      sessionStorage.setItem(GATE_STORAGE_KEY, "cleared");
+      setTimeout(() => {
+        closeGateOverlay();
       }, 1100);
     }
 
-    function handleGateInput(value) {
-      if (!accessGate || gateUnlocked) {
-        return;
-      }
-      accessGate.classList.remove("error");
-
-      if (value === "clear") {
-        resetGateState();
-        return;
-      }
-
-      if (value === "submit") {
-        if (gateInput === NUMERIC_PASSCODE) {
-          grantGateAccess();
-        } else {
-          accessGate.classList.add("error");
-          if (gateStatus) {
-            gateStatus.textContent = "Access Code Denied";
-          }
-          triggerSecurityNotice("Invalid access code");
-          setTimeout(() => accessGate && accessGate.classList.remove("error"), 900);
-        }
-        return;
-      }
-
-      if (gateInput.length < NUMERIC_PASSCODE.length) {
-        gateInput += value;
-        updateGateDisplay();
+    function handleGateSubmit(event) {
+      event.preventDefault();
+      const supplied = gatePasswordInput ? gatePasswordInput.value.trim() : "";
+      if (supplied === CLEARANCE_PASSWORD) {
+        handleGateSuccess();
+      } else {
+        flagGateError();
       }
     }
 
-    if (gateButtons.length) {
-      gateButtons.forEach((button) => {
-        button.addEventListener("click", () => handleGateInput(button.dataset.keypad));
+    if (gateForm) {
+      gateForm.addEventListener("submit", handleGateSubmit);
+    }
+
+    if (gateReset) {
+      gateReset.addEventListener("click", () => {
+        resetGateState();
+        gatePasswordInput?.focus();
       });
     }
 
     window.addEventListener("load", () => {
       setTimeout(() => {
-        pageLoader.classList.add("hidden");
-        if (accessGate) {
-          updateGateDisplay();
-          accessGate.classList.add("active");
-          accessGate.setAttribute("aria-hidden", "false");
-          setBodyScrollLock(true);
+        pageLoader?.classList.add("hidden");
+        if (accessGate && !sessionStorage.getItem(GATE_STORAGE_KEY)) {
+          openGateOverlay();
         }
-      }, 650);
+      }, 5200);
     });
 
     if (sessionStorage.getItem(ACCESS_STORAGE_KEY) === "verified") {
@@ -648,6 +955,7 @@
     }
 
     function triggerSecurityNotice(message) {
+      if (!securityToast) return;
       securityToast.textContent = message;
       securityToast.classList.add("active");
       clearTimeout(toastTimer);
@@ -667,6 +975,9 @@
     });
 
     document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape" && navMenu?.classList.contains("open")) {
+        setNavState(false);
+      }
       const blockedCombos = (
         (event.ctrlKey || event.metaKey) && ["s", "p", "u", "c", "x"].includes(event.key.toLowerCase())
       ) ||
@@ -704,6 +1015,9 @@
     }
 
     function handleAccessTrigger() {
+      if (navMenu?.classList.contains("open")) {
+        setNavState(false);
+      }
       if (sessionStorage.getItem(ACCESS_STORAGE_KEY) === "verified") {
         warningModal.classList.add("active");
         setBodyScrollLock(true);
@@ -714,9 +1028,9 @@
 
     function showBriefLoader() {
       setBodyScrollLock(true);
-      briefLoader.classList.remove("hidden");
+      briefLoader?.classList.remove("hidden");
       setTimeout(() => {
-        briefLoader.classList.add("hidden");
+        briefLoader?.classList.add("hidden");
         warningModal.classList.add("active");
       }, 1200);
     }


### PR DESCRIPTION
## Summary
- switch the CCAI page to the Rubik type family, update the favicon, and align on the black and green brand palette
- rebuild the sticky navigation with a mobile dropdown, full-width hero image, and refreshed hero messaging
- refresh all loaders and gated access logic with the animated lock, five-second preloader, shared clearance password, and the main logo in the footer

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d62cbd28048325b68fd188cf9d0e61