### PR TITLE
Swap Iconify Solar icons to Tabler and darken header/background on phoenix.html

### DIFF
--- a/phoenix.html
+++ b/phoenix.html
@@ -19,9 +19,9 @@
   <script defer src="https://code.iconify.design/iconify-icon/2.1.0/iconify-icon.min.js"></script>
   <style>
     :root {
-      --bg: #343b46;
-      --bg-soft: #2a313b;
-      --canvas: #1e242d;
+      --bg: #1f2630;
+      --bg-soft: #1a212b;
+      --canvas: #161c24;
       --panel: #252c35;
       --panel-2: #222933;
       --panel-3: #2b333d;
@@ -40,7 +40,7 @@
     body {
       margin: 0;
       font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      background: linear-gradient(180deg, #2b313b 0%, #212730 42%, #1a2028 100%);
+      background: radial-gradient(circle at 14% -12%, rgba(214, 63, 78, 0.14), transparent 42%), linear-gradient(180deg, #1e252f 0%, #171d26 44%, #111722 100%);
       color: var(--text);
       line-height: 1.45;
       padding: 72px 0 78px;
@@ -51,8 +51,8 @@
     .brand-mini img { width:30px; height:30px; border-radius:6px; }
 
     a:focus-visible, button:focus-visible, input:focus-visible { outline: 2px solid #ff6a61; outline-offset: 2px; }
-    .toolbar { position: fixed; top:0; left:0; right:0; z-index:60; display:flex; align-items:center; justify-content:space-between; gap:10px; background: rgba(43, 16, 21, .94); padding:10px 14px; backdrop-filter: blur(10px); box-shadow: var(--shadow-sm); }
-    .menu-btn { border:0; background:#2a313b; border-radius:6px; height:42px; width:42px; color:var(--text); box-shadow: inset 0 0 0 1px rgba(255,255,255,.04); }
+    .toolbar { position: fixed; top:0; left:0; right:0; z-index:60; display:flex; align-items:center; justify-content:space-between; gap:10px; background: linear-gradient(180deg, rgba(19, 23, 31, .96), rgba(14, 18, 26, .94)); padding:10px 14px; backdrop-filter: blur(10px); box-shadow: var(--shadow-sm); }
+    .menu-btn { border:0; background:rgba(49, 56, 69, 0.82); border-radius:6px; height:42px; width:42px; color:var(--text); box-shadow: inset 0 0 0 1px rgba(255,255,255,.04); }
     .menu-panel { position: fixed; right:14px; top:62px; z-index:70; min-width:220px; background:#252c35; border-radius:8px; padding:8px; box-shadow:var(--shadow-md); }
     .menu-panel a{ display:block; color:var(--text); text-decoration:none; font-weight:600; padding:10px; border-radius:6px; }
     .menu-panel a:hover{ background:#2d3540; }
@@ -170,7 +170,7 @@
 </head>
 <body>
   <div class="loader" id="appLoader" role="status" aria-live="polite"><div><div class="loader-ring" aria-hidden="true"></div><img class="loader-logo" src="https://www.darenprince.com/app%20icons/op-phoenix-icon.png" alt="Operation Phoenix logo" /><p>Loading critical resources…</p></div></div>
-  <header class="toolbar" aria-label="Top toolbar"><div class="brand-mini"><img src="https://www.darenprince.com/app%20icons/op-phoenix-icon.png" alt="Phoenix icon" /><span>Operation Phoenix</span></div><button class="menu-btn" id="menuToggle" type="button" aria-expanded="false" aria-controls="anchorMenu" aria-label="Open section menu"><iconify-icon icon="solar:hamburger-menu-bold" aria-hidden="true"></iconify-icon></button><nav class="menu-panel hidden" id="anchorMenu" aria-label="Anchor menu"><a href="#hotlines">Hotlines</a><a href="#shelter">Shelter</a><a href="#food">Food</a><a href="#wifi">Wi‑Fi / Charge</a><a href="#medical">Medical</a><a href="#benefits">Benefits</a><a href="#work">Work</a><a href="#last-resort">Safety Plan</a></nav></header>
+  <header class="toolbar" aria-label="Top toolbar"><div class="brand-mini"><img src="https://www.darenprince.com/app%20icons/op-phoenix-icon.png" alt="Phoenix icon" /><span>Operation Phoenix</span></div><button class="menu-btn" id="menuToggle" type="button" aria-expanded="false" aria-controls="anchorMenu" aria-label="Open section menu"><iconify-icon icon="tabler:menu-2" aria-hidden="true"></iconify-icon></button><nav class="menu-panel hidden" id="anchorMenu" aria-label="Anchor menu"><a href="#hotlines">Hotlines</a><a href="#shelter">Shelter</a><a href="#food">Food</a><a href="#wifi">Wi‑Fi / Charge</a><a href="#medical">Medical</a><a href="#benefits">Benefits</a><a href="#work">Work</a><a href="#last-resort">Safety Plan</a></nav></header>
   <main class="container" id="home">
     <header class="hero">
       <div class="hero-top">
@@ -185,12 +185,12 @@
     </header>
 
     <section class="quick-actions" aria-label="Emergency quick actions">
-      <div class="tooltip-wrap"><a class="btn hot call-main" href="tel:911"><iconify-icon icon="solar:shield-warning-bold" aria-hidden="true"></iconify-icon>Call 911</a><button type="button" class="info-tip" aria-label="Why call 911" data-tip="Use 911 for active danger, violence, serious injury, or fire emergencies."><iconify-icon icon="solar:info-circle-bold"></iconify-icon></button><span class="tooltip-text">Use 911 for active danger, violence, serious injury, or fire emergencies.</span></div>
-      <div class="tooltip-wrap"><a class="btn hot call-main" href="tel:988"><iconify-icon icon="solar:heart-angle-bold" aria-hidden="true"></iconify-icon>Call 988</a><button type="button" class="info-tip" aria-label="Why call 988" data-tip="Use 988 for panic, emotional crisis, or suicidal thoughts."><iconify-icon icon="solar:info-circle-bold"></iconify-icon></button><span class="tooltip-text">Use 988 for panic, emotional crisis, or suicidal thoughts.</span></div>
-      <div class="tooltip-wrap"><a class="btn hot call-main" href="tel:211"><iconify-icon icon="solar:call-chat-rounded-bold" aria-hidden="true"></iconify-icon>Call 211</a><button type="button" class="info-tip" aria-label="Why call 211" data-tip="Use 211 for shelter, food, and local aid coordination."><iconify-icon icon="solar:info-circle-bold"></iconify-icon></button><span class="tooltip-text">Use 211 for shelter, food, and local aid coordination.</span></div>
-      <a class="btn" href="#shelter"><iconify-icon icon="solar:home-2-bold"></iconify-icon>Shelter Now</a>
-      <a class="btn" href="#food"><iconify-icon icon="solar:plate-bold"></iconify-icon>Food Today</a>
-      <a class="btn" href="#wifi"><iconify-icon icon="solar:wifi-router-bold"></iconify-icon>Wi-Fi / Charge</a>
+      <div class="tooltip-wrap"><a class="btn hot call-main" href="tel:911"><iconify-icon icon="tabler:alert-triangle-filled" aria-hidden="true"></iconify-icon>Call 911</a><button type="button" class="info-tip" aria-label="Why call 911" data-tip="Use 911 for active danger, violence, serious injury, or fire emergencies."><iconify-icon icon="tabler:info-circle"></iconify-icon></button><span class="tooltip-text">Use 911 for active danger, violence, serious injury, or fire emergencies.</span></div>
+      <div class="tooltip-wrap"><a class="btn hot call-main" href="tel:988"><iconify-icon icon="tabler:heart-handshake" aria-hidden="true"></iconify-icon>Call 988</a><button type="button" class="info-tip" aria-label="Why call 988" data-tip="Use 988 for panic, emotional crisis, or suicidal thoughts."><iconify-icon icon="tabler:info-circle"></iconify-icon></button><span class="tooltip-text">Use 988 for panic, emotional crisis, or suicidal thoughts.</span></div>
+      <div class="tooltip-wrap"><a class="btn hot call-main" href="tel:211"><iconify-icon icon="tabler:phone-call" aria-hidden="true"></iconify-icon>Call 211</a><button type="button" class="info-tip" aria-label="Why call 211" data-tip="Use 211 for shelter, food, and local aid coordination."><iconify-icon icon="tabler:info-circle"></iconify-icon></button><span class="tooltip-text">Use 211 for shelter, food, and local aid coordination.</span></div>
+      <a class="btn" href="#shelter"><iconify-icon icon="tabler:building-community"></iconify-icon>Shelter Now</a>
+      <a class="btn" href="#food"><iconify-icon icon="tabler:bowl-spoon"></iconify-icon>Food Today</a>
+      <a class="btn" href="#wifi"><iconify-icon icon="tabler:wifi"></iconify-icon>Wi-Fi / Charge</a>
     </section>
 
     <div class="search-wrap">
@@ -202,7 +202,7 @@
       <a class="btn chip" href="#emergency" data-filter="Emergency">Emergency</a><a class="btn chip" href="#shelter" data-filter="Shelter">Shelter</a><a class="btn chip" href="#food" data-filter="Food">Food</a>
       <a class="btn chip" href="#wifi" data-filter="Wi-Fi">Wi-Fi</a><a class="btn chip" href="#charging" data-filter="Charging">Charging</a><a class="btn chip" href="#safe-indoors" data-filter="Safe Indoors">Safe Indoors</a>
       <a class="btn chip" href="#benefits" data-filter="Benefits">Benefits</a><a class="btn chip" href="#medical" data-filter="Medical">Medical</a><a class="btn chip" href="#work" data-filter="Work">Work</a>
-      <a class="btn chip" href="#hotlines" data-filter="Hotlines">Hotlines</a><a class="btn chip" href="#last-resort" data-filter="Last Resort">Last Resort</a><button class="btn" id="showAll" type="button"><iconify-icon icon="solar:widget-bold"></iconify-icon>Show All</button>
+      <a class="btn chip" href="#hotlines" data-filter="Hotlines">Hotlines</a><a class="btn chip" href="#last-resort" data-filter="Last Resort">Last Resort</a><button class="btn" id="showAll" type="button"><iconify-icon icon="tabler:layout-grid"></iconify-icon>Show All</button>
     </nav>
 
     <section id="hotlines"><h2 class="section-title">Emergency Hotlines</h2><div class="cards" id="emergency"></div></section>
@@ -236,10 +236,10 @@
     </footer>
   </main>
 
-  <button id="backToTop" aria-label="Back to top"><iconify-icon icon="solar:arrow-up-bold"></iconify-icon></button>
+  <button id="backToTop" aria-label="Back to top"><iconify-icon icon="tabler:arrow-up"></iconify-icon></button>
   <div class="toast-region" id="toastRegion" aria-live="polite" aria-atomic="true"></div>
   <nav class="bottom-nav" aria-label="Sticky navigation">
-    <a href="#home"><iconify-icon icon="solar:home-bold"></iconify-icon>&nbsp;Home</a><a href="#shelter"><iconify-icon icon="solar:home-2-bold"></iconify-icon>&nbsp;Shelter</a><a href="#food"><iconify-icon icon="solar:plate-bold"></iconify-icon>&nbsp;Food</a><a href="#wifi"><iconify-icon icon="solar:wifi-router-bold"></iconify-icon>&nbsp;Wi-Fi</a><a href="#hotlines"><iconify-icon icon="solar:phone-calling-rounded-bold"></iconify-icon>&nbsp;Hotlines</a>
+    <a href="#home"><iconify-icon icon="tabler:home"></iconify-icon>&nbsp;Home</a><a href="#shelter"><iconify-icon icon="tabler:building-community"></iconify-icon>&nbsp;Shelter</a><a href="#food"><iconify-icon icon="tabler:bowl-spoon"></iconify-icon>&nbsp;Food</a><a href="#wifi"><iconify-icon icon="tabler:wifi"></iconify-icon>&nbsp;Wi-Fi</a><a href="#hotlines"><iconify-icon icon="tabler:phone-call"></iconify-icon>&nbsp;Hotlines</a>
   </nav>
 
   <script>
@@ -278,10 +278,10 @@
 
     
     const categoryMeta = {
-      Emergency:{icon:'solar:danger-bold',color:'#f85165'}, Hotlines:{icon:'solar:phone-calling-rounded-bold',color:'#ff9463'}, Shelter:{icon:'solar:home-2-bold',color:'#68a7ff'}, Food:{icon:'solar:plate-bold',color:'#f7c95b'}, 'Wi-Fi':{icon:'solar:wifi-router-bold',color:'#58d8d1'}, Charging:{icon:'solar:bolt-bold',color:'#f8e16f'}, 'Safe Indoors':{icon:'solar:shield-check-bold',color:'#6ecf9d'}, Medical:{icon:'solar:stethoscope-bold',color:'#8cb5ff'}, Benefits:{icon:'solar:document-text-bold',color:'#c798ff'}, Work:{icon:'solar:case-bold',color:'#ffd38a'}
+      Emergency:{icon:'tabler:alert-triangle-filled',color:'#f85165'}, Hotlines:{icon:'tabler:phone-call',color:'#ff9463'}, Shelter:{icon:'tabler:building-community',color:'#68a7ff'}, Food:{icon:'tabler:bowl-spoon',color:'#f7c95b'}, 'Wi-Fi':{icon:'tabler:wifi',color:'#58d8d1'}, Charging:{icon:'tabler:bolt',color:'#f8e16f'}, 'Safe Indoors':{icon:'tabler:shield-check',color:'#6ecf9d'}, Medical:{icon:'tabler:stethoscope',color:'#8cb5ff'}, Benefits:{icon:'tabler:file-text',color:'#c798ff'}, Work:{icon:'tabler:briefcase',color:'#ffd38a'}
     };
     const tagMeta = {
-      urgent:['solar:danger-bold','#f85165'], police:['solar:shield-bold','#88b4ff'], fire:['solar:fire-bold','#ff9e64'], ambulance:['solar:health-bold','#87d89a'], mental:['solar:psychology-bold','#c798ff'], crisis:['solar:siren-bold','#f58f8f'], shelter:['solar:home-2-bold','#68a7ff'], food:['solar:plate-bold','#f7c95b'], wifi:['solar:wifi-router-bold','#58d8d1'], charging:['solar:bolt-bold','#f8e16f'], benefits:['solar:document-text-bold','#c798ff'], housing:['solar:city-bold','#84a8ff'], work:['solar:case-bold','#ffd38a']
+      urgent:['tabler:alert-triangle-filled','#f85165'], police:['tabler:shield','#88b4ff'], fire:['tabler:flame','#ff9e64'], ambulance:['tabler:ambulance','#87d89a'], mental:['tabler:brain','#c798ff'], crisis:['tabler:alarm','#f58f8f'], shelter:['tabler:building-community','#68a7ff'], food:['tabler:bowl-spoon','#f7c95b'], wifi:['tabler:wifi','#58d8d1'], charging:['tabler:bolt','#f8e16f'], benefits:['tabler:file-text','#c798ff'], housing:['tabler:building-skyscraper','#84a8ff'], work:['tabler:briefcase','#ffd38a']
     };
     const toastRegion = document.getElementById('toastRegion');
     function showToast(message, variant='success'){ const toast=document.createElement('div'); toast.className=`toast ${variant}`; toast.textContent=message; toastRegion.appendChild(toast); setTimeout(()=>{toast.remove();},2800);}
@@ -319,7 +319,7 @@
         const callDisabled = phone === 'N/A' || phone.toLowerCase().includes('local') || phone.toLowerCase().includes('search') || phone.toLowerCase().includes('contact');
 
         const label = document.createElement('span'); label.className='label';
-        const metaCat = categoryMeta[category] || {icon:'solar:hashtag-bold', color:'#9aa6b2'};
+        const metaCat = categoryMeta[category] || {icon:'tabler:hash', color:'#9aa6b2'};
         label.style.background = `${metaCat.color}22`; label.style.color = metaCat.color;
         withIconText(label, metaCat.icon, category);
         const h3 = document.createElement('h3'); h3.className='name'; h3.textContent = name;
@@ -330,12 +330,12 @@
         const notesP = document.createElement('p'); notesP.className='notes'; notesP.textContent = notes;
 
         const tagsWrap = document.createElement('div'); tagsWrap.className='tags';
-        (tags||[]).forEach(t => { const el = document.createElement('span'); el.className='tag'; const key=(t||'').toLowerCase(); const tm=tagMeta[key] || ['solar:hashtag-bold','#94a3b8']; el.style.background = `${tm[1]}22`; el.style.color = tm[1]; withIconText(el, tm[0], `#${t}`); tagsWrap.appendChild(el); });
+        (tags||[]).forEach(t => { const el = document.createElement('span'); el.className='tag'; const key=(t||'').toLowerCase(); const tm=tagMeta[key] || ['tabler:hash','#94a3b8']; el.style.background = `${tm[1]}22`; el.style.color = tm[1]; withIconText(el, tm[0], `#${t}`); tagsWrap.appendChild(el); });
 
         const actions = document.createElement('div'); actions.className='actions';
-        const call = document.createElement('a'); call.className = `btn ${callDisabled ? 'hidden' : 'hot'}`; withIconText(call, 'solar:phone-calling-rounded-bold', 'Call'); call.setAttribute('aria-label', `Call ${name}`); if (!callDisabled) call.href = telHref(phone);
-        const map = document.createElement('a'); map.className='btn gold'; map.href = mapHref(address); map.target='_blank'; map.rel='noopener'; withIconText(map, 'solar:map-point-bold', 'Map');
-        const copy = document.createElement('button'); copy.className='btn copy-btn'; copy.type='button'; copy.dataset.address = address; copy.setAttribute('aria-label', `Copy address for ${name}`); withIconText(copy, 'solar:copy-bold', 'Copy');
+        const call = document.createElement('a'); call.className = `btn ${callDisabled ? 'hidden' : 'hot'}`; withIconText(call, 'tabler:phone-call', 'Call'); call.setAttribute('aria-label', `Call ${name}`); if (!callDisabled) call.href = telHref(phone);
+        const map = document.createElement('a'); map.className='btn gold'; map.href = mapHref(address); map.target='_blank'; map.rel='noopener'; withIconText(map, 'tabler:map-pin', 'Map');
+        const copy = document.createElement('button'); copy.className='btn copy-btn'; copy.type='button'; copy.dataset.address = address; copy.setAttribute('aria-label', `Copy address for ${name}`); withIconText(copy, 'tabler:copy', 'Copy');
         actions.append(call, map, copy);
 
         card.append(label, h3, meta, notesP);
@@ -359,7 +359,7 @@
 
     document.getElementById('search').addEventListener('input', applyFilters);
     document.querySelectorAll('.chip[data-filter]').forEach(chip => {
-      const cfg = categoryMeta[chip.dataset.filter] || {icon:'solar:hashtag-bold'};
+      const cfg = categoryMeta[chip.dataset.filter] || {icon:'tabler:hash'};
       const chipIcon = document.createElement('iconify-icon');
       chipIcon.setAttribute('icon', cfg.icon);
       chipIcon.setAttribute('aria-hidden', 'true');
@@ -382,11 +382,11 @@
       try {
         await navigator.clipboard.writeText(btn.dataset.address);
         const prev = btn.textContent;
-        withIconText(btn, 'solar:check-circle-bold', 'Copied');
+        withIconText(btn, 'tabler:circle-check', 'Copied');
         showToast('Address copied to clipboard.');
         setTimeout(() => btn.textContent = prev, 1200);
       } catch {
-        withIconText(btn, 'solar:copy-bold', 'Hold to Copy');
+        withIconText(btn, 'tabler:copy', 'Hold to Copy');
         showToast('Copy failed — long-press to copy manually.', 'info');
       }
     });


### PR DESCRIPTION
### Motivation
- Unify the page iconography to the Tabler Icon set so runtime-generated UI and static markup use a single consistent icon family.
- Subtly darken the page surface and introduce a layered gradient to reduce visual harshness and match the site’s quiet-luxury aesthetic.
- Make the top toolbar/tool button coloring match the Daren Prince author-site header tone for brand consistency.

### Description
- Replaced all `solar:` Iconify references with `tabler:` equivalents in the static HTML toolbar, quick-action buttons, bottom nav, and `Show All` control. 
- Updated JS mappings so `categoryMeta`, `tagMeta`, generated card actions, chip icons, tag icons, and copy-state icons render Tabler icons end-to-end (e.g. `tabler:phone-call`, `tabler:map-pin`, `tabler:circle-check`).
- Darkened theme tokens and background by adjusting `--bg`, `--bg-soft`, `--canvas` and swapping the page `background` to a subtle radial + linear gradient.
- Polished the header visuals by updating `.toolbar` and `.menu-btn` to a deeper charcoal gradient and semi-transparent menu button to match the primary site header treatment.

### Testing
- Searched the modified file for leftover Solar icon tokens with `rg -n "solar:" phoenix.html` and confirmed there are no remaining `solar:` references (passed).
- Reviewed the file diff for `phoenix.html` to ensure only intended icon mappings and styling changes were applied (diff inspected and matched expectations).
- Verified Tabler icon tokens appear in both static markup and JS-generated UI by grepping for `tabler:` in `phoenix.html` (presence confirmed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b9d734a08325a3425f80c8861add)