### PR TITLE
Featured rail full-bleed + tighter snap behavior on index and books pages

### DIFF
--- a/docs/CHANGELOG_DOC_SYNC.md
+++ b/docs/CHANGELOG_DOC_SYNC.md
@@ -2,6 +2,12 @@
 
 > Tracks documentation updates made during the 2025-02-14 audit.
 
+## 2026-04-18 — Featured rail full-bleed + tighter section snapping refinements (GitHub Pages-safe)
+
+- Updated homepage rail behavior (`js/main.js`) so the featured books shell/strip runs full-bleed to the viewport edges instead of staying constrained inside the previous centered max-width container.
+- Refined homepage mobile section snap motion (`js/homepage-rail-enhancements.js`) with a wider 40% section-break capture zone, lower-friction smooth snap timing, and a subtle two-step bounce settle.
+- Added tighter book listing snap control on `book.html` via `js/book-page.js`, making section transitions feel more like a guided vertical rail with reduced overscroll play and better section anchoring.
+
 ## 2026-04-16 — Homepage featured rail upcoming spine + books-card iOS radius + hero image preloader (GitHub Pages-safe)
 
 - Updated `index.html` featured rail copy and structure to:

--- a/js/book-page.js
+++ b/js/book-page.js
@@ -146,3 +146,67 @@ if (detailModal && cardDetailTriggers.length) {
     }
   })
 }
+
+function initBookListingSnapRail() {
+  const isBooksPage = document.body.classList.contains('books-page')
+  if (!isBooksPage) return
+
+  const sections = Array.from(document.querySelectorAll('.books-main > section[id]')).filter(
+    (section) => section.offsetParent !== null
+  )
+  if (!sections.length) return
+
+  let snapTimer = 0
+  let releaseTimer = 0
+  let snapping = false
+  let lastY = window.scrollY
+  let direction = 1
+
+  const runSnap = () => {
+    if (snapping) return
+    const threshold = window.innerHeight * 0.4
+    const resistancePx = 16
+    const candidates = sections
+      .map((section) => ({
+        section,
+        top: section.getBoundingClientRect().top,
+      }))
+      .filter((entry) => entry.top >= -threshold * 0.25 && entry.top <= threshold)
+      .sort((a, b) => Math.abs(a.top) - Math.abs(b.top))
+
+    const nextTarget = candidates[0]
+    if (!nextTarget) return
+
+    const anchoredTop = window.scrollY + nextTarget.top - resistancePx * direction
+    const finalTop = Math.max(0, anchoredTop)
+    const preBounceTop = Math.max(0, finalTop - 8)
+
+    snapping = true
+    window.scrollTo({ top: preBounceTop, behavior: 'smooth' })
+    window.clearTimeout(releaseTimer)
+    releaseTimer = window.setTimeout(() => {
+      window.scrollTo({ top: finalTop, behavior: 'smooth' })
+      window.setTimeout(() => {
+        snapping = false
+      }, 220)
+    }, 120)
+  }
+
+  const scheduleSnap = () => {
+    if (snapping) return
+    const currentY = window.scrollY
+    const delta = currentY - lastY
+    if (Math.abs(delta) > 1) {
+      direction = delta >= 0 ? 1 : -1
+      lastY = currentY
+    }
+    window.clearTimeout(snapTimer)
+    snapTimer = window.setTimeout(runSnap, 90)
+  }
+
+  window.addEventListener('scroll', scheduleSnap, { passive: true })
+  window.addEventListener('wheel', scheduleSnap, { passive: true })
+  window.addEventListener('touchend', scheduleSnap, { passive: true })
+}
+
+initBookListingSnapRail()

