### PR TITLE
Fix mobile right-scroll overflow on Image Index page

### DIFF
--- a/image-index.html
+++ b/image-index.html
@@ -162,6 +162,7 @@
   }
   </script>
   <style>
+    html, body { max-width:100%; overflow-x:clip; }
 
     .image-toolbar { display:flex; flex-wrap:wrap; gap:1rem; align-items:center; justify-content:space-between; margin-bottom:1.5rem; }
     .image-search { flex:1 1 240px; }
@@ -178,16 +179,16 @@
       .image-zoom-controls { display:flex; }
       .image-columns-controls { display:none; }
     }
-    .image-grid { --image-grid-size:220px; --image-grid-columns-mobile:4; display:grid; grid-template-columns:repeat(auto-fill, minmax(var(--image-grid-size), 1fr)); gap:1rem; }
+    .image-grid { --image-grid-size:220px; --image-grid-columns-mobile:4; display:grid; grid-template-columns:repeat(auto-fill, minmax(var(--image-grid-size), 1fr)); gap:1rem; width:100%; max-width:100%; }
     @media (max-width: 768px) {
       .image-grid { --image-grid-size:90px; grid-template-columns:repeat(var(--image-grid-columns-mobile), minmax(0, 1fr)); }
     }
     .image-grid img { width:100%; height:auto; max-height:80vh; border-radius:8px; cursor:zoom-in; transition:transform .2s; }
     .image-grid img:hover, .image-grid img:focus { transform:scale(1.08); }
     .image-grid img:active { transform:scale(1.1); }
-    .img-item { display:flex; flex-direction:column; gap:.65rem; background:#111311; border:1px solid rgba(69,111,58,.35); border-radius:12px; padding:.75rem; box-shadow:0 8px 20px rgba(0,0,0,.28); }
-    .img-meta { display:grid; gap:.3rem; }
-    .img-description { margin:0; font-size:.85rem; color:#d5f0cd; line-height:1.35; }
+    .img-item { display:flex; flex-direction:column; gap:.65rem; background:#111311; border:1px solid rgba(69,111,58,.35); border-radius:12px; padding:.75rem; box-shadow:0 8px 20px rgba(0,0,0,.28); min-width:0; }
+    .img-meta { display:grid; gap:.3rem; min-width:0; }
+    .img-description { margin:0; font-size:.85rem; color:#d5f0cd; line-height:1.35; overflow-wrap:anywhere; word-break:break-word; }
     .img-path { margin:0; font-size:.72rem; color:rgba(255,255,255,.62); overflow-wrap:anywhere; }
     .code-box { display:flex; justify-content:flex-end; background:#253223; padding:.35rem .5rem; border-radius:6px; font-size:.875rem; border:1px solid rgba(69,111,58,.35); }
     .code-box .btn { padding:.25rem .5rem; font-size:.75rem; }
@@ -456,7 +457,6 @@
   <script type="module" src="/js/main.js"></script>
 </body>
 </html>
-
 
 
 


### PR DESCRIPTION
### Motivation
- Users could scroll to the right on small screens when viewing the Image Index due to the gallery/grid and long asset strings forcing layout overflow. 
- The change prevents horizontal dragging/scrolling on mobile without touching global site CSS by scoping fixes to the Image Index page.

### Description
- Added `html, body { max-width:100%; overflow-x:clip; }` to the inline stylesheet in `image-index.html` to stop page-level horizontal overflow. 
- Constrained the gallery by setting `.image-grid { width:100%; max-width:100%; }` so the grid cannot exceed the viewport width. 
- Hardened card layout by adding `min-width:0` to `.img-item` and `.img-meta` and enabling aggressive wrapping with `overflow-wrap:anywhere; word-break:break-word;` on `.img-description` to prevent long filenames/strings from forcing overflow. 
- The only file changed is `image-index.html` (inline CSS adjustments); no JS logic was modified.

### Testing
- Ran `npm run lint:buttons` against the codebase and it passed.
- A full site build was executed via `npm run build` earlier in the session and completed successfully (no build errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae5da7e048325bcce2c22d385230f)