### PR TITLE
Refactor bio and press section headings to use styled heading system

### DIFF
--- a/docs/meet-daren-prince-page.md
+++ b/docs/meet-daren-prince-page.md
@@ -21,6 +21,7 @@ The `meet-daren-prince.html` page introduces Daren’s story, credentials, and p
 8. **Call to Action Row:** Booking details plus a teaser card for the upcoming email waitlist.
 
 Each block sits inside `.container.max-width-adaptive-lg` wrappers and leans on responsive grids defined in `scss/components/_bio-page.scss`.
+Section-level content headings also use the shared `styledh1` style-guide class to keep bio and press page typography visually aligned.
 
 ## Metadata & Structured Data
 

--- a/docs/press-media-page.md
+++ b/docs/press-media-page.md
@@ -27,6 +27,7 @@ The `press.html` page centralizes every media ready asset for Daren Prince. It b
 ## Styling Notes
 
 - Dedicated partial: `scss/components/_press-page.scss` (imported in `scss/styles.scss`).
+- Section-level headings now use the shared `styledh1` treatment from the style guide so all primary content bands use the same branded heading system as the rest of the site.
 - Buttons reuse `.grad-kelly-green`, `.btn--accent`, and `.btn--subtle` variants already defined.
 - Press kit preview frame is locked to the US Letter ratio (`8.5 / 11`) so embedded PDF previews keep consistent proportions instead of clipping across viewport sizes.
 - The in-page media drawer uses a branded dark gradient panel, mint accent borders, and icon-first anchors to match existing site header controls.

--- a/meet-daren-prince.html
+++ b/meet-daren-prince.html
@@ -416,7 +416,7 @@
         <div class="container max-width-adaptive-lg">
           <div class="bio-timeline__grid">
             <div>
-              <h2>How Daren Became the Real World Dating Strategist</h2>
+              <h2 class="styledh1">How Daren Became the Real World Dating Strategist</h2>
               <p>Every milestone sharpened the Game On! perspective by bridging boardroom strategy, personal heartbreak, and the pursuit of relational mastery.</p>
             </div>
             <ul class="bio-timeline__list">
@@ -447,7 +447,7 @@
 
       <section class="bio-media">
         <div class="container max-width-adaptive-lg">
-          <h2 class="margin-bottom-md">Story Angles Producers Love</h2>
+          <h2 class="margin-bottom-md styledh1">Story Angles Producers Love</h2>
           <div class="bio-media__grid">
             <article class="bio-media__card">
               <h3>Dating Without the Games</h3>
@@ -470,7 +470,7 @@
 
       <section class="bio-versions">
         <div class="container max-width-adaptive-lg">
-          <h2 class="margin-bottom-md">Press Ready Bio Options</h2>
+          <h2 class="margin-bottom-md styledh1">Press Ready Bio Options</h2>
           <div class="bio-versions__grid">
             <article class="bio-version">
               <h3>Press Bio</h3>
@@ -496,7 +496,7 @@
         <div class="container max-width-adaptive-lg">
           <div class="bio-cta__grid">
             <div class="bio-cta__card">
-              <h2>Interview Daren Prince</h2>
+              <h2 class="styledh1">Interview Daren Prince</h2>
               <p>Book him for interviews, summits, masterminds, or intimate fireside chats. Daren delivers story driven insights with tactical takeaways that get people moving.</p>
               <ul class="footer-links">
                 <li><i class="ph ph-envelope bio-icon"></i> <a href="mailto:press@darenprince.com">press@darenprince.com</a></li>

--- a/press.html
+++ b/press.html
@@ -170,67 +170,67 @@
  }
  </script>
  <!-- Apple PWA + Safari enhancements -->