--- a/js/homepage-rail-enhancements.js
+++ b/js/homepage-rail-enhancements.js
@@ -225,7 +225,11 @@ function initFeaturedRailModal() {
   }
 
   rail.querySelectorAll('.featured-book-card').forEach((card) => {
-    if (card.classList.contains('featured-book-card--upcoming-spine') || card.classList.contains('featured-book-card--cta')) return
+    if (
+      card.classList.contains('featured-book-card--upcoming-spine') ||
+      card.classList.contains('featured-book-card--cta')
+    )
+      return
     const key = inferBookKey(card)
     if (!key || !FEATURED_BOOKS[key]) return
     const img = card.querySelector('img')
@@ -256,30 +260,34 @@ function initDividerSnap() {
   if (!mobile.matches) return
 
   const findMarkers = () =>
-    Array.from(document.querySelectorAll('.section-divider, .books-gradient-divider, [class*="divider"]')).filter(
-      (el) => el.offsetParent !== null
-    )
+    Array.from(
+      document.querySelectorAll('.section-divider, .books-gradient-divider, [class*="divider"]')
+    ).filter((el) => el.offsetParent !== null)
 
   let snapTimer = 0
   let bounceTimer = 0
   let snapping = false
+  let lastScrollY = window.scrollY
+  let lastScrollDirection = 1
 
   const runSnap = () => {
     if (snapping) return
     const markers = findMarkers()
     if (!markers.length) return
 
-    const threshold = window.innerHeight * 0.27
+    const threshold = window.innerHeight * 0.4
+    const resistancePx = 12
     const candidates = markers
       .map((el) => ({ el, top: el.getBoundingClientRect().top }))
-      .filter((entry) => entry.top >= 0 && entry.top <= threshold)
-      .sort((a, b) => a.top - b.top)
+      .filter((entry) => entry.top >= -threshold * 0.2 && entry.top <= threshold)
+      .sort((a, b) => Math.abs(a.top) - Math.abs(b.top))
 
     const target = candidates[0]
     if (!target) return
 
-    const finalTop = Math.max(0, window.scrollY + target.top - 6)
-    const overshootTop = Math.max(0, finalTop - 16)
+    const targetWithResistance = target.top - resistancePx * lastScrollDirection
+    const finalTop = Math.max(0, window.scrollY + targetWithResistance)
+    const overshootTop = Math.max(0, finalTop - 10)
     snapping = true
     window.scrollTo({ top: overshootTop, behavior: 'smooth' })
     clearTimeout(bounceTimer)
@@ -293,8 +301,14 @@ function initDividerSnap() {
 
   const scheduleSnap = () => {
     if (snapping) return
+    const currentY = window.scrollY
+    const delta = currentY - lastScrollY
+    if (Math.abs(delta) > 1) {
+      lastScrollDirection = delta >= 0 ? 1 : -1
+      lastScrollY = currentY
+    }
     clearTimeout(snapTimer)
-    snapTimer = window.setTimeout(runSnap, 120)
+    snapTimer = window.setTimeout(runSnap, 140)
   }
 
   window.addEventListener('scroll', scheduleSnap, { passive: true })

--- a/js/main.js
+++ b/js/main.js
@@ -587,8 +587,19 @@ function initBookCoverPresentationFixes() {
   style.id = 'book-cover-presentation-fixes'
   style.textContent = `
     .featured-books-shell {
-      border-radius: 10px !important;
+      width: 100vw !important;
+      max-width: none !important;
+      margin-left: calc(50% - 50vw) !important;
+      margin-right: calc(50% - 50vw) !important;
+      border-radius: 0 !important;
       padding-top: clamp(0.75rem, 1.8vw, 1.25rem) !important;
+    }
+
+    .featured-books-strip {
+      width: 100% !important;
+      max-width: none !important;
+      margin-left: 0 !important;
+      margin-right: 0 !important;
     }
 
     .featured-books-strip__headline {
@@ -636,9 +647,8 @@ function initBookCoverPresentationFixes() {
 
     @media (min-width: 48rem) {
       .featured-books-shell {
-        max-width: min(100%, 1180px) !important;
-        padding-left: clamp(1rem, 2.2vw, 1.65rem) !important;
-        padding-right: clamp(1rem, 2.2vw, 1.65rem) !important;
+        padding-left: clamp(1.2rem, 3vw, 3rem) !important;
+        padding-right: clamp(1.2rem, 3vw, 3rem) !important;
       }
 
       .featured-books-strip__rail {
@@ -721,13 +731,8 @@ function initBookCoverPresentationFixes() {
       }
 
       .featured-books-shell {
-        width: 100vw !important;
-        max-width: none !important;
-        margin-left: calc(50% - 50vw) !important;
-        margin-right: calc(50% - 50vw) !important;
         padding-left: 0 !important;
         padding-right: 0 !important;
-        border-radius: 0 !important;
       }
 
       .featured-books-strip__headline,


### PR DESCRIPTION
### Motivation
- Give the homepage featured rail an edge-to-edge layout to match the intended full-bleed visual treatment and eliminate the earlier constrained container feel.
- Make mobile section snap behavior on the index smoother and more intentional with a tiny bounce and light resistance so scrolling feels guided rather than loose.
- Reduce “play” on the books listing page by introducing a tighter vertical snap control so section transitions act like a guided rail.

### Description
- Made the featured books shell and strip full-bleed at runtime by injecting presentation styles in `js/main.js` so `.featured-books-shell` spans `100vw` and `.featured-books-strip` is no longer width-constrained. 
- Refined the index mobile divider snap controller in `js/homepage-rail-enhancements.js` by expanding the capture zone to `40%` of viewport height, adding a small resistance offset and a two-step (overshoot + settle) smooth scroll with tuned timers. 
- Added a new vertical snap rail for the books listing in `js/book-page.js` that detects visible `section` anchors, applies light resistance based on scroll direction, and performs a short pre-bounce then settle scroll for tighter, more deterministic anchoring. 
- Updated documentation in `docs/CHANGELOG_DOC_SYNC.md` to record the full-bleed and snap refinements as GitHub Pages-safe updates.

### Testing
- Ran `npm run lint:buttons` which completed successfully. 
- Ran the test suite with `npm test` (Vitest) and all tests passed: `tests/og-image.spec.ts` and `tests/public-site.spec.ts` (4 tests total) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f46a49408325829b8628fc62150d)