### PR TITLE
Add GitHub Pages PR preview workflow

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,49 @@
+name: Deploy PR previews
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        if: github.event.action != 'closed'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        if: github.event.action != 'closed'
+        run: npm ci
+
+      - name: Build site assets
+        if: github.event.action != 'closed'
+        run: npm run build
+
+      - name: Remove build dependencies
+        if: github.event.action != 'closed'
+        run: rm -rf node_modules
+
+      - name: Deploy preview to GitHub Pages
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          preview-branch: gh-pages
+          source-dir: .

--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ netlify dev
 Pushing to `main` triggers Netlify CI/CD. Connect the Netlify Supabase integration so environment variables stay synchronized.
 If the build ever skips `scripts/generate-env.js`, the browser will fetch `/.netlify/functions/supabase-config` at runtime to hydrate Supabase credentials from Netlify env vars.
 
+### Pull request previews on GitHub Pages
+
+- Workflow: [`.github/workflows/deploy-pr-preview.yml`](./.github/workflows/deploy-pr-preview.yml) installs [Deploy PR Preview](https://github.com/marketplace/actions/deploy-pr-preview) so every in-repo pull request publishes a temporary GitHub Pages build under `pr-preview/pr-<number>/`.
+- Configure **Settings → Pages** to deploy from the `gh-pages` branch (or update `preview-branch` in the workflow to match your Pages branch).
+- Grant the repository **Actions → General → Workflow permissions → Read and write** access so the action can push preview commits and update sticky comments.
+- The workflow skips forked pull requests until upstream support lands in the action; local branches within this repo receive previews automatically.
+- Closing a pull request automatically removes its preview, keeping the `gh-pages` branch tidy.
+
 ### Dashboard Access on Netlify
 
 1. Connect the Supabase integration in Netlify for env parity.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the site and deploys PR previews to the gh-pages branch using the Deploy PR Preview marketplace action
- document the new preview workflow and required repository settings in the README so maintainers know how to enable it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e17f77142883259eb7727d6d1a77c9