### PR TITLE
Fix Emergency category mapping and section node lookup in phoenix resource renderer

### DIFF
--- a/phoenix.html
+++ b/phoenix.html
@@ -226,8 +226,11 @@
       ["Work","Facebook Marketplace / Local Labor","Online / local area","N/A","Look for moving help, yard cleanup, hauling, small repair, labor gigs, flipping low-cost items.","",["gigs","online","labor"]]
     ];
 
-    const sectionMap = { Emergency: 'emergency', Hotlines: 'hotlines', Shelter: 'shelter', Food: 'food', 'Wi-Fi': 'wifi', Charging: 'wifi', 'Safe Indoors': 'medical', Medical: 'medical', Benefits: 'benefits', Work: 'work' };
-    const sectionNodes = Object.fromEntries([...document.querySelectorAll('section[id]')].map(s => [s.id, s.querySelector('.cards')]));
+    const sectionMap = { Emergency: 'hotlines', Hotlines: 'hotlines', Shelter: 'shelter', Food: 'food', 'Wi-Fi': 'wifi', Charging: 'wifi', 'Safe Indoors': 'medical', Medical: 'medical', Benefits: 'benefits', Work: 'work' };
+    const sectionNodes = {
+      ...Object.fromEntries([...document.querySelectorAll('section[id]')].map(s => [s.id, s.querySelector('.cards')])),
+      ...Object.fromEntries([...document.querySelectorAll('.cards[id]')].map(node => [node.id, node]))
+    };
 
     function telHref(phone) {
       const clean = phone.replace(/[^\d]/g, '');


### PR DESCRIPTION
### Motivation
- Emergency-filtered resources were not rendering because `render()` looked up hosts by `sectionMap` but `sectionNodes` only indexed `section[id]`, while the emergency cards live in a `.cards` element with `id="emergency"` inside `#hotlines` rather than a `section#emergency`.
- Ensure filters/chips for `Emergency` and similar categories target an actual DOM host so resources are not silently dropped and the UI remains consistent.

### Description
- Remapped `Emergency` in `sectionMap` from `'emergency'` to `'hotlines'` so Emergency entries render into the existing Emergency Hotlines area via `hotlines` host.
- Broadened `sectionNodes` indexing to include both `section[id]` containers (mapped to their `.cards` child) and any direct `.cards[id]` nodes by merging two `Object.fromEntries` results.
- Left `render()` behavior intact other than resolving `host` from the expanded `sectionNodes`, preserving existing card creation and clearing logic.

### Testing
- Ran `rg -n` searches to confirm the new mapping `Emergency: 'hotlines'` and the added `.cards[id]` indexing in `phoenix.html`, and those checks succeeded.
- Printed the modified source region with `nl -ba` to verify the updated lines are present and correctly formatted, and that check succeeded.
- Executed an inline `node -e` content-check which failed due to quoting/syntax error in the test invocation rather than a code change; the failure was caused by the test command, not the file content.
- Verified the on-disk diff shows the mapping and `sectionNodes` expansion as intended using local verification tools, and that check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01446c2e2c8325ad71ca0dd3e399b2)