### PR TITLE
Refine featured books layout and book card spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ This project exists to:
 
 > **Haley clinical mini-site:** `haley.html` is a standalone, GitHub Pages-ready clinical briefing page with brand-green browser chrome, deployable favicon/social image metadata, and a client-side PIN gate for controlled access. Keep social/favicons as committed repository assets (no Netlify runtime dependencies).
 
-> **Books page refresh:** `book.html` now ships a full six-book collection layout (without embedded Game On-only sections), balanced section spacing, smoother section snap scrolling, refined listing gaps, native/mobile share support (`.js-share-trigger` via `js/main.js`), and a contact-routed Daren’s Desk CTA. Keep metadata + JSON-LD collection schema aligned and run `npm run generate:images` after image changes so GitHub Pages search/image manifests stay current.
+> **Books page refresh:** `book.html` now ships a full six-book collection layout (without embedded Game On-only sections), balanced section spacing, smoother section snap scrolling, refined listing gaps, smaller cover corner radii, slightly larger cover art, native/mobile share support (`.js-share-trigger` via `js/main.js`), and a contact-routed Daren’s Desk CTA. Keep metadata + JSON-LD collection schema aligned and run `npm run generate:images` after image changes so GitHub Pages search/image manifests stay current.
+>
+> **Homepage featured books strip:** `index.html` now presents the “Upcoming Book” headline directly on the page background (styled kicker treatment), removes the outer wrapper shell from the featured rail container, and keeps featured cover thumbnails at their natural image ratio (no forced crop). Rebuild SCSS with `npm run styles:build` (or `npm run build:site`) so GitHub Pages serves the updated layout.
 >
 > **Homepage conversion rail refresh:** `index.html` now merges format selection controls directly into the dynamic format-image card and adds a touch-swipable featured books strip that deep-links to anchor sections on `book.html`. Keep `scss/components/_book-details-wrapper.scss` and `assets/styles.css` in sync by running `npm run build:site` before commit.
 >

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -8464,18 +8464,19 @@ body.books-page .books-main > section {
 }
 .book-collection-list .book-collection-card {
   padding: clamp(1.8rem, 3.4vw, 2.5rem) clamp(1rem, 2.4vw, 1.8rem);
-  border-radius: clamp(0.85rem, 2vw, 1.15rem);
+  border-radius: clamp(0.55rem, 1.4vw, 0.75rem);
   background: linear-gradient(180deg, rgba(12, 14, 12, 0.9) 0%, rgba(8, 10, 8, 0.7) 100%);
 }
 .book-collection-list .book-collection-card + .book-collection-card {
   position: relative;
+  margin-top: clamp(1.2rem, 2.6vw, 1.7rem);
 }
 .book-collection-list .book-collection-card + .book-collection-card::before {
   content: '';
   position: absolute;
   left: 0;
   right: 0;
-  top: 0;
+  top: -0.55rem;
   height: 1px;
   background: linear-gradient(
     105deg,
@@ -8578,7 +8579,7 @@ body.books-page .books-main > section {
 }
 
 .paperback-mockup {
-  width: min(220px, 100%);
+  width: min(242px, 100%);
   margin: 0 auto clamp(1.3rem, 2.8vw, 1.85rem);
   padding: 0;
   filter: drop-shadow(0 18px 24px rgba(0, 0, 0, 0.5));
@@ -8593,7 +8594,7 @@ body.books-page .books-main > section {
   width: 100%;
   height: auto;
   display: block;
-  border-radius: 6px;
+  border-radius: 4px;
   border: 0;
   transform: rotateY(-8deg) rotateX(1deg) translateZ(1px);
   transform-origin: left center;
@@ -9150,15 +9151,26 @@ body.books-page .books-main > section {
 }
 
 .featured-books-strip {
-  background: linear-gradient(150deg, rgba(20, 22, 25, 0.96), rgba(11, 12, 14, 0.88));
-  border: 1px solid color-mix(in srgb, var(--color-white) 12%, transparent);
-  border-radius: 0.6875rem;
-  padding: 1rem;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
   display: grid;
-  gap: 0.75rem;
+  gap: clamp(0.7rem, 2vw, 1rem);
 }
 
-.featured-books-strip__header h3,
+.featured-books-strip__headline {
+  width: min(100%, var(--max-width-lg));
+  margin: 0 auto clamp(0.35rem, 1vw, 0.6rem);
+}
+
+.featured-books-strip__subhead {
+  margin: 0;
+  color: color-mix(in srgb, var(--color-white) 80%, transparent);
+  font-size: clamp(0.94rem, 1.6vw, 1rem);
+}
+
+.featured-books-strip__subhead,
 .featured-book-card h4,
 .featured-books-strip__links {
   margin: 0;
@@ -9181,7 +9193,7 @@ body.books-page .books-main > section {
   scroll-snap-align: start;
   background: linear-gradient(165deg, rgba(21, 23, 27, 0.98), rgba(12, 13, 15, 0.9));
   border: 1px solid color-mix(in srgb, var(--color-white) 14%, transparent);
-  border-radius: clamp(1rem, 2vw, 1.25rem);
+  border-radius: clamp(0.7rem, 1.6vw, 0.9rem);
   padding: 0.5rem;
   display: grid;
   gap: 0.5rem;
@@ -9200,9 +9212,9 @@ body.books-page .books-main > section {
 }
 .featured-book-card img {
   width: 100%;
-  aspect-ratio: 3/4;
-  object-fit: cover;
-  border-radius: clamp(0.82rem, 1.5vw, 1rem);
+  height: auto;
+  object-fit: contain;
+  border-radius: clamp(0.45rem, 1.1vw, 0.6rem);
 }
 
 .featured-book-card:nth-child(2) {

--- a/index.html
+++ b/index.html
@@ -735,12 +735,9 @@
               </div>
             </div>
           </div>
-          <div class="book-block container max-width-adaptive-lg">
-            <section class="featured-books-strip" aria-labelledby="featured-books-heading">
-              <div class="featured-books-strip__header">
-                <p class="section-kicker section-kicker--charcoal-lime">Upcoming Releases</p>
-                <h3 id="featured-books-heading">Swipe through the library and jump to each title</h3>
-              </div>
+          <h3 class="featured-books-strip__headline section-kicker section-kicker--charcoal-lime" id="featured-books-heading">Upcoming Book</h3>
+          <section class="featured-books-strip book-block container max-width-adaptive-lg" aria-labelledby="featured-books-heading">
+              <p class="featured-books-strip__subhead">Swipe through the library and jump to each title</p>
               <div class="featured-books-strip__rail" role="list" aria-label="Featured books">
                 <article class="featured-book-card" role="listitem">
                   <img src="https://www.darenprince.com/assets/images/IMG_0237.jpeg" alt="Rooted cover" loading="lazy">
@@ -779,8 +776,7 @@
                 and
                 <a href="https://www.goodreads.com/author/show/53671567.Daren_Prince" target="_blank" rel="noopener noreferrer">Goodreads</a>.
               </p>
-            </section>
-          </div>
+          </section>
           <div class="book-block container max-width-adaptive-lg">
             <article class="author-spotlight-card">
               <div class="author-spotlight-card__media">
@@ -953,5 +949,4 @@
 
 
 </body></html>
-
 

--- a/scss/components/_book-details-wrapper.scss
+++ b/scss/components/_book-details-wrapper.scss
@@ -163,19 +163,20 @@ body.books-page {
 
   .book-collection-card {
     padding: clamp(1.8rem, 3.4vw, 2.5rem) clamp(1rem, 2.4vw, 1.8rem);
-    border-radius: clamp(0.85rem, 2vw, 1.15rem);
+    border-radius: clamp(0.55rem, 1.4vw, 0.75rem);
     background: linear-gradient(180deg, rgba(12, 14, 12, 0.9) 0%, rgba(8, 10, 8, 0.7) 100%);
   }
 
   .book-collection-card + .book-collection-card {
     position: relative;
+    margin-top: clamp(1.2rem, 2.6vw, 1.7rem);
 
     &::before {
       content: '';
       position: absolute;
       left: 0;
       right: 0;
-      top: 0;
+      top: -0.55rem;
       height: 1px;
       background: linear-gradient(
         105deg,
@@ -288,7 +289,7 @@ body.books-page {
 }
 
 .paperback-mockup {
-  width: min(220px, 100%);
+  width: min(242px, 100%);
   margin: 0 auto clamp(1.3rem, 2.8vw, 1.85rem);
   padding: 0;
   filter: drop-shadow(0 18px 24px rgba(0, 0, 0, 0.5));
@@ -303,7 +304,7 @@ body.books-page {
     width: 100%;
     height: auto;
     display: block;
-    border-radius: 6px;
+    border-radius: 4px;
     border: 0;
     transform: rotateY(-8deg) rotateX(1deg) translateZ(1px);
     transform-origin: left center;
@@ -915,15 +916,26 @@ body.books-page {
 }
 
 .featured-books-strip {
-  background: linear-gradient(150deg, rgba(20, 22, 25, 0.96), rgba(11, 12, 14, 0.88));
-  border: 1px solid color-mix(in srgb, $white 12%, transparent);
-  border-radius: $border-radius;
-  padding: $spacing-md;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
   display: grid;
-  gap: $spacing-sm;
+  gap: clamp(0.7rem, 2vw, 1rem);
 }
 
-.featured-books-strip__header h3,
+.featured-books-strip__headline {
+  width: min(100%, var(--max-width-lg));
+  margin: 0 auto clamp(0.35rem, 1vw, 0.6rem);
+}
+
+.featured-books-strip__subhead {
+  margin: 0;
+  color: color-mix(in srgb, $white 80%, transparent);
+  font-size: clamp(0.94rem, 1.6vw, 1rem);
+}
+
+.featured-books-strip__subhead,
 .featured-book-card h4,
 .featured-books-strip__links {
   margin: 0;
@@ -946,7 +958,7 @@ body.books-page {
   scroll-snap-align: start;
   background: linear-gradient(165deg, rgba(21, 23, 27, 0.98), rgba(12, 13, 15, 0.9));
   border: 1px solid color-mix(in srgb, $white 14%, transparent);
-  border-radius: clamp(1rem, 2vw, 1.25rem);
+  border-radius: clamp(0.7rem, 1.6vw, 0.9rem);
   padding: $spacing-xs;
   display: grid;
   gap: $spacing-xs;
@@ -966,9 +978,9 @@ body.books-page {
 
   img {
     width: 100%;
-    aspect-ratio: 3 / 4;
-    object-fit: cover;
-    border-radius: clamp(0.82rem, 1.5vw, 1rem);
+    height: auto;
+    object-fit: contain;
+    border-radius: clamp(0.45rem, 1.1vw, 0.6rem);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Make the homepage featured-books strip sit directly on the page background with a styled headline and lightweight subhead, restoring the original full-cover ratio for thumbnails. 
- Improve readability of the books list by adding vertical spacing between entries, reducing overly rounded corners, and slightly increasing cover mockup size so covers read larger.
- Keep source SCSS and deployment docs aligned for GitHub Pages builds so produced CSS and metadata remain consistent on publish.

### Description
- Moved the featured-books heading out of the inner wrapper and placed an on-page headline `Upcoming Book`, added `featured-books-strip__headline` and `featured-books-strip__subhead` markup in `index.html` (updated markup around the featured rail).
- Removed the outer wrapper styling from the featured strip and restored natural cover image ratio by removing forced `aspect-ratio` + `object-fit: cover` cropping and switching featured images to `height: auto` + `object-fit: contain` in `scss/components/_book-details-wrapper.scss` and compiled `assets/styles.css`.
- Reduced corner radii for book cards and cover images and increased the paperback mockup width (`min(242px, 100%)`) and added vertical separation between `.book-collection-card` siblings to refine spacing in `scss/components/_book-details-wrapper.scss` and `assets/styles.css`.
- Updated `README.md` to document the homepage featured-books behavior and books page styling refresh, and rebuilt styles so `assets/styles.css` reflects the SCSS changes.

### Testing
- Ran `npm run lint:buttons` which succeeded and reported no button-variant issues. 
- Built/checked styles with `npm run styles:build` (Dart Sass) and an additional `npx sass --no-source-map --load-path=node_modules/@uswds/uswds/packages scss/styles.scss /tmp/daren-styles-check.css`, both succeeded with no Sass errors.
- No failing automated tests were observed for these changes (no `vitest` test runs were required for the styling/markup changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df7b0cdac48325968c4d38bbc9ed88)