### PR TITLE
Fix Open Graph image previews

### DIFF
--- a/book.html
+++ b/book.html
@@ -7,13 +7,19 @@
     <meta name="description" content="No gimmicks. No games. Just results. Game On! is the bold, psychology-backed guide to flirting, confidence, and connection. Available in print, Kindle, & audiobook.">
     <meta property="og:title" content="Game On! by Daren Prince">
     <meta property="og:description" content="Discover the psychology-backed men's playbook for real attraction and conversation mastery.">
-    <meta property="og:image" content="https://darenprince.com/assets/images/og-daren-prince.png">
+    <meta property="og:image" content="https://darenprince.com/assets/images/og-image.jpg">
+    <meta property="og:image:secure_url" content="https://darenprince.com/assets/images/og-image.jpg">
+    <meta property="og:image:type" content="image/jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Daren Prince brand graphic featuring Game On! and Unshakeable book covers">
     <meta property="og:type" content="book">
     <meta property="og:url" content="https://darenprince.com/books/game-on">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Game On! by Daren Prince">
     <meta name="twitter:description" content="Learn how to spark real connection, master confidence, and win her heart with no gimmicks.">
-    <meta name="twitter:image" content="https://darenprince.com/assets/images/og-daren-prince.png">
+    <meta name="twitter:image" content="https://darenprince.com/assets/images/og-image.jpg">
+    <meta name="twitter:image:alt" content="Daren Prince brand graphic featuring Game On! and Unshakeable book covers">
     <link rel="canonical" href="https://darenprince.com/books/game-on">
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/styles.css">
@@ -27,7 +33,7 @@
       "@type": "Person",
       "name": "Daren Prince"
     },
