### PR TITLE
Refine featured books presentation and format selector layout

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -9360,10 +9360,10 @@ body.books-page .books-main > section {
   width: auto;
   flex: 1 1 0;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.35rem;
+  gap: 0.4rem;
   border-radius: 999px;
   padding: 0;
   background: transparent;
@@ -9372,11 +9372,12 @@ body.books-page .books-main > section {
 }
 .format-hero-panel .format-icon {
   color: color-mix(in srgb, var(--color-white) 92%, transparent);
-  font-size: 0.95rem;
+  font-size: 1.05rem;
+  line-height: 1;
   pointer-events: none;
 }
 .format-hero-panel .format-btn {
-  width: auto;
+  width: 100%;
   min-width: 0;
   flex: 1 1 auto;
   background: linear-gradient(130deg, rgba(11, 13, 15, 0.96), rgba(22, 25, 30, 0.92));
@@ -9400,6 +9401,27 @@ body.books-page .books-main > section {
   border-color: color-mix(in srgb, var(--color-accent) 92%, transparent);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 22%, transparent);
   transform: translateY(-1px);
+}
+
+.featured-books-shell {
+  width: min(100%, var(--max-width-lg));
+  margin: 0 auto clamp(1.3rem, 3.8vw, 2.4rem);
+  padding: clamp(1.1rem, 2.5vw, 1.5rem) clamp(0.65rem, 2.3vw, 1.2rem);
+  border-top: 1px solid color-mix(in srgb, var(--color-white) 15%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-white) 15%, transparent);
+  background:
+    radial-gradient(
+      circle at 20% 15%,
+      color-mix(in srgb, var(--color-accent) 12%, transparent) 0%,
+      transparent 57%
+    ),
+    radial-gradient(
+      circle at 85% 15%,
+      color-mix(in srgb, var(--color-white) 7%, transparent) 0%,
+      transparent 52%
+    ),
+    linear-gradient(180deg, rgba(26, 29, 34, 0.82), rgba(21, 24, 28, 0.72));
+  border-radius: clamp(1rem, 2vw, 1.4rem);
 }
 
 .featured-books-strip {
@@ -9470,9 +9492,9 @@ body.books-page .books-main > section {
 }
 .featured-book-card img {
   width: 100%;
-  aspect-ratio: 1/1;
+  aspect-ratio: 2/3;
   height: auto;
-  object-fit: cover;
+  object-fit: contain;
   border-radius: clamp(0.75rem, 1.6vw, 1rem);
 }
 

--- a/index.html
+++ b/index.html
@@ -715,11 +715,12 @@
             </div>
 
           </div>
-          <h3 class="featured-books-strip__headline step-header styledh1 brand-heading" id="featured-books-heading">
-            <span class="brand-heading__base">FEATURED &amp; UPCOMING BOOKS</span><br>
-            <span class="brand-heading__emphasis">BY DAREN PRINCE</span>
-          </h3>
-          <section class="featured-books-strip book-block container max-width-adaptive-lg" aria-labelledby="featured-books-heading">
+          <div class="featured-books-shell">
+            <h3 class="featured-books-strip__headline step-header styledh1 brand-heading" id="featured-books-heading">
+              <span class="brand-heading__base">FEATURED &amp; UPCOMING</span><br>
+              <span class="brand-heading__emphasis">BY DAREN PRINCE</span>
+            </h3>
+            <section class="featured-books-strip book-block container max-width-adaptive-lg" aria-labelledby="featured-books-heading">
               <p class="featured-books-strip__subhead">Swipe through the library and jump to each title</p>
               <div class="featured-books-strip__rail" role="list" aria-label="Featured books">
                 <article class="featured-book-card featured-book-card--upcoming-spine" role="listitem" aria-label="Coming soon books">
@@ -763,7 +764,8 @@
                 and
                 <a href="https://www.goodreads.com/author/show/53671567.Daren_Prince" target="_blank" rel="noopener noreferrer">Goodreads</a>.
               </p>
-          </section>
+            </section>
+          </div>
           <div class="book-block container max-width-adaptive-lg">
             <article class="author-spotlight-card">
               <div class="author-spotlight-card__media">

--- a/scss/components/_book-details-wrapper.scss
+++ b/scss/components/_book-details-wrapper.scss
@@ -1087,10 +1087,10 @@ body.books-page {
     width: auto;
     flex: 1 1 0;
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 0.35rem;
+    gap: 0.4rem;
     border-radius: 999px;
     padding: 0;
     background: transparent;
@@ -1100,12 +1100,13 @@ body.books-page {
 
   .format-icon {
     color: color-mix(in srgb, $white 92%, transparent);
-    font-size: 0.95rem;
+    font-size: 1.05rem;
+    line-height: 1;
     pointer-events: none;
   }
 
   .format-btn {
-    width: auto;
+    width: 100%;
     min-width: 0;
     flex: 1 1 auto;
     background: linear-gradient(130deg, rgba(11, 13, 15, 0.96), rgba(22, 25, 30, 0.92));
@@ -1131,6 +1132,27 @@ body.books-page {
       transform: translateY(-1px);
     }
   }
+}
+
+.featured-books-shell {
+  width: min(100%, var(--max-width-lg));
+  margin: 0 auto clamp(1.3rem, 3.8vw, 2.4rem);
+  padding: clamp(1.1rem, 2.5vw, 1.5rem) clamp(0.65rem, 2.3vw, 1.2rem);
+  border-top: 1px solid color-mix(in srgb, $white 15%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, $white 15%, transparent);
+  background:
+    radial-gradient(
+      circle at 20% 15%,
+      color-mix(in srgb, $accent 12%, transparent) 0%,
+      transparent 57%
+    ),
+    radial-gradient(
+      circle at 85% 15%,
+      color-mix(in srgb, $white 7%, transparent) 0%,
+      transparent 52%
+    ),
+    linear-gradient(180deg, rgba(26, 29, 34, 0.82), rgba(21, 24, 28, 0.72));
+  border-radius: clamp(1rem, 2vw, 1.4rem);
 }
 
 .featured-books-strip {
@@ -1202,9 +1224,9 @@ body.books-page {
 
   img {
     width: 100%;
-    aspect-ratio: 1 / 1;
+    aspect-ratio: 2 / 3;
     height: auto;
-    object-fit: cover;
+    object-fit: contain;
     border-radius: clamp(0.75rem, 1.6vw, 1rem);
   }
 }


### PR DESCRIPTION
### Motivation
- Make the featured rail visually lighter and more focused by removing the redundant word `BOOKS` from the heading and enabling independent block-level styling. 
- Restore true portrait cover rendering so featured covers display at their original aspect ratio instead of being cropped square. 
- Visually separate the featured area with gentle dividers and a subtle radial-gradient background to improve scanability. 
- Improve the buy / format selection card layout by placing format icons above their buttons for clearer affordance on each format option. 

### Description
- Updated `index.html` to change the heading text from `FEATURED & UPCOMING BOOKS` to `FEATURED & UPCOMING` and wrapped the featured rail in a new container element `.featured-books-shell`. 
- Added `.featured-books-shell` CSS (in `scss/components/_book-details-wrapper.scss` and compiled `assets/styles.css`) that applies top/bottom divider lines, padding, a slightly lighter background with subtle radial gradients, and a rounded container so the featured section is visually distinct. 
- Restored portrait covers by changing the featured card image rules to `aspect-ratio: 2 / 3` and `object-fit: contain` in both the SCSS source and compiled CSS so images render at their natural cover proportions. 
- Reworked the format selection layout by switching `.format-option` from a horizontal row to a vertical column, increasing the icon size, and making the format buttons full-width (`width: 100%`) so icons appear above their corresponding `AUDIO`/`DIGITAL`/`PRINT` buttons; changes applied to both SCSS and compiled CSS to keep build output aligned. 
- Files changed: `index.html`, `scss/components/_book-details-wrapper.scss`, and `assets/styles.css`. 

### Testing
- Ran `npm run styles:build` to compile SCSS into `assets/styles.css`, which completed successfully. 
- Ran `npm run lint:buttons` to validate button variants, which returned `Button variant tokens look good` and exited successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e16cbbc9748325a011218d973132e9)