### PR TITLE
Use IMG_0307 as CTA background on featured rail and top-align copy

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -9654,10 +9654,23 @@ body.books-page .books-main > section {
   }
 }
 .featured-book-card--cta {
-  align-content: center;
-  background: linear-gradient(155deg, rgba(5, 6, 8, 0.98), rgba(18, 20, 24, 0.9));
+  position: relative;
+  align-content: start;
+  justify-items: start;
+  text-align: left;
+  gap: 0.45rem;
+  padding-top: 0.9rem;
+  background:
+    linear-gradient(
+      180deg,
+      rgba(8, 9, 12, 0.84) 6%,
+      rgba(8, 9, 12, 0.42) 46%,
+      rgba(8, 9, 12, 0.78) 100%
+    ),
+    url('https://www.darenprince.com/assets/images/IMG_0307.png') center/cover no-repeat;
 }
 .featured-book-card--cta h4 {
+  margin: 0;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   line-height: 1.15;
@@ -9678,6 +9691,7 @@ body.books-page .books-main > section {
   margin: 0;
   color: color-mix(in srgb, var(--color-white) 72%, transparent);
   font-size: 0.9rem;
+  max-width: 22ch;
 }
 
 @keyframes card-cta-line-rise {


### PR DESCRIPTION
### Motivation
- Improve the visual impact of the Featured & Upcoming rail CTA by placing a photographic background behind the final "browse all books" card. 
- Ensure copy remains readable by adding a subtle overlay and moving text to the top of the card.

### Description
- Updated `assets/styles.css` to change the `.featured-book-card--cta` styling to use `https://www.darenprince.com/assets/images/IMG_0307.png` as the card background with a layered `linear-gradient` overlay for readability. 
- Repositioned content to the top-left of the card by setting `align-content: start`, `justify-items: start`, and `text-align: left`, and added `padding-top` and `gap` for spacing. 
- Added `margin: 0` to the CTA heading and a `max-width: 22ch` to the CTA paragraph for improved line length and legibility. 
- This is a CSS-only change; no HTML structure modifications were required and the update targets the homepage featured rail CTA.

### Testing
- Ran repository formatting/lint hooks (`prettier --write` via lint-staged) on the modified CSS file and checks completed successfully. 
- Inspected the updated `assets/styles.css` to confirm the new background, overlay, and alignment rules were applied; no automated visual regression tests were executed and no screenshots were captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3a52da070832585b189162977264d)