### PR TITLE
Soften container shadows across site

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3930,7 +3930,7 @@ input:checked + .toggle-slider::before {
   color: #f5f5f7;
   background: rgba(29, 29, 31, 0.92);
   backdrop-filter: blur(18px);
-  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.24);
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 0;
   font-family:
@@ -3986,7 +3986,7 @@ input:checked + .toggle-slider::before {
   height: clamp(52px, 8vw, 64px);
   border-radius: 0;
   object-fit: cover;
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.28);
 }
 
 .smart-app-banner__copy {
@@ -4368,7 +4368,7 @@ input:checked + .toggle-slider::before {
   border-radius: 0.6875rem;
   background: color-mix(in srgb, var(--gray-900) 88%, transparent);
   border: 1px solid color-mix(in srgb, var(--color-lime) 18%, transparent);
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.28);
 }
 @media (min-width: 768px) {
   .author-spotlight-card {
@@ -4380,7 +4380,7 @@ input:checked + .toggle-slider::before {
   position: relative;
   border-radius: 0.4375rem;
   overflow: hidden;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.38);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
 }
 .author-spotlight-card__media img {
   width: 100%;
@@ -4762,8 +4762,8 @@ body.is-preloading {
   border-radius: 32px;
   background: var(--banner-bg);
   box-shadow:
-    0 45px 80px -60px rgba(9, 16, 28, 0.55),
-    inset 0 1px 0 rgba(255, 255, 255, 0.7);
+    0 26px 48px -34px rgba(9, 16, 28, 0.32),
+    inset 0 1px 0 rgba(255, 255, 255, 0.6);
   color: #1d1d1f;
   border: 1px solid rgba(0, 0, 0, 0.06);
   overflow: hidden;
@@ -4810,7 +4810,7 @@ body.is-preloading {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 18px 38px -24px rgba(255, 143, 10, 0.9);
+  box-shadow: 0 12px 24px -16px rgba(255, 143, 10, 0.55);
   position: relative;
 }
 
@@ -4901,8 +4901,8 @@ body.is-preloading {
   aspect-ratio: 3/4.5;
   border-radius: 16px;
   box-shadow:
-    0 24px 36px -26px rgba(15, 23, 42, 0.6),
-    0 18px 28px -28px rgba(0, 0, 0, 0.55);
+    0 14px 26px -18px rgba(15, 23, 42, 0.35),
+    0 12px 22px -20px rgba(0, 0, 0, 0.28);
 }
 
 .apple-oem-banner__button {
@@ -4916,7 +4916,7 @@ body.is-preloading {
   font-weight: 600;
   font-size: 1rem;
   text-decoration: none;
-  box-shadow: 0 20px 30px -18px var(--accent-soft);
+  box-shadow: 0 12px 22px -14px var(--accent-soft);
   transition:
     transform 0.25s ease,
     box-shadow 0.25s ease;
@@ -4925,7 +4925,7 @@ body.is-preloading {
 .apple-oem-banner__button:hover,
 .apple-oem-banner__button:focus-visible {
   transform: translateY(-2px);
-  box-shadow: 0 26px 42px -18px var(--accent-soft);
+  box-shadow: 0 16px 30px -16px var(--accent-soft);
 }
 
 .apple-oem-banner__footer {
@@ -4957,8 +4957,8 @@ body.is-preloading {
 .apple-oem-banner--inset {
   --banner-bg: linear-gradient(145deg, #ffffff 5%, #f4f7ff 55%, #e8ecff 100%);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.9),
-    0 35px 70px -55px rgba(18, 22, 33, 0.6);
+    inset 0 1px 0 rgba(255, 255, 255, 0.85),
+    0 18px 40px -28px rgba(18, 22, 33, 0.38);
   border: 1px solid rgba(0, 0, 0, 0.08);
 }
 
@@ -5005,7 +5005,7 @@ body.is-preloading {
 .apple-oem-banner--edge {
   --banner-bg: linear-gradient(120deg, #ffffff 0%, #f5f7ff 50%, #edf2ff 100%);
   border: 1px solid rgba(0, 0, 0, 0.05);
-  box-shadow: 0 60px 90px -80px rgba(12, 21, 35, 0.6);
+  box-shadow: 0 20px 38px -28px rgba(12, 21, 35, 0.26);
 }
 
 .apple-oem-banner--edge::before {
@@ -5016,7 +5016,7 @@ body.is-preloading {
   --banner-bg: linear-gradient(120deg, #ffffff 0%, #f8f9fb 60%, #f0f2f7 100%);
   --accent: #0a84ff;
   --accent-soft: rgba(10, 132, 255, 0.16);
-  box-shadow: 0 24px 44px -32px rgba(15, 23, 42, 0.4);
+  box-shadow: 0 16px 32px -24px rgba(15, 23, 42, 0.28);
 }
 
 .apple-oem-banner--minimal .apple-oem-banner__pill {
@@ -5465,7 +5465,7 @@ body.is-preloading {
   border-radius: 0.6875rem;
   padding: 0.75rem;
   text-align: center;
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.32);
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.24);
 }
 .bio-intro .bio-intro__portrait img {
   width: 100%;
@@ -5512,7 +5512,7 @@ body.is-preloading {
   border-radius: 0.6875rem;
   padding: 2rem 1rem;
   text-align: center;
-  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.26);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.22);
 }
 .bio-stats .bio-stat h3 {
   font-size: 2rem;
@@ -5669,7 +5669,7 @@ body.is-preloading {
   border-radius: 0.6875rem;
   padding: 2rem;
   border: 1px solid color-mix(in srgb, var(--color-mint) 20%, transparent);
-  box-shadow: 0 20px 42px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.26);
 }
 .bio-cta .bio-cta__subscribe {
   display: grid;
@@ -5704,7 +5704,7 @@ body.is-preloading {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.24);
 }
 .bio-versions .bio-version h3 {
   margin: 0;
@@ -5778,7 +5778,7 @@ body.is-preloading {
   border-radius: 0.6875rem;
   padding: 2rem;
   border: 1px solid color-mix(in srgb, var(--color-mint) 18%, transparent);
-  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.22);
 }
 .press-hero .press-hero__highlight h2 {
   margin-top: 0;
@@ -5828,7 +5828,7 @@ body.is-preloading {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.2);
 }
 .press-topics .press-topic h3 {
   margin: 0;
@@ -5869,7 +5869,7 @@ body.is-preloading {
   height: 640px;
   border: none;
   border-radius: 0.6875rem;
-  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.32);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.24);
   background: color-mix(in srgb, var(--gray-900) 92%, transparent);
 }
 
@@ -5895,7 +5895,7 @@ body.is-preloading {
   padding: 2rem;
   text-align: center;
   border: 1px solid color-mix(in srgb, var(--color-mint) 14%, transparent);
-  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.26);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.22);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -5937,7 +5937,7 @@ body.is-preloading {
   padding: 1rem;
   border: 1px solid color-mix(in srgb, var(--color-mint) 14%, transparent);
   text-align: center;
-  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.2);
 }
 .press-headshots figure img {
   width: 100%;
@@ -6001,7 +6001,7 @@ body.is-preloading {
   border-radius: 0.6875rem;
   padding: 2rem;
   border: 1px solid color-mix(in srgb, var(--color-mint) 16%, transparent);
-  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.26);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.22);
   display: grid;
   gap: 0.75rem;
 }
@@ -6025,7 +6025,7 @@ body.is-preloading {
   --cta-bg: #4a7bff;
   --cta-outline: rgba(74, 123, 255, 0.45);
   --cta-text: #020613;
-  --shadow: 0 28px 48px rgba(7, 14, 30, 0.55);
+  --shadow: 0 16px 32px rgba(7, 14, 30, 0.35);
   --border-strong: rgba(74, 123, 255, 0.45);
   --border-soft: rgba(104, 149, 255, 0.22);
   --border-card: rgba(74, 123, 255, 0.28);
@@ -6293,7 +6293,7 @@ body.is-preloading {
 }
 .ccai-page .btn-primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 26px 46px rgba(39, 75, 204, 0.38);
+  box-shadow: 0 14px 28px rgba(39, 75, 204, 0.26);
 }
 .ccai-page .btn-secondary {
   border-color: var(--cta-outline);
@@ -6320,7 +6320,7 @@ body.is-preloading {
   border: 1px solid var(--border-strong);
   background: var(--panel-soft);
   border-radius: 1.5rem;
-  box-shadow: 0 20px 48px rgba(7, 14, 30, 0.4);
+  box-shadow: 0 12px 28px rgba(7, 14, 30, 0.28);
   backdrop-filter: blur(16px);
 }
 .ccai-page section::before {
@@ -6502,7 +6502,7 @@ body.is-preloading {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  box-shadow: 0 32px 64px rgba(7, 14, 30, 0.5);
+  box-shadow: 0 18px 36px rgba(7, 14, 30, 0.32);
   position: relative;
 }
 .ccai-page .modal-panel h3 {
@@ -6612,7 +6612,7 @@ body.is-preloading {
   border-radius: 1.75rem;
   overflow: hidden;
   background: var(--panel);
-  box-shadow: 0 32px 66px rgba(7, 14, 30, 0.5);
+  box-shadow: 0 18px 38px rgba(7, 14, 30, 0.34);
 }
 .ccai-page .brief-shell.active {
   display: flex;
@@ -6858,7 +6858,7 @@ body.is-preloading {
   border-radius: 0.825rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: linear-gradient(140deg, rgba(33, 33, 33, 0.75), rgba(7, 10, 6, 0.85));
-  box-shadow: 0 30px 45px rgba(7, 10, 6, 0.35);
+  box-shadow: 0 14px 28px rgba(7, 10, 6, 0.28);
   transition:
     transform 0.3s ease,
     border-color 0.3s ease,
@@ -6868,7 +6868,7 @@ body.is-preloading {
 .contact-page .contact-card:focus-within {
   transform: translateY(-6px);
   border-color: rgba(135, 189, 114, 0.65);
-  box-shadow: 0 40px 60px rgba(7, 10, 6, 0.45);
+  box-shadow: 0 16px 28px rgba(7, 10, 6, 0.32);
 }
 .contact-page .contact-card h2 {
   font-size: 1.45rem;
@@ -7003,7 +7003,7 @@ body.is-preloading {
   border-radius: 0.790625rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(12, 18, 12, 0.85);
-  box-shadow: 0 28px 42px rgba(7, 10, 6, 0.38);
+  box-shadow: 0 16px 32px rgba(7, 10, 6, 0.3);
 }
 .contact-page .contact-form__urgency {
   margin: 0;

--- a/labs/crowncode/stylesheets/global.css
+++ b/labs/crowncode/stylesheets/global.css
@@ -138,7 +138,7 @@ html.ccai-modal-open body {
   background: rgba(8, 22, 38, 0.92);
   border: 1px solid var(--ccai-border);
   color: #f7fbff;
-  box-shadow: 0 24px 48px rgba(6, 18, 30, 0.4);
+  box-shadow: 0 8px 18px rgba(6, 18, 30, 0.18);
 }
 
 .ccai-page .usa-summary-box__heading {

--- a/labs/crowncode/stylesheets/packages/ccai-overrides.css
+++ b/labs/crowncode/stylesheets/packages/ccai-overrides.css
@@ -28,7 +28,7 @@
   border-radius: 1rem;
   background: linear-gradient(160deg, rgba(17, 46, 81, 0.95), rgba(8, 27, 45, 0.95));
   border: 1px solid var(--ccai-border);
-  box-shadow: 0 32px 64px rgba(6, 18, 30, 0.55);
+  box-shadow: 0 10px 20px rgba(6, 18, 30, 0.22);
   text-align: center;
   width: min(90vw, 420px);
 }
@@ -130,7 +130,7 @@
 .ccai-gate__keypad button:hover,
 .ccai-gate__keypad button:focus-visible {
   transform: translateY(-2px);
-  box-shadow: 0 16px 28px rgba(6, 18, 30, 0.45);
+  box-shadow: 0 8px 16px rgba(6, 18, 30, 0.2);
   border-color: rgba(154, 209, 255, 0.7);
   outline: none;
 }

--- a/scss/components/_bio-page.scss
+++ b/scss/components/_bio-page.scss
@@ -1,6 +1,6 @@
-@use "../base/variables" as *;
-@use "../tokens/colors" as *;
-@use "../base/mixins" as *;
+@use '../base/variables' as *;
+@use '../tokens/colors' as *;
+@use '../base/mixins' as *;
 
 .bio-hero {
   position: relative;
@@ -9,7 +9,7 @@
   overflow: hidden;
 
   &::after {
-    content: "";
+    content: '';
     position: absolute;
     inset: 0;
     background: radial-gradient(circle at top right, rgba($mint-green, 0.18) 0%, transparent 55%);
@@ -80,11 +80,15 @@
   }
 
   .bio-intro__portrait {
-    background: linear-gradient(160deg, color-mix(in srgb, $mint-green 24%, transparent), transparent 60%);
+    background: linear-gradient(
+      160deg,
+      color-mix(in srgb, $mint-green 24%, transparent),
+      transparent 60%
+    );
     border-radius: $border-radius;
     padding: $spacing-sm;
     text-align: center;
-    box-shadow: 0 16px 32px rgba(0, 0, 0, 0.32);
+    box-shadow: 0 10px 22px rgba(0, 0, 0, 0.24);
 
     img {
       width: 100%;
@@ -139,7 +143,7 @@
     border-radius: $border-radius;
     padding: $spacing-lg $spacing-md;
     text-align: center;
-    box-shadow: 0 18px 34px rgba(0, 0, 0, 0.26);
+    box-shadow: 0 12px 26px rgba(0, 0, 0, 0.22);
 
     h3 {
       font-size: 2rem;
@@ -168,7 +172,11 @@
   }
 
   .bio-pillar {
-    background: linear-gradient(160deg, color-mix(in srgb, $gray-900 82%, transparent), transparent 55%);
+    background: linear-gradient(
+      160deg,
+      color-mix(in srgb, $gray-900 82%, transparent),
+      transparent 55%
+    );
     padding: $spacing-lg;
     border-radius: $border-radius;
     border: 1px solid color-mix(in srgb, $mint-green 16%, transparent);
@@ -223,7 +231,7 @@
       padding-left: $spacing-lg;
 
       &::before {
-        content: "";
+        content: '';
         position: absolute;
         top: 0.4rem;
         left: 0;
@@ -249,7 +257,8 @@
 
 .bio-media {
   padding: $spacing-xl 0;
-  background: linear-gradient(180deg, rgba(17, 18, 23, 0.92), rgba(17, 18, 23, 0.92)),
+  background:
+    linear-gradient(180deg, rgba(17, 18, 23, 0.92), rgba(17, 18, 23, 0.92)),
     url('../assets/images/IMG_6127.png') center/cover no-repeat;
 
   .bio-media__grid {
@@ -289,7 +298,8 @@
 
 .bio-cta {
   padding: $spacing-xl 0 $spacing-lg;
-  background: linear-gradient(180deg, rgba(17, 18, 23, 0.94), rgba(17, 18, 23, 0.94)),
+  background:
+    linear-gradient(180deg, rgba(17, 18, 23, 0.94), rgba(17, 18, 23, 0.94)),
     url('../assets/images/IMG_6099.jpeg') center/cover no-repeat;
 
   .bio-cta__grid {
@@ -307,7 +317,7 @@
     border-radius: $border-radius;
     padding: $spacing-lg;
     border: 1px solid color-mix(in srgb, $mint-green 20%, transparent);
-    box-shadow: 0 20px 42px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 14px 30px rgba(0, 0, 0, 0.26);
   }
 
   .bio-cta__subscribe {
@@ -344,7 +354,7 @@
     display: flex;
     flex-direction: column;
     gap: $spacing-sm;
-    box-shadow: 0 16px 38px rgba(0, 0, 0, 0.28);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.24);
 
     h3 {
       margin: 0;

--- a/scss/components/_book-details-wrapper.scss
+++ b/scss/components/_book-details-wrapper.scss
@@ -1,6 +1,6 @@
-@use "../base/variables" as *;
-@use "../tokens/colors" as *;
-@use "../base/mixins" as *;
+@use '../base/variables' as *;
+@use '../tokens/colors' as *;
+@use '../base/mixins' as *;
 
 .book-section {
   margin-top: $spacing-xl;
@@ -55,7 +55,9 @@
     text-align: center;
     color: $lime-green;
     font-weight: 700;
-    transition: opacity 0.3s ease, transform 0.3s ease;
+    transition:
+      opacity 0.3s ease,
+      transform 0.3s ease;
 
     &.hide {
       opacity: 0;
@@ -68,7 +70,9 @@
     display: flex;
     gap: $spacing-sm;
     justify-content: center;
-    transition: opacity 0.3s ease, transform 0.3s ease;
+    transition:
+      opacity 0.3s ease,
+      transform 0.3s ease;
     width: 100%;
 
     &.hide {
@@ -109,7 +113,9 @@
     gap: $spacing-sm;
     opacity: 0;
     transform: translateY(10px);
-    transition: opacity 0.3s ease, transform 0.3s ease;
+    transition:
+      opacity 0.3s ease,
+      transform 0.3s ease;
 
     &.visible {
       opacity: 1;
@@ -183,7 +189,7 @@
   border-radius: $border-radius;
   background: color-mix(in srgb, $gray-900 88%, transparent);
   border: 1px solid color-mix(in srgb, $lime-green 18%, transparent);
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.28);
 
   @include respond-to(md) {
     grid-template-columns: minmax(0, 180px) 1fr;
@@ -194,7 +200,7 @@
     position: relative;
     border-radius: calc($border-radius - $spacing-xxs);
     overflow: hidden;
-    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.38);
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
 
     img {
       width: 100%;
@@ -235,4 +241,3 @@
     align-self: flex-start;
   }
 }
-

--- a/scss/components/_press-page.scss
+++ b/scss/components/_press-page.scss
@@ -1,6 +1,6 @@
-@use "../base/variables" as *;
-@use "../tokens/colors" as *;
-@use "../base/mixins" as *;
+@use '../base/variables' as *;
+@use '../tokens/colors' as *;
+@use '../base/mixins' as *;
 
 .press-hero {
   position: relative;
@@ -8,7 +8,7 @@
   overflow: hidden;
 
   &::after {
-    content: "";
+    content: '';
     position: absolute;
     inset: 0;
     background: radial-gradient(circle at top left, rgba($mint-green, 0.18) 0%, transparent 55%);
@@ -65,7 +65,7 @@
     border-radius: $border-radius;
     padding: $spacing-lg;
     border: 1px solid color-mix(in srgb, $mint-green 18%, transparent);
-    box-shadow: 0 18px 36px rgba(0, 0, 0, 0.28);
+    box-shadow: 0 12px 26px rgba(0, 0, 0, 0.22);
 
     h2 {
       margin-top: 0;
@@ -119,7 +119,7 @@
     display: flex;
     flex-direction: column;
     gap: $spacing-sm;
-    box-shadow: 0 16px 32px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 10px 22px rgba(0, 0, 0, 0.2);
 
     h3 {
       margin: 0;
@@ -165,7 +165,7 @@
     height: 640px;
     border: none;
     border-radius: $border-radius;
-    box-shadow: 0 24px 50px rgba(0, 0, 0, 0.32);
+    box-shadow: 0 14px 30px rgba(0, 0, 0, 0.24);
     background: color-mix(in srgb, $gray-900 92%, transparent);
   }
 }
@@ -183,12 +183,16 @@
   }
 
   .press-download {
-    background: linear-gradient(150deg, color-mix(in srgb, $gray-900 86%, transparent), transparent 70%);
+    background: linear-gradient(
+      150deg,
+      color-mix(in srgb, $gray-900 86%, transparent),
+      transparent 70%
+    );
     border-radius: $border-radius;
     padding: $spacing-lg;
     text-align: center;
     border: 1px solid color-mix(in srgb, $mint-green 14%, transparent);
-    box-shadow: 0 18px 38px rgba(0, 0, 0, 0.26);
+    box-shadow: 0 12px 26px rgba(0, 0, 0, 0.22);
     display: flex;
     flex-direction: column;
     gap: $spacing-sm;
@@ -235,7 +239,7 @@
     padding: $spacing-md;
     border: 1px solid color-mix(in srgb, $mint-green 14%, transparent);
     text-align: center;
-    box-shadow: 0 14px 30px rgba(0, 0, 0, 0.24);
+    box-shadow: 0 10px 22px rgba(0, 0, 0, 0.2);
 
     img {
       width: 100%;
@@ -309,7 +313,7 @@
     border-radius: $border-radius;
     padding: $spacing-lg;
     border: 1px solid color-mix(in srgb, $mint-green 16%, transparent);
-    box-shadow: 0 18px 36px rgba(0, 0, 0, 0.26);
+    box-shadow: 0 12px 26px rgba(0, 0, 0, 0.22);
     display: grid;
     gap: $spacing-sm;
 

--- a/scss/components/_promotion-tools.scss
+++ b/scss/components/_promotion-tools.scss
@@ -108,8 +108,8 @@
   border-radius: 32px;
   background: var(--banner-bg);
   box-shadow:
-    0 45px 80px -60px rgba(9, 16, 28, 0.55),
-    inset 0 1px 0 rgba(255, 255, 255, 0.7);
+    0 26px 48px -34px rgba(9, 16, 28, 0.32),
+    inset 0 1px 0 rgba(255, 255, 255, 0.6);
   color: #1d1d1f;
   border: 1px solid rgba(0, 0, 0, 0.06);
   overflow: hidden;
@@ -156,7 +156,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 18px 38px -24px rgba(255, 143, 10, 0.9);
+  box-shadow: 0 12px 24px -16px rgba(255, 143, 10, 0.55);
   position: relative;
 }
 
@@ -247,8 +247,8 @@
   aspect-ratio: 3 / 4.5;
   border-radius: 16px;
   box-shadow:
-    0 24px 36px -26px rgba(15, 23, 42, 0.6),
-    0 18px 28px -28px rgba(0, 0, 0, 0.55);
+    0 14px 26px -18px rgba(15, 23, 42, 0.35),
+    0 12px 22px -20px rgba(0, 0, 0, 0.28);
 }
 
 .apple-oem-banner__button {
@@ -262,7 +262,7 @@
   font-weight: 600;
   font-size: 1rem;
   text-decoration: none;
-  box-shadow: 0 20px 30px -18px var(--accent-soft);
+  box-shadow: 0 12px 22px -14px var(--accent-soft);
   transition:
     transform 0.25s ease,
     box-shadow 0.25s ease;
@@ -271,7 +271,7 @@
 .apple-oem-banner__button:hover,
 .apple-oem-banner__button:focus-visible {
   transform: translateY(-2px);
-  box-shadow: 0 26px 42px -18px var(--accent-soft);
+  box-shadow: 0 16px 30px -16px var(--accent-soft);
 }
 
 .apple-oem-banner__footer {
@@ -303,8 +303,8 @@
 .apple-oem-banner--inset {
   --banner-bg: linear-gradient(145deg, #ffffff 5%, #f4f7ff 55%, #e8ecff 100%);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.9),
-    0 35px 70px -55px rgba(18, 22, 33, 0.6);
+    inset 0 1px 0 rgba(255, 255, 255, 0.85),
+    0 18px 40px -28px rgba(18, 22, 33, 0.38);
   border: 1px solid rgba(0, 0, 0, 0.08);
 }
 
@@ -351,7 +351,7 @@
 .apple-oem-banner--edge {
   --banner-bg: linear-gradient(120deg, #ffffff 0%, #f5f7ff 50%, #edf2ff 100%);
   border: 1px solid rgba(0, 0, 0, 0.05);
-  box-shadow: 0 60px 90px -80px rgba(12, 21, 35, 0.6);
+  box-shadow: 0 20px 38px -28px rgba(12, 21, 35, 0.26);
 }
 
 .apple-oem-banner--edge::before {
@@ -362,7 +362,7 @@
   --banner-bg: linear-gradient(120deg, #ffffff 0%, #f8f9fb 60%, #f0f2f7 100%);
   --accent: #0a84ff;
   --accent-soft: rgba(10, 132, 255, 0.16);
-  box-shadow: 0 24px 44px -32px rgba(15, 23, 42, 0.4);
+  box-shadow: 0 16px 32px -24px rgba(15, 23, 42, 0.28);
 }
 
 .apple-oem-banner--minimal .apple-oem-banner__pill {

--- a/scss/components/_smart-app-banner.scss
+++ b/scss/components/_smart-app-banner.scss
@@ -16,7 +16,7 @@
   color: #f5f5f7;
   background: rgba(29, 29, 31, 0.92);
   backdrop-filter: blur(18px);
-  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.24);
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 0;
   font-family:
@@ -73,7 +73,7 @@
   height: clamp(52px, 8vw, 64px);
   border-radius: 0;
   object-fit: cover;
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.28);
 }
 
 .smart-app-banner__copy {

--- a/scss/pages/_ccai.scss
+++ b/scss/pages/_ccai.scss
@@ -15,7 +15,7 @@
   --cta-bg: #4a7bff;
   --cta-outline: rgba(74, 123, 255, 0.45);
   --cta-text: #020613;
-  --shadow: 0 28px 48px rgba(7, 14, 30, 0.55);
+  --shadow: 0 16px 32px rgba(7, 14, 30, 0.35);
   --border-strong: rgba(74, 123, 255, 0.45);
   --border-soft: rgba(104, 149, 255, 0.22);
   --border-card: rgba(74, 123, 255, 0.28);
@@ -314,7 +314,7 @@
 
     &:hover {
       transform: translateY(-2px);
-      box-shadow: 0 26px 46px rgba(39, 75, 204, 0.38);
+      box-shadow: 0 14px 28px rgba(39, 75, 204, 0.26);
     }
   }
 
@@ -346,7 +346,7 @@
     border: 1px solid var(--border-strong);
     background: var(--panel-soft);
     border-radius: 1.5rem;
-    box-shadow: 0 20px 48px rgba(7, 14, 30, 0.4);
+    box-shadow: 0 12px 28px rgba(7, 14, 30, 0.28);
     backdrop-filter: blur(16px);
 
     &::before {
@@ -552,7 +552,7 @@
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
-    box-shadow: 0 32px 64px rgba(7, 14, 30, 0.5);
+    box-shadow: 0 18px 36px rgba(7, 14, 30, 0.32);
     position: relative;
 
     h3 {
@@ -678,7 +678,7 @@
     border-radius: 1.75rem;
     overflow: hidden;
     background: var(--panel);
-    box-shadow: 0 32px 66px rgba(7, 14, 30, 0.5);
+    box-shadow: 0 18px 38px rgba(7, 14, 30, 0.34);
 
     &.active {
       display: flex;

--- a/scss/pages/_contact.scss
+++ b/scss/pages/_contact.scss
@@ -120,7 +120,7 @@
     border-radius: calc($border-radius * 1.2);
     border: 1px solid rgba(255, 255, 255, 0.08);
     background: linear-gradient(140deg, rgba(33, 33, 33, 0.75), rgba(7, 10, 6, 0.85));
-    box-shadow: 0 30px 45px rgba(7, 10, 6, 0.35);
+    box-shadow: 0 14px 28px rgba(7, 10, 6, 0.28);
     transition:
       transform 0.3s ease,
       border-color 0.3s ease,
@@ -130,7 +130,7 @@
     &:focus-within {
       transform: translateY(-6px);
       border-color: rgba(135, 189, 114, 0.65);
-      box-shadow: 0 40px 60px rgba(7, 10, 6, 0.45);
+      box-shadow: 0 16px 28px rgba(7, 10, 6, 0.32);
     }
 
     h2 {
@@ -290,7 +290,7 @@
     border-radius: calc($border-radius * 1.15);
     border: 1px solid rgba(255, 255, 255, 0.08);
     background: rgba(12, 18, 12, 0.85);
-    box-shadow: 0 28px 42px rgba(7, 10, 6, 0.38);
+    box-shadow: 0 16px 32px rgba(7, 10, 6, 0.3);
   }
 
   .contact-form__urgency {


### PR DESCRIPTION
## Summary
- soften container and panel box shadows for CCAI layouts, contact flows, promotional banners, bio highlights, press assets, and smart app overlays to reduce visual heft
- update Crowncode overrides and compiled styles so production CSS matches the new subtle shadow depths across experiences

## Testing
- npx sass --load-path=node_modules/@uswds/uswds/packages scss/styles.scss assets/styles.css

------
https://chatgpt.com/codex/tasks/task_e_68e3277447708325a87bf56b435599d4