### PR TITLE
Restore Phoenix metadata and enforce red browser theming

### DIFF
--- a/phoenix.html
+++ b/phoenix.html
@@ -6,9 +6,13 @@
   <title>Operation Phoenix — Alexandria, LA Survival Guide</title>
   <meta name="description" content="Operation Phoenix: static survival resource guide for shelter, food, Wi-Fi, charging, medical, and stabilization resources in Alexandria, Louisiana." />
   <meta name="theme-color" content="#b31217" />
-  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#b31217" />
+  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#b31217" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black" />
   <link rel="icon" type="image/png" href="https://www.darenprince.com/app%20icons/op-phoenix-icon.png" />
   <link rel="apple-touch-icon" href="https://www.darenprince.com/app%20icons/op-phoenix-icon.png" />
+  <link rel="manifest" href="./phoenix.webmanifest" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800" rel="stylesheet" />

--- a/phoenix.webmanifest
+++ b/phoenix.webmanifest
@@ -3,8 +3,8 @@
   "short_name": "Phoenix",
   "start_url": "./phoenix.html",
   "display": "standalone",
-  "background_color": "#0d0d0d",
-  "theme_color": "#0d0d0d",
+  "background_color": "#b31217",
+  "theme_color": "#b31217",
   "description": "Offline-capable emergency support resources for crisis situations.",
   "icons": [
     {"src":"app icons/op-phoenix-icon.png","sizes":"192x192","type":"image/png"},


### PR DESCRIPTION
### Motivation
- Restore `phoenix.html` to a production-ready metadata state and ensure the app chrome uses the brand red across browsers.
- Ensure both Safari standalone mode and Chrome/Android PWA/installed shells resolve to the same red brand token so status bars and browser chrome are consistent.
- Align the HTML head and the webmanifest so the installed PWA and in-browser theme values are unified.

### Description
- Added explicit `theme-color` meta tags for light and dark schemes (all set to `#b31217`) while keeping the base `theme-color` declaration in `phoenix.html`.
- Added `apple-mobile-web-app-capable` and adjusted `apple-mobile-web-app-status-bar-style` for improved Safari standalone behavior.
- Linked the `phoenix.webmanifest` from `phoenix.html` so installed PWA shells can consume the same theme values.
- Updated `phoenix.webmanifest` `background_color` and `theme_color` to the red brand token `#b31217` for consistent installed app chrome.

### Testing
- Performed a file-level diff check to confirm only `phoenix.html` and `phoenix.webmanifest` metadata/manifest changes were introduced, and the check passed.
- Inspected `phoenix.html` head content to verify the new `theme-color` meta tags and Apple web app meta tags are present, and the inspection passed.
- Inspected `phoenix.webmanifest` to verify `background_color` and `theme_color` are set to `#b31217`, and the inspection passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0198ac6cb8832588672d910f361cf0)