### PR TITLE
Neutralize green tint in charcoal/gray background tokens

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2,7 +2,7 @@
 :root {
   --gray-50: #fdfdfd;
   --gray-100: #d5d5d5;
-  --gray-200: #b8bab7;
+  --gray-200: #b8b8b8;
   --gray-600: #313132;
   --gray-700: #2f2f2f;
   --gray-800: #212121;
@@ -18,9 +18,9 @@
   --color-bright: #87bd72;
   --color-mint: #c2e9c1;
   --color-lime: #8cd679;
-  --color-charcoal: #3b3c3b;
-  --color-muted: #b8bab7;
-  --color-black: #070a06;
+  --color-charcoal: #3a3a3a;
+  --color-muted: #b8b8b8;
+  --color-black: #070707;
   --color-white: #fdfdfd;
   --color-surface: #212121;
   --color-icon: #e6e6e6;
@@ -61,22 +61,22 @@
   --light-container-accent: #67a658;
   --light-nav-gradient: linear-gradient(#eaeaea, #cacaca);
   --light-footer-gradient: linear-gradient(#fdfbfb, #f1f0f0);
-  --dark-main-gradient: linear-gradient(#494949, #525151 50%, #646464);
+  --dark-main-gradient: linear-gradient(#494949, #525252 50%, #646464);
   --header-gradient: var(--grad-gray);
   --footer-gradient: var(--grad-gray);
 }
 
 .theme-light {
-  --color-charcoal: #3b3c3b;
-  --color-black: #070a06;
+  --color-charcoal: #3a3a3a;
+  --color-black: #070707;
   --color-white: #ffffff;
   --color-surface: #eaeaea;
   --color-icon: #717171;
   --color-border: rgba(0, 0, 0, 0.15);
-  --color-contrast-high: #070a06;
-  --gray-900: #070a06;
-  --gray-800: #3b3c3b;
-  --gray-700: #b8bab7;
+  --color-contrast-high: #070707;
+  --gray-900: #070707;
+  --gray-800: #3a3a3a;
+  --gray-700: #b8b8b8;
   --gray-600: #d5d5d5;
   --header-gradient: var(--light-nav-gradient);
   --footer-gradient: var(--light-footer-gradient);

--- a/scss/tokens/_css-vars.scss
+++ b/scss/tokens/_css-vars.scss
@@ -1,7 +1,7 @@
 :root {
   --gray-50: #fdfdfd;
   --gray-100: #d5d5d5;
-  --gray-200: #b8bab7;
+  --gray-200: #b8b8b8;
   --gray-600: #313132;
   --gray-700: #2f2f2f;
   --gray-800: #212121;
@@ -17,9 +17,9 @@
   --color-bright: #87bd72;
   --color-mint: #c2e9c1;
   --color-lime: #8cd679;
-  --color-charcoal: #3b3c3b;
-  --color-muted: #b8bab7;
-  --color-black: #070a06;
+  --color-charcoal: #3a3a3a;
+  --color-muted: #b8b8b8;
+  --color-black: #070707;
   --color-white: #fdfdfd;
   --color-surface: #212121;
   --color-icon: #e6e6e6;
@@ -60,22 +60,22 @@
   --light-container-accent: #67a658;
   --light-nav-gradient: linear-gradient(#eaeaea, #cacaca);
   --light-footer-gradient: linear-gradient(#fdfbfb, #f1f0f0);
-  --dark-main-gradient: linear-gradient(#494949, #525151 50%, #646464);
+  --dark-main-gradient: linear-gradient(#494949, #525252 50%, #646464);
   --header-gradient: var(--grad-gray);
   --footer-gradient: var(--grad-gray);
 }
 
 .theme-light {
-  --color-charcoal: #3b3c3b;
-  --color-black: #070a06;
+  --color-charcoal: #3a3a3a;
+  --color-black: #070707;
   --color-white: #ffffff;
   --color-surface: #eaeaea;
   --color-icon: #717171;
   --color-border: rgba(0, 0, 0, 0.15);
-  --color-contrast-high: #070a06;
-  --gray-900: #070a06;
-  --gray-800: #3b3c3b;
-  --gray-700: #b8bab7;
+  --color-contrast-high: #070707;
+  --gray-900: #070707;
+  --gray-800: #3a3a3a;
+  --gray-700: #b8b8b8;
   --gray-600: #d5d5d5;
   --header-gradient: var(--light-nav-gradient);
   --footer-gradient: var(--light-footer-gradient);


### PR DESCRIPTION
### Motivation
- Background surfaces intended to read as charcoal or neutral gray had a subtle green bias, so the palette tokens were adjusted to remove that tint while keeping brand greens intact.
- The goal is to ensure dark and light theme neutrals render consistently without affecting accent/brand colors.

### Description
- Updated core CSS variable tokens in `scss/tokens/_css-vars.scss` to neutral values (`--gray-200`, `--color-charcoal`, `--color-muted`, `--color-black`) and adjusted the dark gradient midpoint (`--dark-main-gradient`).
- Synchronized the compiled stylesheet by regenerating `assets/styles.css` so runtime pages pick up the neutralized values.
- Left brand/accent green tokens unchanged to preserve existing branding and focus-ring colors.
- Changes are scoped to token values and compiled output only, not to component markup or images.

### Testing
- Ran `npx sass --load-path=node_modules/@uswds/uswds/packages scss/styles.scss assets/styles.css` to regenerate `assets/styles.css`, which completed successfully.
- Ran `npm run lint:buttons` to validate button variant tokens, which returned success.
- Performed a full site build earlier with `npm run build` to verify there were no build-time regressions, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df3bf4d7c48325b6a5117b228a8a84)