### PR TITLE
Fix 911 OG image reference and guard against regressions

### DIFF
--- a/911.html
+++ b/911.html
@@ -139,7 +139,7 @@
     property="og:description"
     content="Daren Prince has activated his personal SOS emergency portal. This is a live distress signal that indicates potential danger or duress. The portal contains his current live location, along with photos, videos, audio recordings, and evidence captured in real time. This alert requires immediate attention. Please review the portal without delay. Treat this as a call to safeguard life."
   />
-  <meta property="og:image" content="emergency-911/911-og%20image.jpeg" />
+  <meta property="og:image" content="emergency-911/911-ogimage.jpeg" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <meta property="og:image:alt" content="⚠️ SOS ALERT TRIGGERED – Review Immediately" />
@@ -149,7 +149,7 @@
     name="twitter:description"
     content="Daren Prince has activated his personal SOS emergency portal. This is a live distress signal that indicates potential danger or duress. The portal contains his current live location, along with photos, videos, audio recordings, and evidence captured in real time. This alert requires immediate attention. Please review the portal without delay. Treat this as a call to safeguard life."
   />
-  <meta name="twitter:image" content="emergency-911/911-og%20image.jpeg" />
+  <meta name="twitter:image" content="emergency-911/911-ogimage.jpeg" />
   <meta name="twitter:image:alt" content="⚠️ SOS ALERT TRIGGERED – Review Immediately" />
   <title>Urgent! ⚠️ SOS Alert From Daren Prince</title>
   <link rel="apple-touch-icon" sizes="180x180" href="emergency-911/favicon/apple-touch-icon.png" />

--- a/tests/og-image.spec.ts
+++ b/tests/og-image.spec.ts
@@ -1,0 +1,28 @@
+import { accessSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { load } from 'cheerio'
+import { describe, expect, it } from 'vitest'
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(currentDir, '..')
+const htmlPath = path.join(repoRoot, '911.html')
+const imageRelativePath = 'emergency-911/911-ogimage.jpeg'
+const imagePath = path.join(repoRoot, imageRelativePath)
+
+describe('911 metadata og:image', () => {
+  const html = readFileSync(htmlPath, 'utf8')
+  const $ = load(html)
+
+  it('references the dedicated OG asset', () => {
+    const ogImage = $('meta[property="og:image"]').attr('content')
+    const twitterImage = $('meta[name="twitter:image"]').attr('content')
+
+    expect(ogImage).toBe(imageRelativePath)
+    expect(twitterImage).toBe(imageRelativePath)
+  })
+
+  it('includes the OG image file in the repository', () => {
+    expect(() => accessSync(imagePath)).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- point the 911 emergency landing page OG/Twitter image metadata at the correct dedicated artwork
- add a Vitest safeguard that asserts the metadata references the expected file and that the asset exists in the repo

## Testing
- npm test *(fails: netlify-rules.spec.ts receives 503 responses from darenprince.netlify.app)*

------
https://chatgpt.com/codex/tasks/task_e_68e19cf0978883258bb83de622a774e2