### PR TITLE
Update featured books rail background image and heading spacing

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -9407,10 +9407,11 @@ body.books-page .books-main > section {
 .featured-books-shell {
   width: min(100%, var(--max-width-lg));
   margin: 0 auto clamp(1.3rem, 3.8vw, 2.4rem);
-  padding: clamp(1.1rem, 2.5vw, 1.5rem) clamp(0.65rem, 2.3vw, 1.2rem);
+  padding: clamp(1.6rem, 3.8vw, 2.35rem) clamp(0.65rem, 2.3vw, 1.2rem);
   border-top: 1px solid color-mix(in srgb, var(--color-white) 15%, transparent);
   border-bottom: 1px solid color-mix(in srgb, var(--color-white) 15%, transparent);
   background:
+    linear-gradient(180deg, rgba(11, 13, 15, 0.72), rgba(11, 13, 15, 0.82)),
     radial-gradient(
       circle at 20% 15%,
       color-mix(in srgb, var(--color-accent) 12%, transparent) 0%,
@@ -9421,6 +9422,7 @@ body.books-page .books-main > section {
       color-mix(in srgb, var(--color-white) 7%, transparent) 0%,
       transparent 52%
     ),
+    url('/assets/images/sitebg/cbad6b12cb5c4ba29d1a55a3f2685a6a.jpg') center / cover no-repeat,
     linear-gradient(180deg, rgba(26, 29, 34, 0.82), rgba(21, 24, 28, 0.72));
   border-radius: clamp(1rem, 2vw, 1.4rem);
 }

--- a/docs/CHANGELOG_DOC_SYNC.md
+++ b/docs/CHANGELOG_DOC_SYNC.md
@@ -8,6 +8,12 @@
 - Added `scripts/check-deploy-metadata.mjs` and `npm run lint:metadata` to enforce deploy-ready favicon, Apple icon, OG image, Twitter image, and `theme-color` tags across key public pages before build/deploy.
 - Updated build/documentation guidance (`README.md`, `docs/BUILD_PIPELINE.md`) so GitHub Pages deployment explicitly includes metadata/social-asset validation and branded browser-chrome requirements.
 
+## 2026-04-18 — Homepage featured books rail background refresh + heading spacing polish (GitHub Pages-safe)
+
+- Updated featured books rail styling in `scss/components/_book-details-wrapper.scss` to layer the requested production background image (`/assets/images/sitebg/cbad6b12cb5c4ba29d1a55a3f2685a6a.jpg`) beneath the section overlays for the homepage index rail.
+- Increased top padding on the featured books shell so the `FEATURED & UPCOMING / BY DAREN PRINCE` heading has clearer breathing room above it.
+- Synced `assets/styles.css` with the same featured-rail background + spacing updates so the change is deploy-ready for GitHub Pages static hosting.
+
 ## 2026-04-18 — Featured rail full-bleed + tighter section snapping refinements (GitHub Pages-safe)
 
 - Updated homepage rail behavior (`js/main.js`) so the featured books shell/strip runs full-bleed to the viewport edges instead of staying constrained inside the previous centered max-width container.

--- a/scss/components/_book-details-wrapper.scss
+++ b/scss/components/_book-details-wrapper.scss
@@ -1137,10 +1137,11 @@ body.books-page {
 .featured-books-shell {
   width: min(100%, var(--max-width-lg));
   margin: 0 auto clamp(1.3rem, 3.8vw, 2.4rem);
-  padding: clamp(1.1rem, 2.5vw, 1.5rem) clamp(0.65rem, 2.3vw, 1.2rem);
+  padding: clamp(1.6rem, 3.8vw, 2.35rem) clamp(0.65rem, 2.3vw, 1.2rem);
   border-top: 1px solid color-mix(in srgb, $white 15%, transparent);
   border-bottom: 1px solid color-mix(in srgb, $white 15%, transparent);
   background:
+    linear-gradient(180deg, rgba(11, 13, 15, 0.72), rgba(11, 13, 15, 0.82)),
     radial-gradient(
       circle at 20% 15%,
       color-mix(in srgb, $accent 12%, transparent) 0%,
@@ -1151,6 +1152,7 @@ body.books-page {
       color-mix(in srgb, $white 7%, transparent) 0%,
       transparent 52%
     ),
+    url('/assets/images/sitebg/cbad6b12cb5c4ba29d1a55a3f2685a6a.jpg') center / cover no-repeat,
     linear-gradient(180deg, rgba(26, 29, 34, 0.82), rgba(21, 24, 28, 0.72));
   border-radius: clamp(1rem, 2vw, 1.4rem);
 }


### PR DESCRIPTION
### Motivation
- Use the requested production site texture image as the background for the homepage featured books rail and add more top padding so the section heading has better breathing room while keeping the overlay gradients and contrast intact.
- Ensure the change is present in the compiled deployable CSS so GitHub Pages static hosting serves the updated visual immediately.

### Description
- Applied the background image to the featured books container by updating `.featured-books-shell` in `scss/components/_book-details-wrapper.scss` to include `url('/assets/images/sitebg/cbad6b12cb5c4ba29d1a55a3f2685a6a.jpg')` layered with the existing gradients and increased the top padding via `padding: clamp(1.6rem, 3.8vw, 2.35rem) ...`.
- Synced the compiled stylesheet `assets/styles.css` to reflect the SCSS changes so the static build artifact matches source styles.
- Added a changelog entry in `docs/CHANGELOG_DOC_SYNC.md` documenting the featured-rail background refresh and heading spacing polish.

### Testing
- Ran `npm run styles:build` to recompile `assets/styles.css`, and the build completed successfully.
- Verified the change exists in source and compiled files using `rg -n "cbad6b12cb5c4ba29d1a55a3f2685a6a|featured-books-shell" scss/components/_book-details-wrapper.scss assets/styles.css docs/CHANGELOG_DOC_SYNC.md`, and the patterns were found in all expected files.
- Pre-commit formatting tasks (via `lint-staged` / `prettier`) executed as part of the commit hook and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2fb798ea48325a0c11edc4b48616d)