-      "image": "https://darenprince.com/assets/images/og-daren-prince.png",
+      "image": "https://darenprince.com/assets/images/og-image.jpg",
     "bookFormat": "https://schema.org/EBook",
     "isbn": "9798303844407",
     "offers": {

--- a/contact.html
+++ b/contact.html
@@ -7,13 +7,19 @@
     <meta name="description" content="Want to connect with Daren Prince? Submit interview requests, speaking inquiries, or direct messages here. Let’s talk about it.">
     <meta property="og:title" content="Contact Daren Prince">
     <meta property="og:description" content="Reach out to Daren Prince for media, coaching, or collab opportunities. He reads every message.">
-    <meta property="og:image" content="https://darenprince.com/assets/images/og-daren-prince.png">
+    <meta property="og:image" content="https://darenprince.com/assets/images/og-image.jpg">
+    <meta property="og:image:secure_url" content="https://darenprince.com/assets/images/og-image.jpg">
+    <meta property="og:image:type" content="image/jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Daren Prince brand graphic featuring Game On! and Unshakeable book covers">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://darenprince.com/contact">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Contact Daren Prince">
     <meta name="twitter:description" content="Have a question, request, or idea? Send a message directly to Daren Prince.">
-    <meta name="twitter:image" content="https://darenprince.com/assets/images/og-daren-prince.png">
+    <meta name="twitter:image" content="https://darenprince.com/assets/images/og-image.jpg">
+    <meta name="twitter:image:alt" content="Daren Prince brand graphic featuring Game On! and Unshakeable book covers">
     <link rel="canonical" href="https://darenprince.com/contact">
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/styles.css">

--- a/image-index.html
+++ b/image-index.html
@@ -7,13 +7,19 @@
   <meta name="description" content="Browse a searchable catalog of images from Daren Prince's official site. View and copy asset links quickly.">
   <meta property="og:title" content="Image Index | Daren Prince">
   <meta property="og:description" content="Search and preview images from Daren Prince's official site in one place.">
-  <meta property="og:image" content="https://darenprince.com/assets/images/og-daren-prince.png">
+  <meta property="og:image" content="https://darenprince.com/assets/images/og-image.jpg">
+  <meta property="og:image:secure_url" content="https://darenprince.com/assets/images/og-image.jpg">
+  <meta property="og:image:type" content="image/jpeg">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="Daren Prince brand graphic featuring Game On! and Unshakeable book covers">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://darenprince.com/image-index">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Image Index | Daren Prince">
   <meta name="twitter:description" content="Quickly browse and copy image assets from Daren Prince's site.">
-  <meta name="twitter:image" content="https://darenprince.com/assets/images/og-daren-prince.png">
+  <meta name="twitter:image" content="https://darenprince.com/assets/images/og-image.jpg">
+  <meta name="twitter:image:alt" content="Daren Prince brand graphic featuring Game On! and Unshakeable book covers">
   <link rel="canonical" href="https://darenprince.com/image-index">
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/styles.css">

--- a/index.html
+++ b/index.html
@@ -15,7 +15,15 @@
       property="og:description"
       content="Official author site of Daren Prince. Explore books on connection, healing, and confidence."
     />
-    <meta property="og:image" content="https://darenprince.com/assets/images/og-daren-prince.png" />
+    <meta property="og:image" content="https://darenprince.com/assets/images/og-image.jpg" />
+    <meta property="og:image:secure_url" content="https://darenprince.com/assets/images/og-image.jpg" />
+    <meta property="og:image:type" content="image/jpeg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta
+      property="og:image:alt"
+      content="Daren Prince brand graphic featuring Game On! and Unshakeable book covers"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://darenprince.com/" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -26,7 +34,11 @@
     />
     <meta
       name="twitter:image"
-      content="https://darenprince.com/assets/images/og-daren-prince.png"
+      content="https://darenprince.com/assets/images/og-image.jpg"
+    />
+    <meta
+      name="twitter:image:alt"
+      content="Daren Prince brand graphic featuring Game On! and Unshakeable book covers"
     />
     <link rel="canonical" href="https://darenprince.com/" />
     <link
@@ -48,7 +60,7 @@
         "@type": "Person",
         "name": "Daren Prince",
         "url": "https://darenprince.com",
-        "image": "https://darenprince.com/assets/images/og-daren-prince.png",
+        "image": "https://darenprince.com/assets/images/og-image.jpg",
         "sameAs": [
           "https://www.amazon.com/author/darenprince",
           "https://www.goodreads.com/author/show/53671567.Daren_Prince"

--- a/press.html
+++ b/press.html
@@ -7,13 +7,19 @@
   <meta name="description" content="Access the official Daren Prince press kit, approved headshots, story angles, and media contact for interviews and speaking requests.">
   <meta property="og:title" content="Press &amp; Media | Daren Prince">
   <meta property="og:description" content="Download the official press kit, headshots, and media assets for Daren Prince. Book him for interviews, podcasts, and events.">
-  <meta property="og:image" content="https://darenprince.com/assets/images/og-daren-prince.png">
+  <meta property="og:image" content="https://darenprince.com/assets/images/og-image.jpg">
+  <meta property="og:image:secure_url" content="https://darenprince.com/assets/images/og-image.jpg">
+  <meta property="og:image:type" content="image/jpeg">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="Daren Prince brand graphic featuring Game On! and Unshakeable book covers">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://darenprince.com/press">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Daren Prince | Press Kit &amp; Media Info">
   <meta name="twitter:description" content="Download official press materials for Daren Prince and request interviews or speaking engagements.">
-  <meta name="twitter:image" content="https://darenprince.com/assets/images/og-daren-prince.png">
+  <meta name="twitter:image" content="https://darenprince.com/assets/images/og-image.jpg">
+  <meta name="twitter:image:alt" content="Daren Prince brand graphic featuring Game On! and Unshakeable book covers">
   <link rel="canonical" href="https://darenprince.com/press">
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/styles.css">


### PR DESCRIPTION
## Summary
- point Open Graph and Twitter cards on key pages to the optimized og-image.jpg asset
- add image metadata (secure URL, dimensions, type, alt text) to improve social share rendering and update related JSON-LD

## Testing
- not run (static HTML changes)


------
https://chatgpt.com/codex/tasks/task_e_68e07a5e6ae48325aefd5479da1e6abb