### PR TITLE
Fix Phoenix page background and overlay quick-action tips

### DIFF
--- a/phoenix.html
+++ b/phoenix.html
@@ -40,7 +40,7 @@
     body {
       margin: 0;
       font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      background: linear-gradient(180deg, #4f1518 0%, #341116 42%, #2a1116 100%);
+      background: linear-gradient(180deg, #2b313b 0%, #212730 42%, #1a2028 100%);
       color: var(--text);
       line-height: 1.45;
       padding: 72px 0 78px;
@@ -114,9 +114,10 @@
     .tags { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
     .tag { font-size: .76rem; padding: 4px 8px; border-radius: 999px; background: #303842; color: #d7dce2; display:inline-flex; align-items:center; gap:6px; }
     .tag iconify-icon{font-size:.9rem;}
-    .tooltip-wrap{position:relative;display:inline-flex;align-items:center;}
-    .info-tip{display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:999px;background:rgba(255,255,255,.14);margin-left:6px;cursor:help;color:#fff;}
-    .tooltip-text{position:absolute;bottom:calc(100% + 8px);left:50%;transform:translateX(-50%);min-width:170px;max-width:220px;background:#111722;color:#f5f7fa;font-size:.74rem;padding:8px;border-radius:6px;box-shadow:var(--shadow-sm);opacity:0;pointer-events:none;transition:opacity .2s ease;}
+    .tooltip-wrap{position:relative;display:block;}
+    .info-tip{position:absolute;top:8px;right:8px;display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;border-radius:999px;background:rgba(17,23,34,.72);border:1px solid rgba(255,255,255,.16);margin:0;cursor:help;color:#fff;z-index:2;}
+    .tooltip-text{position:absolute;top:8px;right:36px;min-width:170px;max-width:220px;background:#111722;color:#f5f7fa;font-size:.74rem;padding:8px;border-radius:6px;box-shadow:var(--shadow-sm);opacity:0;pointer-events:none;transition:opacity .2s ease;}
+    .tooltip-wrap .btn{width:100%;}
     .tooltip-wrap:hover .tooltip-text,.tooltip-wrap:focus-within .tooltip-text{opacity:1;}
     .toast-region{position:fixed;top:74px;right:14px;display:grid;gap:8px;z-index:120;}
     .toast{background:#1d2430;border-left:4px solid var(--accent);padding:10px 12px;border-radius:8px;color:#f5f7fa;box-shadow:var(--shadow-md);font-size:.86rem;opacity:0;transform:translateY(-6px);animation:toastIn .2s ease forwards;}


### PR DESCRIPTION
### Motivation
- The page canvas was using a Phoenix-red background which should remain a browser chrome accent only, not the site canvas. 
- The quick-action info tips were placed beside buttons, creating layout clutter and inconsistent visual hierarchy. 
- The change aims to reduce visual noise and align the page with the platforms dark/neutral shell and design system. 

### Description
- Replaced the red page background gradient in `phoenix.html` with a neutral dark gradient so the site canvas is no longer red while the `theme-color` meta tags remain unchanged. 
- Converted `.tooltip-wrap` to a block container and positioned `.info-tip` absolutely so the info control overlays the action button at the top-right. 
- Repositioned `.tooltip-text` to anchor to the overlaid info control and added `.tooltip-wrap .btn{width:100%;}` to preserve full-width button behavior. 
- No other files or metadata were modified; changes are limited to CSS rules in `phoenix.html`. 

### Testing
- Inspected the file diff for `phoenix.html` to confirm only the intended CSS and layout rules were changed and the `theme-color` meta tags were preserved, and the inspection passed. 
- Verified the tooltip overlay and full-width button behavior in a local preview of the updated page and observed the expected hover/focus reveal behavior. 
- Recorded the updated file in the workspace and confirmed the change was saved successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b6d0e7c48325989080850d8c9c44)