### PR TITLE
Enhance Operation Phoenix UX with modern navigation and branded loading state

### DIFF
--- a/phoenix.html
+++ b/phoenix.html
@@ -5,25 +5,26 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Operation Phoenix — Alexandria, LA Survival Guide</title>
   <meta name="description" content="Operation Phoenix: static survival resource guide for shelter, food, Wi-Fi, charging, medical, and stabilization resources in Alexandria, Louisiana." />
+  <meta name="theme-color" content="#0b1b2f" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,200..700,0..1,-50..200" rel="stylesheet" />
   <style>
     :root {
-      --bg: #120f10;
-      --bg-soft: #1c1516;
-      --panel: #241819;
-      --panel-2: #2e1c1b;
-      --ember: #d84a2b;
-      --flame: #ff7a2f;
-      --gold: #ffc259;
-      --cream: #f6e8d0;
-      --muted: #cabca7;
-      --ash: #60514b;
-      --ok: #ff9f43;
-      --danger: #ff5f5f;
+      --bg: #f4f7fb;
+      --bg-soft: #e9eef5;
+      --panel: #ffffff;
+      --panel-2: #f8fbff;
+      --primary: #0b1b2f;
+      --accent: #2f6fed;
+      --accent-2: #0c9fa5;
+      --text: #142033;
+      --muted: #57657a;
+      --line: #d4dde8;
+      --ok: #0e8f63;
+      --danger: #c53535;
       --radius: 16px;
-      --shadow: 0 10px 26px rgba(0,0,0,.35);
+      --shadow: 0 12px 30px rgba(15,35,60,.1);
     }
 
     * { box-sizing: border-box; }