- <!-- Smart App banner is rendered by js/main.js -->
- <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
- <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
- <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
- <link rel="icon" type="image/png" sizes="48x48" href="/assets/icons/generated/favicon-48x48.png">
- <link rel="manifest" href="/assets/icons/generated/manifest.webmanifest">
- <meta name="mobile-web-app-capable" content="yes">
- <meta name="theme-color" content="#456f3a">
- <meta name="application-name" content="Daren Prince Official Site">
- <link rel="apple-touch-icon" sizes="57x57" href="/assets/icons/generated/apple-touch-icon-57x57.png">
- <link rel="apple-touch-icon" sizes="60x60" href="/assets/icons/generated/apple-touch-icon-60x60.png">
- <link rel="apple-touch-icon" sizes="72x72" href="/assets/icons/generated/apple-touch-icon-72x72.png">
- <link rel="apple-touch-icon" sizes="76x76" href="/assets/icons/generated/apple-touch-icon-76x76.png">
- <link rel="apple-touch-icon" sizes="114x114" href="/assets/icons/generated/apple-touch-icon-114x114.png">
- <link rel="apple-touch-icon" sizes="120x120" href="/assets/icons/generated/apple-touch-icon-120x120.png">
- <link rel="apple-touch-icon" sizes="144x144" href="/assets/icons/generated/apple-touch-icon-144x144.png">
- <link rel="apple-touch-icon" sizes="152x152" href="/assets/icons/generated/apple-touch-icon-152x152.png">
- <link rel="apple-touch-icon" sizes="167x167" href="/assets/icons/generated/apple-touch-icon-167x167.png">
- <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/generated/apple-touch-icon-180x180.png">
- <link rel="apple-touch-icon" sizes="1024x1024" href="/assets/icons/generated/apple-touch-icon-1024x1024.png">
- <meta name="apple-mobile-web-app-capable" content="yes">
- <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
- <meta name="apple-mobile-web-app-title" content="Daren Prince">
- <link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-640x1136.png">
- <link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-1136x640.png">
- <link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-750x1334.png">
- <link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-1334x750.png">
- <link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1125x2436.png">
- <link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2436x1125.png">
- <link rel="apple-touch-startup-image" media="(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1170x2532.png">
- <link rel="apple-touch-startup-image" media="(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2532x1170.png">
- <link rel="apple-touch-startup-image" media="(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1179x2556.png">
- <link rel="apple-touch-startup-image" media="(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2556x1179.png">
- <link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-828x1792.png">
- <link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-1792x828.png">
- <link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1242x2688.png">
- <link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2688x1242.png">
- <link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1242x2208.png">
- <link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2208x1242.png">
- <link rel="apple-touch-startup-image" media="(device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1284x2778.png">
- <link rel="apple-touch-startup-image" media="(device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2778x1284.png">
- <link rel="apple-touch-startup-image" media="(device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1290x2796.png">
- <link rel="apple-touch-startup-image" media="(device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2796x1290.png">
- <link rel="apple-touch-startup-image" media="(device-width: 744px) and (device-height: 1133px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1488x2266.png">
- <link rel="apple-touch-startup-image" media="(device-width: 744px) and (device-height: 1133px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2266x1488.png">
- <link rel="apple-touch-startup-image" media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1536x2048.png">
- <link rel="apple-touch-startup-image" media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2048x1536.png">
- <link rel="apple-touch-startup-image" media="(device-width: 810px) and (device-height: 1080px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1620x2160.png">
- <link rel="apple-touch-startup-image" media="(device-width: 810px) and (device-height: 1080px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2160x1620.png">
- <link rel="apple-touch-startup-image" media="(device-width: 820px) and (device-height: 1080px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1640x2160.png">
- <link rel="apple-touch-startup-image" media="(device-width: 820px) and (device-height: 1080px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2160x1640.png">
- <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1668x2388.png">
- <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2388x1668.png">
- <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1668x2224.png">
- <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
- <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
- <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
- <meta name="msapplication-TileColor" content="#456f3a">
- <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
- <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
- <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
+   <!-- Smart App banner is rendered by js/main.js -->
+   <link rel="icon" type="image/x-icon" href="/assets/icons/generated/favicon.ico">
+   <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/generated/favicon-16x16.png">
+   <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/generated/favicon-32x32.png">
+   <link rel="icon" type="image/png" sizes="48x48" href="/assets/icons/generated/favicon-48x48.png">
+   <link rel="manifest" href="/assets/icons/generated/manifest.webmanifest">
+   <meta name="mobile-web-app-capable" content="yes">
+   <meta name="theme-color" content="#456f3a">
+   <meta name="application-name" content="Daren Prince Official Site">
+   <link rel="apple-touch-icon" sizes="57x57" href="/assets/icons/generated/apple-touch-icon-57x57.png">
+   <link rel="apple-touch-icon" sizes="60x60" href="/assets/icons/generated/apple-touch-icon-60x60.png">
+   <link rel="apple-touch-icon" sizes="72x72" href="/assets/icons/generated/apple-touch-icon-72x72.png">
+   <link rel="apple-touch-icon" sizes="76x76" href="/assets/icons/generated/apple-touch-icon-76x76.png">
+   <link rel="apple-touch-icon" sizes="114x114" href="/assets/icons/generated/apple-touch-icon-114x114.png">
+   <link rel="apple-touch-icon" sizes="120x120" href="/assets/icons/generated/apple-touch-icon-120x120.png">
+   <link rel="apple-touch-icon" sizes="144x144" href="/assets/icons/generated/apple-touch-icon-144x144.png">
+   <link rel="apple-touch-icon" sizes="152x152" href="/assets/icons/generated/apple-touch-icon-152x152.png">
+   <link rel="apple-touch-icon" sizes="167x167" href="/assets/icons/generated/apple-touch-icon-167x167.png">
+   <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/generated/apple-touch-icon-180x180.png">
+   <link rel="apple-touch-icon" sizes="1024x1024" href="/assets/icons/generated/apple-touch-icon-1024x1024.png">
+   <meta name="apple-mobile-web-app-capable" content="yes">
+   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+   <meta name="apple-mobile-web-app-title" content="Daren Prince">
+   <link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-640x1136.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-1136x640.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-750x1334.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-1334x750.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1125x2436.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2436x1125.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1170x2532.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2532x1170.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1179x2556.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2556x1179.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-828x1792.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-1792x828.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1242x2688.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2688x1242.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1242x2208.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2208x1242.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1284x2778.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2778x1284.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1290x2796.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2796x1290.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 744px) and (device-height: 1133px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1488x2266.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 744px) and (device-height: 1133px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2266x1488.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1536x2048.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2048x1536.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 810px) and (device-height: 1080px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1620x2160.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 810px) and (device-height: 1080px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2160x1620.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 820px) and (device-height: 1080px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1640x2160.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 820px) and (device-height: 1080px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2160x1640.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1668x2388.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2388x1668.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-1668x2224.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2224x1668.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/assets/icons/generated/apple-touch-startup-image-2048x2732.png">
+   <link rel="apple-touch-startup-image" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)" href="/assets/icons/generated/apple-touch-startup-image-2732x2048.png">
+   <meta name="msapplication-TileColor" content="#456f3a">
+   <meta name="msapplication-TileImage" content="/assets/icons/generated/mstile-144x144.png">
+   <meta name="msapplication-config" content="/assets/icons/generated/browserconfig.xml">
+   <link rel="yandex-tableau-widget" href="/assets/icons/generated/yandex-browser-manifest.json">
  <!-- End Apple PWA + Safari enhancements -->
 <meta property="og:site_name" content="darenprince.com"><meta name="author" content="Daren Prince"><meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
 <script type="application/ld+json" data-generated-by="seo-enrich">{
@@ -324,7 +324,7 @@
  </div>
  </div>
  <div class="press-hero__highlight">
- <h2>Highlights</h2>
+ <h2 class="styledh1">Highlights</h2>
  <ul>
  <li><i class="ph ph-star"></i> Amazon Top 100 author across multiple self help categories.</li>
  <li><i class="ph ph-microphone"></i> Featured on relationship podcasts, livestreams, and community summits.</li>
@@ -337,7 +337,7 @@
  <section class="viewer press-viewer" aria-labelledby="press-kit-viewer">
  <div class="container max-width-adaptive-lg">
  <div class="press-viewer__header">
- <h2 id="press-kit-viewer">Press Kit Preview</h2>
+ <h2 id="press-kit-viewer" class="styledh1">Press Kit Preview</h2>
  <div class="toolbar">
  <a href="/assets/brand/Game_On_Press-Retailer_Kit_Brand_Identity_US_EU_compressed.pdf" class="btn btn--ghost" download=""><i class="ph ph-download"></i>Download</a>
  <a href="/assets/brand/Game_On_Press-Retailer_Kit_Brand_Identity_US_EU_compressed.pdf" target="_blank" rel="noopener" class="btn btn--ghost"><i class="ph ph-magnifying-glass-plus"></i>Open Fullscreen</a>
@@ -381,7 +381,7 @@
 
  <section id="media-downloads" class="press-downloads">
  <div class="container max-width-adaptive-lg">
- <h2 class="margin-bottom-md">Downloadable Assets</h2>
+ <h2 class="margin-bottom-md styledh1">Downloadable Assets</h2>
  <div class="press-downloads__grid">
  <article class="press-download">
  <img src="/assets/images/presskit-thumb-portrait.jpg" alt="Game On! press kit cover">
@@ -407,7 +407,7 @@
 
  <section id="media-headshots" class="press-headshots">
  <div class="container max-width-adaptive-lg">
- <h2 class="margin-bottom-md">Headshot Gallery</h2>
+ <h2 class="margin-bottom-md styledh1">Headshot Gallery</h2>
  <div class="press-headshots__grid">
  <figure>
  <img src="/assets/images/daren-prince-profile-lg.jpg" alt="Professional headshot of Daren Prince Sr. in charcoal jacket">
@@ -424,7 +424,7 @@
  <section id="media-contact" class="press-contact">
  <div class="container max-width-adaptive-lg press-contact__grid">
  <div>
- <h2>Media Contact</h2>
+ <h2 class="styledh1">Media Contact</h2>
  <p>For interviews, speaking requests, or media placements connect with the press desk. We respond within one business day.</p>
  <ul class="press-contact__list">
  <li><i class="ph ph-envelope"></i> <a href="mailto:press@darenprince.com">press@darenprince.com</a></li>


### PR DESCRIPTION
### Motivation
- Bring section-level headings on the Bio and Press pages into alignment with the site style guide so primary content bands use the same branded typographic treatment. 
- Improve visual consistency and make hero/section headings reusable across pages via the shared `styledh1` class. 

### Description
- Applied the `styledh1` style-guide class to section-level headings in `press.html` (Highlights, Press Kit Preview, Downloadable Assets, Headshot Gallery, Media Contact). 
- Applied the `styledh1` class to major bio headings in `meet-daren-prince.html` (timeline heading, Story Angles, Press Ready Bio Options, Interview CTA). 
- Updated documentation files `docs/press-media-page.md` and `docs/meet-daren-prince-page.md` to reflect the new heading pattern. 
- Ran the icon generation script which updated favicon/manifest metadata referenced in page templates to keep deploy metadata valid for GitHub Pages (`/assets/icons/generated/*`). 

### Testing
- Ran `npm run lint:buttons` which completed successfully. 
- Ran `npm run generate:icons` to generate favicons and metadata assets which completed successfully. 
- Ran `npm run lint:metadata` which initially failed on missing icons but passed after icon generation, and final metadata checks reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3a85d49bc8325bc031426e3cfa1e0)