### PR TITLE
Revert "Fix homepage preloader getting stuck after restore"

### DIFF
--- a/REVERT_6446f1d9.txt
+++ b/REVERT_6446f1d9.txt
@@ -1,0 +1,3 @@
+This reverts commit 6446f1d9a2d28aebd7850223f0a2e67398256cbb.
+
+Fix homepage preloader getting stuck after restore.


### PR DESCRIPTION
## Summary

- _What changed? Why?_

## Screenshots (Required for UI changes)

### Desktop

- _Attach desktop screenshot(s)_

### Mobile

- _Attach mobile screenshot(s)_

## Checklist

- [ ] I rebased (or merged once) on the latest `main`.
- [ ] I ran `npm run format` or let the pre-commit hook format staged files.
- [ ] I included required generated assets (`assets/styles.css`, `assets/image-manifest.json`, `public/search/*.json`, `nexuswho-assets/`) when they changed.
- [ ] I confirmed GitHub Pages build/deploy implications for this PR.
- [ ] For visual changes, I added both desktop and mobile screenshots above.
