### PR TITLE
Refine CrownDocs deployment shell and theme‑aware logo system

### DIFF
--- a/crowndocs/README.md
+++ b/crowndocs/README.md
@@ -2,13 +2,32 @@
 
 Nuxt Content documentation platform for Crown Labs.
 
+## Runtime + Shell Baseline
+
+- Node 20 LTS recommended.
+- npm 10+ recommended.
+- `NITRO_PRESET=netlify` is optional for local parity checks.
+
 ## Run
-- npm install
-- npm run dev
+
+- `npm install`
+- `npm run dev`
 
 ## Build
-- npm run generate
 
-## Deploy (Netlify)
+- `npm run generate`
+
+## Deployment (Netlify)
+
 - Build command: `npm run generate`
 - Publish directory: `.output/public`
+
+## Public Docs QA Checklist
+
+- Verify home and docs routes render with no console errors.
+- Verify theme toggle persistence (localStorage key: `crowndocs-theme`).
+- Verify logo alternates correctly:
+  - Dark mode: `https://www.darenprince.com/labs/assets/crown-labs-logo.png`
+  - Light mode: `https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png`
+- Verify metadata tags for `theme-color`, OG, and Twitter are present in generated HTML.
+- Keep `crownlabsbible/docs/*` references deprecated (do not reintroduce).

--- a/crowndocs/app.vue
+++ b/crowndocs/app.vue
@@ -1,3 +1,118 @@
+<script setup lang="ts">
+import { computed, onMounted, watch } from 'vue'
+
+const STORAGE_KEY = 'crowndocs-theme'
+const theme = useState<'dark' | 'light'>('theme', () => 'dark')
+
+const logoSrc = computed(() =>
+  theme.value === 'dark'
+    ? 'https://www.darenprince.com/labs/assets/crown-labs-logo.png'
+    : 'https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png'
+)
+
+const themeLabel = computed(() => (theme.value === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'))
+
+const applyTheme = (mode: 'dark' | 'light') => {
+  if (!import.meta.client) return
+  document.documentElement.setAttribute('data-theme', mode)
+  document.body.dataset.theme = mode
+}
+
+const toggleTheme = () => {
+  theme.value = theme.value === 'dark' ? 'light' : 'dark'
+}
+
+onMounted(() => {
+  const persisted = localStorage.getItem(STORAGE_KEY)
+  if (persisted === 'light' || persisted === 'dark') {
+    theme.value = persisted
+  }
+  applyTheme(theme.value)
+})
+
+watch(theme, (mode) => {
+  applyTheme(mode)
+  if (import.meta.client) localStorage.setItem(STORAGE_KEY, mode)
+})
+</script>
+
 <template>
-  <NuxtPage />
+  <div class="site-shell">
+    <header class="site-header">
+      <NuxtLink to="/" class="brand-link" aria-label="Crown Labs Documentation home">
+        <img :src="logoSrc" alt="Crown Labs" class="brand-logo" />
+      </NuxtLink>
+      <button class="theme-toggle" type="button" :aria-label="themeLabel" @click="toggleTheme">
+        {{ theme === 'dark' ? 'Light' : 'Dark' }}
+      </button>
+    </header>
+
+    <NuxtPage />
+
+    <footer class="site-footer">Crown Labs Documentation Platform</footer>
+  </div>
 </template>
+
+<style>
+:root {
+  --bg: #0c1117;
+  --surface: #141c24;
+  --text: #e7edf3;
+  --muted: #9cafc3;
+  --accent: #d4b26a;
+  --border: rgba(212, 178, 106, 0.2);
+}
+
+:root[data-theme='light'] {
+  --bg: #f5f7fa;
+  --surface: #ffffff;
+  --text: #1f2937;
+  --muted: #4b5563;
+  --accent: #7a5a1c;
+  --border: rgba(31, 41, 55, 0.15);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+a { color: var(--accent); }
+
+.site-shell { min-height: 100vh; }
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.875rem 1rem;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg) 90%, transparent);
+  backdrop-filter: blur(10px);
+}
+
+.brand-logo { height: 36px; width: auto; display: block; }
+
+.theme-toggle {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  padding: 0.4rem 0.75rem;
+  cursor: pointer;
+}
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  text-align: center;
+  padding: 1rem;
+  margin-top: 2rem;
+}
+</style>

--- a/crowndocs/content/corporate-infrastructure/documentation-platform.md
+++ b/crowndocs/content/corporate-infrastructure/documentation-platform.md
@@ -13,3 +13,16 @@
 - Utility toolbar: text size controls, copy, print, share, and back-to-top.
 - Deprecated legacy files: `viewer-clean.html` and `investor-clean.html` are retired from primary navigation and can be removed after external references are migrated.
 - Next implementation step: extract shared interactive behavior into `docs/assets/js/platform.js`.
