### PR TITLE
Restore preferred Open Graph image asset

### DIFF
--- a/book.html
+++ b/book.html
@@ -8,12 +8,18 @@
     <meta property="og:title" content="Game On! by Daren Prince">
     <meta property="og:description" content="Discover the psychology-backed men's playbook for real attraction and conversation mastery.">
     <meta property="og:image" content="https://darenprince.com/assets/images/og-daren-prince.png">
+    <meta property="og:image:secure_url" content="https://darenprince.com/assets/images/og-daren-prince.png">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:width" content="1366">
+    <meta property="og:image:height" content="767">
+    <meta property="og:image:alt" content="Portrait of Daren Prince with Game On! and Unshakeable book covers">
     <meta property="og:type" content="book">
     <meta property="og:url" content="https://darenprince.com/books/game-on">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Game On! by Daren Prince">
     <meta name="twitter:description" content="Learn how to spark real connection, master confidence, and win her heart with no gimmicks.">
     <meta name="twitter:image" content="https://darenprince.com/assets/images/og-daren-prince.png">
+    <meta name="twitter:image:alt" content="Portrait of Daren Prince with Game On! and Unshakeable book covers">
     <link rel="canonical" href="https://darenprince.com/books/game-on">
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/styles.css">

--- a/contact.html
+++ b/contact.html
@@ -8,12 +8,18 @@
     <meta property="og:title" content="Contact Daren Prince">
     <meta property="og:description" content="Reach out to Daren Prince for media, coaching, or collab opportunities. He reads every message.">
     <meta property="og:image" content="https://darenprince.com/assets/images/og-daren-prince.png">
+    <meta property="og:image:secure_url" content="https://darenprince.com/assets/images/og-daren-prince.png">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:width" content="1366">
+    <meta property="og:image:height" content="767">
+    <meta property="og:image:alt" content="Portrait of Daren Prince with Game On! and Unshakeable book covers">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://darenprince.com/contact">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Contact Daren Prince">
     <meta name="twitter:description" content="Have a question, request, or idea? Send a message directly to Daren Prince.">
     <meta name="twitter:image" content="https://darenprince.com/assets/images/og-daren-prince.png">
+    <meta name="twitter:image:alt" content="Portrait of Daren Prince with Game On! and Unshakeable book covers">
     <link rel="canonical" href="https://darenprince.com/contact">
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/styles.css">

--- a/image-index.html
+++ b/image-index.html
@@ -8,12 +8,18 @@
   <meta property="og:title" content="Image Index | Daren Prince">
   <meta property="og:description" content="Search and preview images from Daren Prince's official site in one place.">
   <meta property="og:image" content="https://darenprince.com/assets/images/og-daren-prince.png">
+  <meta property="og:image:secure_url" content="https://darenprince.com/assets/images/og-daren-prince.png">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:width" content="1366">
+  <meta property="og:image:height" content="767">
+  <meta property="og:image:alt" content="Portrait of Daren Prince with Game On! and Unshakeable book covers">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://darenprince.com/image-index">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Image Index | Daren Prince">
   <meta name="twitter:description" content="Quickly browse and copy image assets from Daren Prince's site.">
   <meta name="twitter:image" content="https://darenprince.com/assets/images/og-daren-prince.png">
+  <meta name="twitter:image:alt" content="Portrait of Daren Prince with Game On! and Unshakeable book covers">
   <link rel="canonical" href="https://darenprince.com/image-index">
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/styles.css">

--- a/index.html
+++ b/index.html
@@ -15,7 +15,21 @@
       property="og:description"
       content="Official author site of Daren Prince. Explore books on connection, healing, and confidence."
     />
-    <meta property="og:image" content="https://darenprince.com/assets/images/og-daren-prince.png" />
+    <meta
+      property="og:image"
+      content="https://darenprince.com/assets/images/og-daren-prince.png"
+    />
+    <meta
+      property="og:image:secure_url"
+      content="https://darenprince.com/assets/images/og-daren-prince.png"
+    />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="1366" />
+    <meta property="og:image:height" content="767" />
+    <meta
+      property="og:image:alt"
+      content="Portrait of Daren Prince with Game On! and Unshakeable book covers"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://darenprince.com/" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -27,6 +41,10 @@
     <meta
       name="twitter:image"
       content="https://darenprince.com/assets/images/og-daren-prince.png"
+    />
+    <meta
+      name="twitter:image:alt"
+      content="Portrait of Daren Prince with Game On! and Unshakeable book covers"
     />
     <link rel="canonical" href="https://darenprince.com/" />
     <link

--- a/press.html
+++ b/press.html
@@ -8,12 +8,18 @@
   <meta property="og:title" content="Press &amp; Media | Daren Prince">
   <meta property="og:description" content="Download the official press kit, headshots, and media assets for Daren Prince. Book him for interviews, podcasts, and events.">
   <meta property="og:image" content="https://darenprince.com/assets/images/og-daren-prince.png">
+  <meta property="og:image:secure_url" content="https://darenprince.com/assets/images/og-daren-prince.png">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:width" content="1366">
+  <meta property="og:image:height" content="767">
+  <meta property="og:image:alt" content="Portrait of Daren Prince with Game On! and Unshakeable book covers">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://darenprince.com/press">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Daren Prince | Press Kit &amp; Media Info">
   <meta name="twitter:description" content="Download official press materials for Daren Prince and request interviews or speaking engagements.">
   <meta name="twitter:image" content="https://darenprince.com/assets/images/og-daren-prince.png">
+  <meta name="twitter:image:alt" content="Portrait of Daren Prince with Game On! and Unshakeable book covers">
   <link rel="canonical" href="https://darenprince.com/press">
   <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/styles.css">


### PR DESCRIPTION
## Summary
- revert Open Graph and Twitter metadata on key pages to use the existing og-daren-prince.png asset
- update accompanying metadata (secure URL, type, dimensions, alt text, JSON-LD) to match the restored PNG image

## Testing
- not run (static HTML changes)


------
https://chatgpt.com/codex/tasks/task_e_68e07a5e6ae48325aefd5479da1e6abb