### PR TITLE
Restore Crown Labs theme-aware logos and add sticky docs header

### DIFF
--- a/crownlabsbible/05-corporate-infrastructure/documentation-platform.md
+++ b/crownlabsbible/05-corporate-infrastructure/documentation-platform.md
@@ -9,6 +9,7 @@
   - Favicon: https://www.darenprince.com/app%20icons/crownicon.PNG
 - Viewer rendering rules: escape markdown before conversion, render structural markdown safely, support explicit `[[Document Name]]` references only, and never regex-replace already-rendered HTML.
 - Navigation standards: expandable hierarchy, active state, breadcrumbs, mobile close-on-select, current path display.
+- Sticky header behavior: toolbar remains fixed at the top while scrolling; includes an in-body theme-aware Crown Labs logo in addition to the sidebar logo.
 - Footer standard: branding, docs links, investor, executive, ecosystem map, roadmap, contact, signup UI, Iconify social links.
 - Utility toolbar: text size controls, copy, print, share, and back-to-top.
 - Deprecated legacy files: `viewer-clean.html` and `investor-clean.html` are retired from primary navigation and can be removed after external references are migrated.

--- a/crownlabsbible/docs/assets/css/platform.css
+++ b/crownlabsbible/docs/assets/css/platform.css
@@ -328,14 +328,30 @@ button {
   flex-direction: column;
 }
 .cl-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 22px;
   margin-bottom: 30px;
-  padding-bottom: 18px;
+  padding: 14px 0 18px;
   border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg) 85%, transparent);
+  backdrop-filter: blur(8px);
 }
+.cl-toolbar-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.cl-header-logo {
+  height: 34px;
+  width: auto;
+  display: block;
+}
+
 .cl-breadcrumbs {
   display: flex;
   align-items: center;

--- a/crownlabsbible/docs/index.html
+++ b/crownlabsbible/docs/index.html
@@ -16,7 +16,7 @@
   <div class="cl-app" id="app">
     <aside class="cl-sidebar">
       <div class="cl-sidebar-header">
-        <img class="cl-logo" src="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-dark-logo="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-light-logo="https://www.darenprince.com/assets/logos/logo-hires-black-for-light-bg.svg" alt="Crown Labs" />
+        <img class="cl-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
         <button class="cl-icon-btn" id="navToggle" title="Toggle navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
       </div>
       <div class="cl-title">Crown Labs Documentation</div>
@@ -35,8 +35,9 @@
     <main class="cl-main">
       <div class="cl-reader">
         <div class="cl-toolbar">
-          <div>
+          <div class="cl-toolbar-meta">
             <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu"><span class="ms-icon" aria-hidden="true">menu</span></button>
+            <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
             <div class="cl-breadcrumbs"><span class="current">Crown Labs - index.html</span></div>
             <small class="cl-path">crownlabsbible/docs/index.html</small>
           </div>
@@ -47,7 +48,7 @@
         </div>
         <article class="cl-content page"><h1>Crown Labs Documentation Platform</h1><p>Canonical routes, safe rendering, shared styling, and branded documentation operations.</p><div class="card-grid"><a class="card" href="viewer.html"><h3>Documentation Viewer</h3><p>Safe markdown reader with hierarchy, breadcrumbs, and utility controls.</p></a><a class="card" href="categories.html"><h3>Category Architecture</h3><p>Corporate foundation, identity, writing, investor, infrastructure, and product systems.</p></a><a class="card" href="products.html"><h3>Product Index</h3><p>Portfolio documentation entry points for all major Crown Labs products.</p></a></div></article>
         <footer class="cl-footer">
-          <div class="cl-footer-grid"><div><img src="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-dark-logo="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-light-logo="https://www.darenprince.com/assets/logos/logo-hires-black-for-light-bg.svg" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p></div></div>
+          <div class="cl-footer-grid"><div><img src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p></div></div>
         </footer>
       </div>
     </main>


### PR DESCRIPTION
### Motivation
- The documentation pages were using incorrect/legacy logo assets and lacked an in-body header logo and persistent toolbar, so branding and UX did not match the documented theme-aware design. 
- The change aligns the live docs markup and styles with the documented dark/light logo pair and improves navigation persistence during scroll.

### Description
- Replaced sidebar and footer logo references in `crownlabsbible/docs/index.html` to use the documented theme-aware URLs (`https://www.darenprince.com/labs/assets/crown-labs-logo.png` for dark and `https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png` for light). 
- Added an in-body header logo by introducing a `cl-toolbar-meta` wrapper and an `img.cl-header-logo` element inside the main toolbar in `crownlabsbible/docs/index.html`. 
- Made the docs toolbar sticky and visually separated with `position: sticky`, `top: 0`, elevated `z-index`, subtle `backdrop-filter: blur(8px)`, adjusted padding, and added `.cl-toolbar-meta` and `.cl-header-logo` styles in `crownlabsbible/docs/assets/css/platform.css`. 
- Documented the new behavior in `crownlabsbible/05-corporate-infrastructure/documentation-platform.md` by adding a `Sticky header behavior` line describing the dual-logo and sticky toolbar requirement.

### Testing
- Ran `rg -n "cl-header-logo|cl-toolbar-meta|crown-labs-logo.png|30F807E6"` to verify updated references and the command returned the expected matches (success). 
- Inspected diffs with `git diff -- crownlabsbible/docs/index.html crownlabsbible/docs/assets/css/platform.css crownlabsbible/05-corporate-infrastructure/documentation-platform.md` to confirm intended changes (success). 
- Committed changes which triggered `lint-staged` / `prettier` hooks and completed successfully, and created PR metadata with `make_pr` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc4cd6775c8325aa27d2fb91fd4c2a)