### PR TITLE
Fix 911 emergency portal preloader

### DIFF
--- a/911.html
+++ b/911.html
@@ -40,5 +40,6 @@
     <p class="page-preloader__text">Preparing emergency portal&hellip;</p>
   </div>
 <!-- ... rest of file unchanged ... -->
+  <script src="emergency-911/dist/911.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add the emergency portal script to the 911 landing page so the preloader dismisses and reveals the gate

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0da6e45a88325918c1a8a36da367b