@@ -31,21 +32,27 @@
     body {
       margin: 0;
       font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      background: radial-gradient(1000px 420px at 20% -5%, #3b1e1b 0%, var(--bg) 45%), var(--bg);
-      color: var(--cream);
+      background: radial-gradient(1000px 420px at 20% -5%, #dfe9f8 0%, var(--bg) 45%), var(--bg);
+      color: var(--text);
       line-height: 1.45;
-      padding-bottom: 78px;
+      padding: 72px 0 78px;
     }
 
     .material-symbols-rounded { font-variation-settings: "FILL" 1, "wght" 500, "GRAD" 0, "opsz" 24; font-size: 1.1rem; line-height: 1; }
 
+
+    a:focus-visible, button:focus-visible, input:focus-visible { outline: 3px solid #77a2ff; outline-offset: 2px; }
+    .toolbar { position: fixed; top:0; left:0; right:0; z-index:60; display:flex; align-items:center; justify-content:space-between; gap:10px; background: rgba(255,255,255,.95); border-bottom:1px solid var(--line); padding:10px 14px; backdrop-filter: blur(10px); }
+    .menu-btn { border:1px solid #bfd0e7; background:#fff; border-radius:10px; height:42px; width:42px; color:#0b1b2f; }
+    .menu-panel { position: fixed; right:14px; top:62px; z-index:70; min-width:220px; background:#fff; border:1px solid var(--line); border-radius:12px; padding:8px; box-shadow:var(--shadow); }
+    .menu-panel a{ display:block; color:#1d3557; text-decoration:none; font-weight:600; padding:10px; border-radius:8px; }
+    .menu-panel a:hover{ background:#f2f6ff; }
+    .loader{ position:fixed; inset:0; z-index:100; display:grid; place-items:center; background:rgba(244,247,251,.96); transition:opacity .25s ease, visibility .25s ease; }
+    .loader[aria-hidden="true"]{ opacity:0; visibility:hidden; }
+    .loader-ring{ width:84px; height:84px; border-radius:50%; border:3px solid #c8d9ef; border-top-color:#2f6fed; margin:0 auto 8px; animation:spin 1s linear infinite;}
+    .loader-logo{ width:78px; height:78px; border-radius:16px; animation:pulse 1.2s infinite ease-in-out;}
+
     .container { width: min(100%, 860px); margin: 0 auto; padding: 14px 14px 24px; }
-    .top-nav { position: sticky; top: 10px; z-index: 30; margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center; background: rgba(24, 18, 20, .86); border: 1px solid #4b3936; border-radius: 14px; padding: 10px 14px; backdrop-filter: blur(8px); }
-    .brand-mini { display:flex; align-items:center; gap:10px; font-weight:700; letter-spacing:.2px; }
-    .brand-mini img { width: 30px; height: 30px; border-radius: 8px; border:1px solid #5c4239; }
-    .menu-inline { display:flex; gap:8px; flex-wrap:wrap; }
-    .menu-inline a { color: var(--muted); text-decoration:none; font-size:.86rem; padding: 7px 10px; border-radius:999px; border:1px solid transparent; transition: all .2s ease; }
-    .menu-inline a:hover { color: var(--cream); border-color:#5a433d; background:#2b1d1d; }
     .hero {
       background: linear-gradient(150deg, #2f1616, #1a1112 65%);
       border: 1px solid #483835;
@@ -56,7 +63,7 @@
     .hero-top { display: flex; gap: 12px; align-items: center; }
     .icon { width: 64px; height: 64px; border-radius: 14px; border: 1px solid #5c4239; }
     h1 { margin: 0; font-size: 1.4rem; letter-spacing: .2px; }
-    .motto { margin: 6px 0 0; color: var(--gold); font-weight: 650; font-size: .95rem; }
+    .motto { margin: 6px 0 0; color: var(--accent); font-weight: 650; font-size: .95rem; }
     .sub { margin: 10px 0 4px; color: var(--muted); }
     .note { margin: 10px 0 0; background: rgba(255, 194, 89, .1); border: 1px solid rgba(255, 194, 89, .35); padding: 10px; border-radius: 12px; color: #ffe4ac; }
 
@@ -67,15 +74,15 @@
       display: inline-flex; align-items: center; justify-content: center; gap: 8px;
       text-decoration: none; border-radius: 12px; min-height: 50px;
       padding: 10px 12px; font-weight: 700; font-size: .98rem;
-      border: 1px solid #644940; color: var(--cream); background: #35201f;
+      border: 1px solid #644940; color: var(--text); background: #35201f;
     }
     .btn.hot { background: linear-gradient(180deg, #a52f1f, #7d2218); border-color: #d25538; }
-    .btn.gold { background: linear-gradient(180deg, #896022, #6e4c1c); border-color: #c8963f; }
+    .btn.gold { background: linear-gradient(180deg, #2f6fed, #2458b9); border-color: #2f6fed; color: #fff; }
 
     .search-wrap { margin: 14px 0; }
     .search {
-      width: 100%; min-height: 50px; border: 1px solid #5a4641; border-radius: 13px;
-      background: #201718; color: var(--cream); padding: 12px 14px; font-size: 1rem;
+      width: 100%; min-height: 50px; border: 1px solid var(--line); border-radius: 13px;
+      background: #fff; color: var(--text); padding: 12px 14px; font-size: 1rem;
     }
 
     section { margin-top: 18px; }
@@ -103,7 +110,7 @@
     .actions .btn { min-height: 44px; font-size: .9rem; }
     .small { font-size: .83rem; color: var(--muted); }
 
-    details summary { cursor: pointer; font-weight: 700; color: var(--gold); }
+    details summary { cursor: pointer; font-weight: 700; color: var(--accent); }
 
     .last-resort {
       border: 1px solid #805047;
@@ -116,8 +123,8 @@
 
     .bottom-nav {
       position: fixed; left: 0; right: 0; bottom: 0;
-      background: rgba(18, 15, 16, .97);
-      border-top: 1px solid #523d39;
+      background: rgba(255,255,255,.97);
+      border-top: 1px solid var(--line);
       padding: 8px;
       display: grid;
       grid-template-columns: repeat(5, 1fr);
@@ -125,14 +132,14 @@
       backdrop-filter: blur(8px);
     }
     .bottom-nav a {
-      color: var(--cream); text-decoration: none; font-size: .8rem; text-align: center;
-      background: #2b1d1d; border: 1px solid #5a433d; border-radius: 10px; padding: 8px 4px;
+      color: var(--text); text-decoration: none; font-size: .8rem; text-align: center;
+      background: #fff; border: 1px solid #c9d8ea; border-radius: 10px; padding: 8px 4px;
       min-height: 42px; display: flex; align-items: center; justify-content: center;
     }
 
     #backToTop {
       position: fixed; right: 12px; bottom: 86px; border: 1px solid #815447; background: #462723;
-      color: var(--cream); border-radius: 999px; width: 50px; height: 50px; display: none;
+      color: var(--text); border-radius: 999px; width: 50px; height: 50px; display: none;
       font-weight: 800;
     }
 
@@ -140,20 +147,15 @@
     .site-footer a { color: #ffd9ad; text-decoration:none; }
     .hidden { display: none !important; }
     @keyframes reveal { to { opacity: 1; transform: translateY(0); } }
-    @media (max-width:720px){ .menu-inline{ display:none; } .top-nav{top:0;} }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    @keyframes pulse { 50% { transform: scale(1.05); } }
+    @media (max-width:720px){ .chips { grid-template-columns: repeat(2, minmax(0,1fr)); } }
   </style>
 </head>
 <body>
+  <div class="loader" id="appLoader" role="status" aria-live="polite"><div><div class="loader-ring" aria-hidden="true"></div><img class="loader-logo" src="https://www.darenprince.com/app%20icons/op-phoenix-icon.png" alt="Operation Phoenix logo" /><p>Loading critical resources…</p></div></div>
+  <header class="toolbar" aria-label="Top toolbar"><div class="brand-mini"><img src="https://www.darenprince.com/app%20icons/op-phoenix-icon.png" alt="Phoenix icon" /><span>Operation Phoenix</span></div><button class="menu-btn" id="menuToggle" type="button" aria-expanded="false" aria-controls="anchorMenu" aria-label="Open section menu"><span class="material-symbols-rounded" aria-hidden="true">menu</span></button><nav class="menu-panel hidden" id="anchorMenu" aria-label="Anchor menu"><a href="#hotlines">Hotlines</a><a href="#shelter">Shelter</a><a href="#food">Food</a><a href="#wifi">Wi‑Fi / Charge</a><a href="#medical">Medical</a><a href="#benefits">Benefits</a><a href="#work">Work</a><a href="#last-resort">Safety Plan</a></nav></header>
   <main class="container" id="home">
-    <nav class="top-nav" aria-label="Primary">
-      <div class="brand-mini">
-        <img src="https://www.darenprince.com/app%20icons/op-phoenix-icon.png" alt="Phoenix icon" />
-        <span>Operation Phoenix</span>
-      </div>
-      <div class="menu-inline">
-        <a href="#hotlines">Hotlines</a><a href="#shelter">Shelter</a><a href="#food">Food</a><a href="#medical">Medical</a><a href="#last-resort">Safety Plan</a>
-      </div>
-    </nav>
     <header class="hero">
       <div class="hero-top">
         <img class="icon" src="https://www.darenprince.com/app%20icons/op-phoenix-icon.png" alt="Operation Phoenix app icon" />
@@ -345,6 +347,27 @@
     const back = document.getElementById('backToTop');
     window.addEventListener('scroll', () => back.style.display = window.scrollY > 350 ? 'block' : 'none');
     back.addEventListener('click', () => window.scrollTo({top: 0, behavior: 'smooth'}));
+
+    const menuToggle = document.getElementById('menuToggle');
+    const anchorMenu = document.getElementById('anchorMenu');
+    menuToggle.addEventListener('click', () => {
+      const isOpen = !anchorMenu.classList.contains('hidden');
+      anchorMenu.classList.toggle('hidden', isOpen);
+      menuToggle.setAttribute('aria-expanded', String(!isOpen));
+    });
+    anchorMenu.querySelectorAll('a').forEach((link) => link.addEventListener('click', () => {
+      anchorMenu.classList.add('hidden');
+      menuToggle.setAttribute('aria-expanded', 'false');
+    }));
+    window.addEventListener('click', (e) => {
+      if (!anchorMenu.contains(e.target) && !menuToggle.contains(e.target)) {
+        anchorMenu.classList.add('hidden');
+        menuToggle.setAttribute('aria-expanded', 'false');
+      }
+    });
+    window.addEventListener('load', () => {
+      setTimeout(() => document.getElementById('appLoader').setAttribute('aria-hidden', 'true'), 450);
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace the original brown/low-contrast skin with a modern, cool blue/neutral color palette and improve overall readability and spacing. 
- Provide persistent access to section anchors via a fixed toolbar and an accessible, expandable hamburger anchor menu for faster navigation on mobile. 
- Improve perceived performance and polish by introducing a short branded loading state driven by the app logo. 

### Description
- Reworked theme tokens and CSS variables in `phoenix.html` (replaced brown tones with `--primary`, `--accent`, `--text`, `--line`, etc.) and added a `meta` theme color. 
- Added a fixed top `toolbar` with brand, an ARIA-enabled hamburger `menu-btn`, and a floating `menu-panel` anchor list, plus keyboard/focus-visible styles for accessibility. 
- Implemented an animated loader overlay (`.loader`, `.loader-ring`, `.loader-logo`) that pulses and spins and is dismissed shortly after `load`. 
- Added lightweight JS to control menu toggle/auto-close (`aria-expanded` wiring, close-on-anchor-click and outside-click) and hide the loader on page load; preserved existing data-driven rendering and filter logic. 

### Testing
- Ran targeted static checks with `rg -n "menuToggle|appLoader|toolbar|menu-panel|theme-color" phoenix.html` to confirm new selectors and metadata were present (succeeded). 
- Verified file contents and structure via `nl -ba phoenix.html | sed -n '1,230p' && nl -ba phoenix.html | sed -n '330,390p'` to inspect inserted CSS/HTML/JS blocks (succeeded). 
- Confirmed the modified file is present in working tree via `git status --short` and validated the new interactive behaviors with basic runtime checks (loader hides after `load`, menu toggles and closes on outside click) (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a014866c8508325ae9a5a9d7c48e65c)