### PR TITLE
Align docs header (logo left, hamburger right); fix mobile layering and active-link styling

### DIFF
--- a/crownlabsbible/docs/README.md
+++ b/crownlabsbible/docs/README.md
@@ -31,6 +31,9 @@ All routes are aligned to the viewer-style documentation shell and include:
 - dark/light theme toggle support plus collapsible desktop/mobile navigation state
 - Iconify icon usage for visual language consistency
 - route-level SEO/social metadata (`description`, Open Graph, Twitter cards)
+- unified toolbar header pattern: brand mark left, mobile navigation toggle right, breadcrumb stack below
+- mobile layering fix: off-canvas menu and scrim now stack above sticky toolbar to prevent header/menu overlap
+- active route highlighting uses solid Crown red text for reliable contrast (replaces conic-gradient text fill)
 
 ## Brand and Browser Assets
 

--- a/crownlabsbible/docs/assets/css/platform.css
+++ b/crownlabsbible/docs/assets/css/platform.css
@@ -141,12 +141,10 @@ button {
 }
 
 .cl-quicklinks a.is-active {
-  background: rgba(156, 39, 28, 0.12);
-  border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
-  color: transparent;
-  background-image: conic-gradient(from 180deg, #7f1d1d, #b91c1c, #ef4444, #b91c1c, #7f1d1d);
-  -webkit-background-clip: text;
-  background-clip: text;
+  background: color-mix(in srgb, var(--accent) 16%, var(--surface-2));
+  border-color: color-mix(in srgb, var(--accent) 52%, var(--border));
+  color: #ef4444;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 48%, transparent);
 }
 
 .cl-icon-btn,
@@ -347,7 +345,13 @@ button {
 .cl-toolbar-meta {
   display: flex;
   flex-direction: column;
-  gap: 7px;
+  gap: 9px;
+}
+.cl-toolbar-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 .cl-header-logo {
   height: clamp(22px, 2.2vw, 30px);
@@ -571,7 +575,7 @@ button {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.55);
-  z-index: 15;
+  z-index: 55;
 }
 @media (max-width: 980px) {
   .cl-app,
@@ -585,6 +589,7 @@ button {
     width: min(88vw, 372px);
     transform: translateX(-105%);
     box-shadow: 24px 0 70px rgba(0, 0, 0, 0.42);
+    z-index: 60;
   }
   body.nav-open .cl-sidebar {
     transform: translateX(0);
@@ -596,7 +601,9 @@ button {
     padding: 24px 20px 0;
   }
   .cl-toolbar {
-    display: block;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
   }
   .cl-tools {
     justify-content: flex-start;
@@ -611,7 +618,8 @@ button {
   }
   .cl-mobile-menu {
     display: inline-flex !important;
-    margin-bottom: 12px;
+    margin-bottom: 0;
+    margin-left: auto;
   }
 }
 @media (min-width: 981px) {

--- a/crownlabsbible/docs/categories.html
+++ b/crownlabsbible/docs/categories.html
@@ -36,8 +36,10 @@
       <div class="cl-reader">
         <div class="cl-toolbar">
           <div class="cl-toolbar-meta">
-            <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
-            <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu"><span class="ms-icon" aria-hidden="true">menu</span></button>
+            <div class="cl-toolbar-head">
+              <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
+              <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu" title="Open navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
+            </div>
             <div class="cl-breadcrumbs"><span class="current">Crown Labs - categories.html</span></div>
             <small class="cl-path">crownlabsbible/docs/categories.html</small>
           </div>

--- a/crownlabsbible/docs/ecosystem-map.html
+++ b/crownlabsbible/docs/ecosystem-map.html
@@ -36,8 +36,10 @@
       <div class="cl-reader">
         <div class="cl-toolbar">
           <div class="cl-toolbar-meta">
-            <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
-            <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu"><span class="ms-icon" aria-hidden="true">menu</span></button>
+            <div class="cl-toolbar-head">
+              <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
+              <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu" title="Open navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
+            </div>
             <div class="cl-breadcrumbs"><span class="current">Crown Labs - Ecosystem Map</span></div>
             <small class="cl-path">crownlabsbible/docs/ecosystem-map.html</small>
           </div>

--- a/crownlabsbible/docs/executive-dashboard.html
+++ b/crownlabsbible/docs/executive-dashboard.html
@@ -36,8 +36,10 @@
       <div class="cl-reader">
         <div class="cl-toolbar">
           <div class="cl-toolbar-meta">
-            <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
-            <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu"><span class="ms-icon" aria-hidden="true">menu</span></button>
+            <div class="cl-toolbar-head">
+              <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
+              <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu" title="Open navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
+            </div>
             <div class="cl-breadcrumbs"><span class="current">Crown Labs - Executive Dashboard</span></div>
             <small class="cl-path">crownlabsbible/docs/executive-dashboard.html</small>
           </div>

--- a/crownlabsbible/docs/index.html
+++ b/crownlabsbible/docs/index.html
@@ -36,8 +36,10 @@
       <div class="cl-reader">
         <div class="cl-toolbar">
           <div class="cl-toolbar-meta">
-            <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu"><span class="ms-icon" aria-hidden="true">menu</span></button>
-            <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
+            <div class="cl-toolbar-head">
+              <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
+              <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu" title="Open navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
+            </div>
             <div class="cl-breadcrumbs"><span class="current">Crown Labs - index.html</span></div>
             <small class="cl-path">crownlabsbible/docs/index.html</small>
           </div>

--- a/crownlabsbible/docs/investor-mode.html
+++ b/crownlabsbible/docs/investor-mode.html
@@ -36,8 +36,10 @@
       <div class="cl-reader">
         <div class="cl-toolbar">
           <div class="cl-toolbar-meta">
-            <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
-            <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu"><span class="ms-icon" aria-hidden="true">menu</span></button>
+            <div class="cl-toolbar-head">
+              <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
+              <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu" title="Open navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
+            </div>
             <div class="cl-breadcrumbs"><span class="current">Crown Labs - Investor Mode</span></div>
             <small class="cl-path">crownlabsbible/docs/investor-mode.html</small>
           </div>

--- a/crownlabsbible/docs/products.html
+++ b/crownlabsbible/docs/products.html
@@ -36,8 +36,10 @@
       <div class="cl-reader">
         <div class="cl-toolbar">
           <div class="cl-toolbar-meta">
-            <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
-            <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu"><span class="ms-icon" aria-hidden="true">menu</span></button>
+            <div class="cl-toolbar-head">
+              <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
+              <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu" title="Open navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
+            </div>
             <div class="cl-breadcrumbs"><span class="current">Crown Labs - products.html</span></div>
             <small class="cl-path">crownlabsbible/docs/products.html</small>
           </div>

--- a/crownlabsbible/docs/roadmap-tracker.html
+++ b/crownlabsbible/docs/roadmap-tracker.html
@@ -36,8 +36,10 @@
       <div class="cl-reader">
         <div class="cl-toolbar">
           <div class="cl-toolbar-meta">
-            <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
-            <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu"><span class="ms-icon" aria-hidden="true">menu</span></button>
+            <div class="cl-toolbar-head">
+              <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
+              <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu" title="Open navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
+            </div>
             <div class="cl-breadcrumbs"><span class="current">Crown Labs - Roadmap Tracker</span></div>
             <small class="cl-path">crownlabsbible/docs/roadmap-tracker.html</small>
           </div>

--- a/crownlabsbible/docs/viewer.html
+++ b/crownlabsbible/docs/viewer.html
@@ -34,8 +34,10 @@
     <div class="cl-reader">
       <div class="cl-toolbar">
         <div class="cl-toolbar-meta">
-          <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
-          <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu"><span class="ms-icon" aria-hidden="true">menu</span></button>
+          <div class="cl-toolbar-head">
+            <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
+            <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu" title="Open navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
+          </div>
           <div class="cl-breadcrumbs" id="breadcrumbRoot"></div>
           <small class="cl-path" id="pathLabel">Select a document</small>
         </div>


### PR DESCRIPTION
### Motivation
- Create a unified toolbar so the Crown Labs mark is anchored to the left and the mobile hamburger is anchored to the right for consistent header hierarchy across docs routes.
- Prevent the sticky toolbar from being visually overlaid by the mobile off-canvas menu by fixing stacking context and scrim layering.
- Replace the fragile conic-gradient active-link treatment with a stable, high-contrast Crown red selected state for reliable rendering and accessibility.
- Keep repeated toolbar markup synchronized across all docs routes and document the shell pattern in `README.md`.

### Description
- Introduced a `cl-toolbar-head` wrapper in the toolbar markup for all routes (`index.html`, `viewer.html`, `categories.html`, `products.html`, `investor-mode.html`, `executive-dashboard.html`, `ecosystem-map.html`, `roadmap-tracker.html`) to place the logo left and the mobile menu button right and moved breadcrumbs below.
- Updated `crownlabsbible/docs/assets/css/platform.css` to add `.cl-toolbar-head` rules, tweak `.cl-toolbar-meta` spacing, change `.cl-mobile-menu` layout, replace `.cl-quicklinks a.is-active` with a solid red treatment, and raise z-indexes for `.cl-scrim` and `.cl-sidebar` to prevent header/menu overlap.
- Added `title="Open navigation"` on mobile menu buttons for clearer intent and slightly improved accessibility.
- Updated `crownlabsbible/docs/README.md` with the new toolbar/header pattern, mobile layering behavior, and active-route styling decision.

### Testing
- Verified markup propagation with `rg -n "cl-toolbar|cl-mobile-menu|cl-header-logo|cl-breadcrumbs"` across docs HTML files and confirmed `cl-toolbar-head` presence where applicable (success).
- Confirmed CSS updates and layering with `rg -n "cl-toolbar-head|cl-mobile-menu|is-active|z-index: 60|z-index: 55"` (success).
- Scanned the docs tree for common broken-content markers with `rg -n "TODO|placeholder|lorem|undefined|null|broken"` to ensure no regressions were introduced (no issues found).
- Performed git staging/commits for the change set and created the PR metadata (commits succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7a42d670832596f5a7cf094f17d3)