### PR TITLE
Unify Crown Labs docs branding and stabilize sticky toolbar

### DIFF
--- a/crownlabsbible/docs/assets/css/platform.css
+++ b/crownlabsbible/docs/assets/css/platform.css
@@ -95,8 +95,10 @@ button {
   margin-bottom: 16px;
 }
 .cl-logo {
-  height: 38px;
+  height: 34px;
   width: auto;
+  max-width: 170px;
+  object-fit: contain;
   display: block;
 }
 .nav-collapsed .cl-logo {
@@ -330,6 +332,7 @@ button {
 .cl-toolbar {
   position: sticky;
   top: 0;
+  top: max(0px, env(safe-area-inset-top));
   z-index: 30;
   display: flex;
   align-items: flex-start;
@@ -347,8 +350,10 @@ button {
   gap: 7px;
 }
 .cl-header-logo {
-  height: 34px;
+  height: clamp(22px, 2.2vw, 30px);
   width: auto;
+  max-width: min(180px, 38vw);
+  object-fit: contain;
   display: block;
 }
 

--- a/crownlabsbible/docs/categories.html
+++ b/crownlabsbible/docs/categories.html
@@ -16,7 +16,7 @@
   <div class="cl-app" id="app">
     <aside class="cl-sidebar">
       <div class="cl-sidebar-header">
-        <img class="cl-logo" src="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-dark-logo="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-light-logo="https://www.darenprince.com/assets/logos/logo-hires-black-for-light-bg.svg" alt="Crown Labs" />
+        <img class="cl-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
         <button class="cl-icon-btn" id="navToggle" title="Toggle navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
       </div>
       <div class="cl-title">Crown Labs Documentation</div>
@@ -35,7 +35,8 @@
     <main class="cl-main">
       <div class="cl-reader">
         <div class="cl-toolbar">
-          <div>
+          <div class="cl-toolbar-meta">
+            <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
             <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu"><span class="ms-icon" aria-hidden="true">menu</span></button>
             <div class="cl-breadcrumbs"><span class="current">Crown Labs - categories.html</span></div>
             <small class="cl-path">crownlabsbible/docs/categories.html</small>
@@ -47,7 +48,7 @@
         </div>
         <article class="cl-content page"><h1>Documentation Categories</h1><div class="card-grid"><a class="card" href="viewer.html#Corporate%20Identity"><h3>Corporate Foundation</h3><p>Identity and classification frameworks.</p></a><a class="card" href="viewer.html#Branding%20%26%20Visual%20Identity%20Standards"><h3>Branding & Visual Identity</h3><p>Brand standards and visual rules.</p></a><a class="card" href="viewer.html#Writing%20Standards%20Overview"><h3>Writing & Communication</h3><p>Voice, writing, and communication systems.</p></a><a class="card" href="investor-mode.html"><h3>Investor Framework</h3><p>Valuation, monetization, licensing, and investor relations.</p></a><a class="card" href="viewer.html#Company%20Overview"><h3>Corporate Infrastructure</h3><p>Governance, holdings, roadmap, and operations.</p></a><a class="card" href="products.html"><h3>Product Documentation</h3><p>All product dossiers and product-level docs.</p></a><a class="card" href="viewer.html#Documentation%20Platform"><h3>Operational Systems</h3><p>Documentation platform standards and maintenance architecture.</p></a></div></article>
         <footer class="cl-footer">
-          <div class="cl-footer-grid"><div><img src="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-dark-logo="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-light-logo="https://www.darenprince.com/assets/logos/logo-hires-black-for-light-bg.svg" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p></div></div>
+          <div class="cl-footer-grid"><div><img src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p></div></div>
         </footer>
       </div>
     </main>

--- a/crownlabsbible/docs/ecosystem-map.html
+++ b/crownlabsbible/docs/ecosystem-map.html
@@ -16,7 +16,7 @@
   <div class="cl-app" id="app">
     <aside class="cl-sidebar">
       <div class="cl-sidebar-header">
-        <img class="cl-logo" src="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-dark-logo="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-light-logo="https://www.darenprince.com/assets/logos/logo-hires-black-for-light-bg.svg" alt="Crown Labs" />
+        <img class="cl-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
         <button class="cl-icon-btn" id="navToggle" title="Toggle navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
       </div>
       <div class="cl-title">Crown Labs Documentation</div>
@@ -35,7 +35,8 @@
     <main class="cl-main">
       <div class="cl-reader">
         <div class="cl-toolbar">
-          <div>
+          <div class="cl-toolbar-meta">
+            <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
             <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu"><span class="ms-icon" aria-hidden="true">menu</span></button>
             <div class="cl-breadcrumbs"><span class="current">Crown Labs - Ecosystem Map</span></div>
             <small class="cl-path">crownlabsbible/docs/ecosystem-map.html</small>
@@ -47,7 +48,7 @@
         </div>
         <article class="cl-content page"><h1>Ecosystem Map</h1><p class="page-eyebrow">Portfolio Systems Map</p><p class="page-intro">A unified map of products, infrastructure, and strategic dependencies showing how every lane supports the Crown Labs operating model.</p><div class="card-grid"><a class="card" href="products.html"><h3>Product Lanes</h3><p>Navigate CrownCam, Crowncast, Sentinel Vault, Crown SOS, and adjacent modules.</p></a><a class="card" href="viewer.html#Ecosystem%20Philosophy"><h3>Ecosystem Doctrine</h3><p>Review principles for interoperability, narrative discipline, and long-term platform stewardship.</p></a><a class="card" href="categories.html"><h3>Category Hierarchy</h3><p>Understand how documentation categories map to business and operational objectives.</p></a></div><h2 class="section-title">Dependency Health</h2><ul class="status-list"><li><span>Shared Navigation & Footer Shell</span><span class="status-chip live">Live</span></li><li><span>Cross-route Metadata Coverage</span><span class="status-chip review">Review</span></li><li><span>Product Taxonomy Expansion</span><span class="status-chip building">Building</span></li></ul></article>
         <footer class="cl-footer">
-          <div class="cl-footer-grid"><div><img src="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-dark-logo="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-light-logo="https://www.darenprince.com/assets/logos/logo-hires-black-for-light-bg.svg" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p></div></div>
+          <div class="cl-footer-grid"><div><img src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p></div></div>
         </footer>
       </div>
     </main>

--- a/crownlabsbible/docs/executive-dashboard.html
+++ b/crownlabsbible/docs/executive-dashboard.html
@@ -16,7 +16,7 @@
   <div class="cl-app" id="app">
     <aside class="cl-sidebar">
       <div class="cl-sidebar-header">
-        <img class="cl-logo" src="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-dark-logo="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-light-logo="https://www.darenprince.com/assets/logos/logo-hires-black-for-light-bg.svg" alt="Crown Labs" />
+        <img class="cl-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
         <button class="cl-icon-btn" id="navToggle" title="Toggle navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
       </div>
       <div class="cl-title">Crown Labs Documentation</div>
@@ -35,7 +35,8 @@
     <main class="cl-main">
       <div class="cl-reader">
         <div class="cl-toolbar">
-          <div>
+          <div class="cl-toolbar-meta">
+            <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
             <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu"><span class="ms-icon" aria-hidden="true">menu</span></button>
             <div class="cl-breadcrumbs"><span class="current">Crown Labs - Executive Dashboard</span></div>
             <small class="cl-path">crownlabsbible/docs/executive-dashboard.html</small>
@@ -47,7 +48,7 @@
         </div>
         <article class="cl-content page"><h1>Executive Dashboard</h1><p class="page-eyebrow">Leadership Control Tower</p><p class="page-intro">A single executive surface for governance, operations cadence, and strategic execution across all Crown Labs documentation lanes.</p><div class="insight-grid"><article class="insight-card"><h3><span class="ms-icon" aria-hidden="true">admin_panel_settings</span>Governance Streams</h3><p class="insight-value">4</p><p>Corporate, product, investor, and infrastructure streams aligned with one publication hierarchy.</p></article><article class="insight-card"><h3><span class="ms-icon" aria-hidden="true">task_alt</span>Operational Priorities</h3><p class="insight-value">12</p><p>Cross-functional priorities tracked from draft through release, with owner visibility.</p></article><article class="insight-card"><h3><span class="ms-icon" aria-hidden="true">alarm</span>Critical Risks</h3><p class="insight-value">2 Open</p><p>Legacy assets and taxonomy drift are flagged for immediate clean-up cycles.</p></article></div><h2 class="section-title">Executive Workstream Status</h2><ul class="status-list"><li><span>Portfolio Governance Blueprint</span><span class="status-chip live">Live</span></li><li><span>Expansion Roadmap Execution</span><span class="status-chip review">Review</span></li><li><span>Q3 Narrative Deck Inputs</span><span class="status-chip building">Building</span></li></ul><div class="quick-actions"><a href="viewer.html#Portfolio%20Governance"><span class="ms-icon" aria-hidden="true">account_tree</span>Open Governance</a><a href="roadmap-tracker.html"><span class="ms-icon" aria-hidden="true">map</span>View Roadmap Tracker</a></div></article>
         <footer class="cl-footer">
-          <div class="cl-footer-grid"><div><img src="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-dark-logo="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-light-logo="https://www.darenprince.com/assets/logos/logo-hires-black-for-light-bg.svg" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p></div></div>
+          <div class="cl-footer-grid"><div><img src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p></div></div>
         </footer>
       </div>
     </main>

--- a/crownlabsbible/docs/investor-mode.html
+++ b/crownlabsbible/docs/investor-mode.html
@@ -16,7 +16,7 @@
   <div class="cl-app" id="app">
     <aside class="cl-sidebar">
       <div class="cl-sidebar-header">
-        <img class="cl-logo" src="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-dark-logo="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-light-logo="https://www.darenprince.com/assets/logos/logo-hires-black-for-light-bg.svg" alt="Crown Labs" />
+        <img class="cl-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
         <button class="cl-icon-btn" id="navToggle" title="Toggle navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
       </div>
       <div class="cl-title">Crown Labs Documentation</div>
@@ -35,7 +35,8 @@
     <main class="cl-main">
       <div class="cl-reader">
         <div class="cl-toolbar">
-          <div>
+          <div class="cl-toolbar-meta">
+            <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
             <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu"><span class="ms-icon" aria-hidden="true">menu</span></button>
             <div class="cl-breadcrumbs"><span class="current">Crown Labs - Investor Mode</span></div>
             <small class="cl-path">crownlabsbible/docs/investor-mode.html</small>
@@ -47,7 +48,7 @@
         </div>
         <article class="cl-content page"><h1>Investor Mode</h1><p class="page-eyebrow">Capital Intelligence Surface</p><p class="page-intro">Institutional-facing documentation for valuation confidence, monetization architecture, and licensing posture across the Crown Labs portfolio.</p><div class="insight-grid"><article class="insight-card"><h3><span class="ms-icon" aria-hidden="true">bar_chart</span>Portfolio Readiness</h3><p class="insight-value">87%</p><p>Primary investor-facing dossiers have refreshed copy, metadata, and shared shell parity.</p></article><article class="insight-card"><h3><span class="ms-icon" aria-hidden="true">account_balance_wallet</span>Revenue Tracks</h3><p class="insight-value">6 Active</p><p>SaaS, licensing, creator subscriptions, media syndication, education, and enterprise support.</p></article><article class="insight-card"><h3><span class="ms-icon" aria-hidden="true">verified_user</span>Compliance</h3><p class="insight-value">In Review</p><p>Risk controls and governance audit notes are centralized before external release.</p></article></div><h2 class="section-title">Investor Documentation Routes</h2><ul class="status-list"><li><span>Investor Relations Narrative</span><span class="status-chip live">Live</span></li><li><span>Valuation Methodology</span><span class="status-chip review">Review</span></li><li><span>Monetization Models</span><span class="status-chip live">Live</span></li><li><span>Licensing Structures</span><span class="status-chip building">Building</span></li></ul><div class="quick-actions"><a href="viewer.html#Investor%20Relations"><span class="ms-icon" aria-hidden="true">description</span>Open Investor Relations</a><a href="viewer.html#Valuation%20Methodology"><span class="ms-icon" aria-hidden="true">calculate</span>Open Valuation Methodology</a></div></article>
         <footer class="cl-footer">
-          <div class="cl-footer-grid"><div><img src="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-dark-logo="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-light-logo="https://www.darenprince.com/assets/logos/logo-hires-black-for-light-bg.svg" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p></div></div>
+          <div class="cl-footer-grid"><div><img src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p></div></div>
         </footer>
       </div>
     </main>

--- a/crownlabsbible/docs/products.html
+++ b/crownlabsbible/docs/products.html
@@ -16,7 +16,7 @@
   <div class="cl-app" id="app">
     <aside class="cl-sidebar">
       <div class="cl-sidebar-header">
-        <img class="cl-logo" src="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-dark-logo="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-light-logo="https://www.darenprince.com/assets/logos/logo-hires-black-for-light-bg.svg" alt="Crown Labs" />
+        <img class="cl-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
         <button class="cl-icon-btn" id="navToggle" title="Toggle navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
       </div>
       <div class="cl-title">Crown Labs Documentation</div>
@@ -35,7 +35,8 @@
     <main class="cl-main">
       <div class="cl-reader">
         <div class="cl-toolbar">
-          <div>
+          <div class="cl-toolbar-meta">
+            <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
             <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu"><span class="ms-icon" aria-hidden="true">menu</span></button>
             <div class="cl-breadcrumbs"><span class="current">Crown Labs - products.html</span></div>
             <small class="cl-path">crownlabsbible/docs/products.html</small>
@@ -47,7 +48,7 @@
         </div>
         <article class="cl-content page"><h1>Product Documentation Index</h1><div class="card-grid"><a class="card" href="viewer.html#Crown%20Psychology"><h3>Crown Psychology</h3><p>Emotional intelligence and psychology product systems.</p></a><a class="card" href="viewer.html#CrownCam"><h3>CrownCam</h3><p>Documentation for visual capture and analytics lane.</p></a><a class="card" href="viewer.html#Sentinel%20Vault"><h3>Sentinel Vault</h3><p>Continuity, security, and archival intelligence platform.</p></a><a class="card" href="viewer.html#Crown%20SOS"><h3>Crown SOS</h3><p>Emergency intelligence and alerting infrastructure.</p></a><a class="card" href="viewer.html#Crown%20WatchTower"><h3>Crown WatchTower</h3><p>Monitoring, governance, and oversight systems.</p></a><a class="card" href="viewer.html#CrownCast"><h3>CrownCast</h3><p>Media and communication product stack.</p></a><a class="card" href="viewer.html#AI%20Cherry%20Pie"><h3>AI Cherry Pie</h3><p>AI product and platform architecture documentation.</p></a></div></article>
         <footer class="cl-footer">
-          <div class="cl-footer-grid"><div><img src="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-dark-logo="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-light-logo="https://www.darenprince.com/assets/logos/logo-hires-black-for-light-bg.svg" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p></div></div>
+          <div class="cl-footer-grid"><div><img src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p></div></div>
         </footer>
       </div>
     </main>

--- a/crownlabsbible/docs/roadmap-tracker.html
+++ b/crownlabsbible/docs/roadmap-tracker.html
@@ -16,7 +16,7 @@
   <div class="cl-app" id="app">
     <aside class="cl-sidebar">
       <div class="cl-sidebar-header">
-        <img class="cl-logo" src="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-dark-logo="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-light-logo="https://www.darenprince.com/assets/logos/logo-hires-black-for-light-bg.svg" alt="Crown Labs" />
+        <img class="cl-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
         <button class="cl-icon-btn" id="navToggle" title="Toggle navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
       </div>
       <div class="cl-title">Crown Labs Documentation</div>
@@ -35,7 +35,8 @@
     <main class="cl-main">
       <div class="cl-reader">
         <div class="cl-toolbar">
-          <div>
+          <div class="cl-toolbar-meta">
+            <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
             <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu"><span class="ms-icon" aria-hidden="true">menu</span></button>
             <div class="cl-breadcrumbs"><span class="current">Crown Labs - Roadmap Tracker</span></div>
             <small class="cl-path">crownlabsbible/docs/roadmap-tracker.html</small>
@@ -47,7 +48,7 @@
         </div>
         <article class="cl-content page"><h1>Roadmap Tracker</h1><p class="page-eyebrow">Execution Timeline</p><p class="page-intro">Roadmap visibility for documentation platform hardening, content upgrades, and upcoming architecture milestones.</p><ol class="timeline"><li><strong>Phase 1 — Stabilization (Completed)</strong><p>Canonical routing, shared shell adoption, and theme persistence normalized.</p></li><li><strong>Phase 2 — Standardization (Active)</strong><p>Footer destination rebuilds, metadata alignment, and route-level UX consistency.</p></li><li><strong>Phase 3 — Intelligence Layer (Planned)</strong><p>Modular data feeds for roadmap metrics, release status, and governance checkpoints.</p></li></ol><h2 class="section-title">Current Priority Queue</h2><ul class="status-list"><li><span>GitHub Pages deployment hardening</span><span class="status-chip live">Live</span></li><li><span>SEO and social preview parity</span><span class="status-chip review">Review</span></li><li><span>Viewer intelligence module extraction</span><span class="status-chip building">Building</span></li></ul><div class="quick-actions"><a href="executive-dashboard.html"><span class="ms-icon" aria-hidden="true">dashboard</span>Open Executive Dashboard</a><a href="viewer.html"><span class="ms-icon" aria-hidden="true">menu_book</span>Open Documentation Viewer</a></div></article>
         <footer class="cl-footer">
-          <div class="cl-footer-grid"><div><img src="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-dark-logo="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-light-logo="https://www.darenprince.com/assets/logos/logo-hires-black-for-light-bg.svg" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p></div></div>
+          <div class="cl-footer-grid"><div><img src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p></div></div>
         </footer>
       </div>
     </main>

--- a/crownlabsbible/docs/viewer.html
+++ b/crownlabsbible/docs/viewer.html
@@ -13,7 +13,7 @@
 <div class="cl-app" id="app">
   <aside class="cl-sidebar">
     <div class="cl-sidebar-header">
-      <img class="cl-logo" src="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-dark-logo="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-light-logo="https://www.darenprince.com/assets/logos/logo-hires-black-for-light-bg.svg" alt="Crown Labs" />
+      <img class="cl-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
       <button class="cl-icon-btn" id="navToggle" title="Toggle navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
     </div>
     <div class="cl-title">Crown Labs Documentation</div>
@@ -33,7 +33,8 @@
   <main class="cl-main">
     <div class="cl-reader">
       <div class="cl-toolbar">
-        <div>
+        <div class="cl-toolbar-meta">
+          <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
           <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu"><span class="ms-icon" aria-hidden="true">menu</span></button>
           <div class="cl-breadcrumbs" id="breadcrumbRoot"></div>
           <small class="cl-path" id="pathLabel">Select a document</small>
@@ -51,7 +52,7 @@
       <article class="cl-content" id="content"><p class="cl-empty">Choose a document from the navigation.</p></article>
       <footer class="cl-footer">
         <div class="cl-footer-grid">
-          <div><img src="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-dark-logo="https://www.darenprince.com/assets/logos/logo-hires-white-for-dark-bg.svg" data-light-logo="https://www.darenprince.com/assets/logos/logo-hires-black-for-light-bg.svg" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p><div class="cl-social"><a href="https://www.darenprince.com"><span class="ms-icon" aria-hidden="true">language</span></a><a href="https://github.com/darenprince"><span class="ms-icon" aria-hidden="true">code</span></a><a href="#"><span class="ms-icon" aria-hidden="true">work</span></a><a href="#"><span class="ms-icon" aria-hidden="true">alternate_email</span></a></div></div>
+          <div><img src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p><div class="cl-social"><a href="https://www.darenprince.com"><span class="ms-icon" aria-hidden="true">language</span></a><a href="https://github.com/darenprince"><span class="ms-icon" aria-hidden="true">code</span></a><a href="#"><span class="ms-icon" aria-hidden="true">work</span></a><a href="#"><span class="ms-icon" aria-hidden="true">alternate_email</span></a></div></div>
           <div><h4>Documentation</h4><a href="viewer.html"><span class="ms-icon" aria-hidden="true">description</span>Viewer</a><a href="ecosystem-map.html"><span class="ms-icon" aria-hidden="true">map</span>Ecosystem Map</a><a href="roadmap-tracker.html"><span class="ms-icon" aria-hidden="true">route</span>Roadmap</a></div>
           <div><h4>Business</h4><a href="investor-mode.html"><span class="ms-icon" aria-hidden="true">account_balance_wallet</span>Investor Mode</a><a href="executive-dashboard.html"><span class="ms-icon" aria-hidden="true">monitoring</span>Executive Dashboard</a><a href="mailto:apps@crownlabs.tech"><span class="ms-icon" aria-hidden="true">mail</span>Contact</a></div>
           <div><h4>Updates</h4><p>Get release notes and documentation updates.</p><form class="cl-signup" onsubmit="event.preventDefault();toast('Signup captured. Connect mailing provider next.');"><input type="email" placeholder="Email address" required /><button><span class="ms-icon" aria-hidden="true">arrow_forward</span></button></form></div>


### PR DESCRIPTION
### Motivation
- Ensure the Crown Labs docs shell is visually consistent by replacing mixed logo treatments with a single, theme-aware logo pair across sidebar, toolbar, and footer. 
- Fix uncontrolled logo sizing that produced an oversized wordmark outside the menu and restore predictable responsive scaling. 
- Make the top toolbar reliably sticky across devices and safe-area insets so toolbar controls remain accessible when scrolling.

### Description
- Replaced disparate logo references in all pages under `crownlabsbible/docs` to a single dark/light pair and added the missing toolbar logo block (`.cl-header-logo`) to each docs page for consistent branding. 
- Constrained logo rendering in `crownlabsbible/docs/assets/css/platform.css` by adjusting `.cl-logo` and `.cl-header-logo` to use `clamp()`/`max-width` and `object-fit: contain` to prevent oversize and maintain responsive behavior. 
- Reinforced sticky toolbar anchoring by adding a safe-area-aware top anchor `top: max(0px, env(safe-area-inset-top));` to `.cl-toolbar` in `platform.css`. 
- Files updated: `crownlabsbible/docs/assets/css/platform.css` and all docs shell pages under `crownlabsbible/docs/*.html` (viewer, products, categories, ecosystem-map, executive-dashboard, investor-mode, roadmap-tracker, etc.).

### Testing
- Ran a repository grep to confirm old logo references were replaced and `cl-header-logo` exists across docs pages using `rg` which returned the updated pages (success). 
- Verified diff and staged changes with `git diff --stat` and created a commit that ran `lint-staged`/`prettier` during commit which completed successfully (success). 
- Performed local file inspections of `platform.css` to confirm size/clamp and `top` changes and validated HTML inserts in each modified `*.html` file (manual verification via tooling; no visual browser tests were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc4ea1daa48325b76bd841341c41e8)