### PR TITLE
Refine header glass overlay to limit blur under hero CTA

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -885,13 +885,12 @@ body.theme-light {
   content: '';
   position: absolute;
   inset: 0;
-  height: 200%;
   pointer-events: none;
   z-index: -1;
   backdrop-filter: blur(16px) saturate(145%);
   -webkit-backdrop-filter: blur(16px) saturate(145%);
-  mask-image: linear-gradient(to bottom, black 0 50%, transparent 50% 100%);
-  -webkit-mask-image: linear-gradient(to bottom, black 0 50%, transparent 50% 100%);
+  mask-image: linear-gradient(to bottom, transparent 0 58%, black 78% 100%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0 58%, black 78% 100%);
 }
 .site-header::after {
   content: '';


### PR DESCRIPTION
### Motivation
- Limit the sticky header's glass/backdrop blur so it no longer bleeds far behind the hero image and instead appears primarily under the CTA region, targeting the header pseudo-element in `assets/styles.css`.

### Description
- In `assets/styles.css` updated `.site-header::before` by removing the oversized `height: 200%` and replacing the mask with `mask-image`/`-webkit-mask-image: linear-gradient(to bottom, transparent 0 58%, black 78% 100%)` so the backdrop-filter blur is revealed mainly at the lower portion of the header.

### Testing
- Pre-commit `lint-staged` hook executed `prettier --write` on `assets/styles.css` during staging and completed successfully; no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dddfe9f9148325b4276b64d256eba1)