### PR TITLE
Fix section separator alignment at section boundaries

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -162,7 +162,7 @@ main:not(.console-main):not(.hero-section):not(.emergency-main):not(.not-found-p
   + section::before {
   content: '';
   position: absolute;
-  top: calc(var(--section-space-y) * -0.5);
+  top: 0;
   left: clamp(1.5rem, 5vw, 3.5rem);
   right: clamp(1.5rem, 5vw, 3.5rem);
   height: 1px;

--- a/scss/base/_globals.scss
+++ b/scss/base/_globals.scss
@@ -27,7 +27,7 @@ body {
   > section + section::before {
     content: '';
     position: absolute;
-    top: calc(var(--section-space-y) * -0.5);
+    top: 0;
     left: clamp(1.5rem, 5vw, 3.5rem);
     right: clamp(1.5rem, 5vw, 3.5rem);
     height: 1px;


### PR DESCRIPTION
### Motivation
- The thin gradient divider between stacked page sections was positioned above the section boundary because the global pseudo-element used `top: calc(var(--section-space-y) * -0.5)`, so the line rendered too far up instead of exactly where sections meet.

### Description
- Change `scss/base/_globals.scss` to set `top: 0` for `.main-content-separators > section + section::before` and regenerate the compiled stylesheet `assets/styles.css` so the deployed CSS reflects the fix.

### Testing
- Ran `npx sass --load-path=node_modules/@uswds/uswds/packages scss/styles.scss assets/styles.css` and `npm run build:site`, both completed successfully and the generated CSS now uses `top: 0` for the affected selector.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df455b5d24832596a354fdd9f80ff0)