+
+## CrownLabsBible Legacy Review
+
+- `crownlabsbible/docs/index.html` and `crownlabsbible/docs/viewer.html` remain deprecated legacy endpoints.
+- Canonical public interface is the Nuxt `crowndocs` shell and `/docs/*` content routes.
+- Do not mirror legacy logo behavior from the old viewer; use shell-level theme-aware logo switching only.
+
+## Theme-aware Logo Rules (Production)
+
+- Dark mode logo: `https://www.darenprince.com/labs/assets/crown-labs-logo.png`.
+- Light mode logo: `https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png`.
+- Logo swapping is bound to persistent theme state (`crowndocs-theme`) and applies globally through `app.vue`.
+- Any new docs page must inherit shell branding and must not define local competing logos.

--- a/crowndocs/nuxt.config.ts
+++ b/crowndocs/nuxt.config.ts
@@ -7,17 +7,37 @@ export default defineNuxtConfig({
       meta: [
         { name: 'description', content: 'Crown Labs institutional documentation platform.' },
         { name: 'theme-color', content: '#0c1117' },
+        { name: 'theme-color', media: '(prefers-color-scheme: light)', content: '#f5f7fa' },
         { property: 'og:title', content: 'Crown Labs Documentation' },
-        { property: 'og:description', content: 'Institutional documentation, governance, investor frameworks, and product dossiers.' },
+        {
+          property: 'og:description',
+          content:
+            'Institutional documentation, governance, investor frameworks, and product dossiers.',
+        },
         { property: 'og:type', content: 'website' },
-        { name: 'twitter:card', content: 'summary_large_image' }
+        {
+          property: 'og:image',
+          content: 'https://www.darenprince.com/labs/assets/crown-labs-logo.png',
+        },
+        { name: 'twitter:card', content: 'summary_large_image' },
+        { name: 'twitter:title', content: 'Crown Labs Documentation' },
+        {
+          name: 'twitter:description',
+          content:
+            'Institutional documentation, governance, investor frameworks, and product dossiers.',
+        },
+        {
+          name: 'twitter:image',
+          content: 'https://www.darenprince.com/labs/assets/crown-labs-logo.png',
+        },
       ],
-      link: [
-        { rel: 'icon', type: 'image/svg+xml', href: '/brand/favicon.svg' }
-      ]
-    }
+      link: [{ rel: 'icon', type: 'image/svg+xml', href: '/brand/favicon.svg' }],
+    },
   },
   nitro: {
-    prerender: { routes: ['/'], failOnError: false }
-  }
+    prerender: {
+      routes: ['/', '/docs/foundation', '/docs/corporate-infrastructure/documentation-platform'],
+      failOnError: false,
+    },
+  },
 })

--- a/crowndocs/package-lock.json
+++ b/crowndocs/package-lock.json
@@ -5256,12 +5256,14 @@
       }
     },
     "node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/commondir": {
@@ -11094,6 +11096,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tagged-tag": {

--- a/crowndocs/pages/index.vue
+++ b/crowndocs/pages/index.vue
@@ -2,7 +2,7 @@
   <main class="wrap">
     <header>
       <h1>Crown Labs Documentation</h1>
-      <p>Quiet luxury infrastructure documentation platform.</p>
+      <p>Quiet luxury infrastructure documentation platform for public-facing institutional content.</p>
     </header>
     <section>
       <ul>
@@ -17,8 +17,6 @@
 </template>
 
 <style scoped>
-:global(body){font-family:Inter, system-ui, sans-serif;background:#0c1117;color:#e7edf3;margin:0}
 .wrap{max-width:960px;margin:0 auto;padding:3rem 1.25rem}
-a{color:#d4b26a;text-decoration:none}
-a:hover{text-decoration:underline}
+ul{line-height:1.8}
 </style>


### PR DESCRIPTION
### Motivation
- Provide a single, production-grade docs shell so all pages inherit consistent theme, branding, and header/footer behavior. 
- Ensure logo and browser/chrome metadata behave correctly for both dark and light modes for public-facing documentation. 
- Capture deployment and QA guidance in repository docs so builds are reproducible and brand-safe.

### Description
- Added a global app shell at `crowndocs/app.vue` implementing persistent theme state (`crowndocs-theme`), safe theme application on mount/watch, a sticky header/footer, and centralized dark/light logo switching. 
- Hardened site metadata and social previews in `crowndocs/nuxt.config.ts` by adding dual-mode `theme-color`, OG/Twitter image/title/description entries, and explicit prerender routes. 
- Updated public landing and copy in `crowndocs/pages/index.vue` and expanded runtime/deploy guidance and a QA checklist in `crowndocs/README.md`. 
- Documented deprecation of legacy CrownLabsBible viewer and formalized production theme/logo rules in `crowndocs/content/corporate-infrastructure/documentation-platform.md`; `crowndocs/package-lock.json` updated during dependency installation.

### Testing
- Ran `npm install` in `crowndocs` successfully to install dependencies. 
- Ran `npm run generate` in `crowndocs` and verified a successful static build that produced `.output/public` (Nuxt prerender logs produced existing content-query 404 warnings observed during prerender crawl). 
- Noted an initial `nuxt: not found` failure prior to installing dependencies, which was resolved by the above `npm install` step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2f8da86c8325b168e0cd237bc499)