### PR TITLE
Remove runtime padding-top override on .featured-books-shell

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -592,7 +592,6 @@ function initBookCoverPresentationFixes() {
       margin-left: calc(50% - 50vw) !important;
       margin-right: calc(50% - 50vw) !important;
       border-radius: 0 !important;
-      padding-top: clamp(0.75rem, 1.8vw, 1.25rem) !important;
     }
 
     .featured-books-strip {


### PR DESCRIPTION
### Motivation
- The runtime style injected by `initBookCoverPresentationFixes()` was setting `.featured-books-shell` `padding-top` with `!important`, which overrode the authored stylesheet and prevented the intended heading spacing on the homepage.

### Description
- Deleted the `padding-top: clamp(0.75rem, 1.8vw, 1.25rem) !important;` line from the injected `<style>` in `js/main.js` inside `initBookCoverPresentationFixes()` so the stylesheet-defined spacing on `.featured-books-shell` can take effect.

### Testing
- Pre-commit hooks (`lint-staged` + `prettier`) ran and passed, and the override removal was verified with `rg -n "featured-books-shell|padding-top" js/main.js` and by inspecting `initBookCoverPresentationFixes()` to confirm the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3179665848325a2eee7eb63525709)