### PR TITLE
Create canonical /labs/ landing page and integrate Crown Labs docs

### DIFF
--- a/assets/labs-data.json
+++ b/assets/labs-data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-01T03:49:12.299Z",
+  "generatedAt": "2026-06-01T04:28:12.394Z",
   "generatedFrom": "docs/crownlabsbible/",
   "authority": "Crown Labs product truth is governed by docs/crownlabsbible/. Do not hand-edit product definitions here.",
   "productCount": 8,

--- a/assets/labs.css
+++ b/assets/labs.css
@@ -285,3 +285,265 @@ select {
   color: var(--muted);
   border-bottom-color: rgba(157, 168, 187, 0.35);
 }
+
+.labs-landing {
+  background:
+    radial-gradient(circle at 20% 0%, rgba(108, 134, 255, 0.12), transparent 34rem),
+    linear-gradient(180deg, #070b14 0%, #0b0f17 38%, #0a0d13 100%);
+}
+.labs-landing main {
+  overflow: hidden;
+}
+.landing-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
+  gap: 28px;
+  align-items: end;
+  padding: 72px 0 42px;
+  border-bottom: 1px solid var(--line);
+}
+.landing-hero h1,
+.definition-band h2,
+.split-section h2,
+.product-overview h2,
+.founder-section h2 {
+  letter-spacing: -0.045em;
+}
+.landing-hero h1 {
+  max-width: 13.6ch;
+  font-size: clamp(2.3rem, 6.4vw, 5rem);
+  line-height: 0.98;
+}
+.hero-copy .intro {
+  max-width: 62ch;
+}
+.hero-actions,
+.section-actions,
+.founder-links,
+.doc-funnel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+.primary-link,
+.secondary-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 46px;
+  border: 1px solid rgba(233, 245, 255, 0.26);
+  padding: 12px 16px;
+  color: #f7fbff;
+  text-decoration: none;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  background: rgba(233, 245, 255, 0.08);
+}
+.primary-link {
+  background: #e7edf6;
+  color: #08101b;
+  border-color: #e7edf6;
+}
+.primary-link:hover,
+.primary-link:focus-visible,
+.secondary-link:hover,
+.secondary-link:focus-visible {
+  transform: translateY(-1px);
+}
+.secondary-link {
+  color: #dce7f7;
+  background: rgba(255, 255, 255, 0.02);
+}
+.primary-link.compact,
+.secondary-link.compact {
+  min-height: 40px;
+  padding: 10px 13px;
+  font-size: 0.92rem;
+}
+.hero-panel,
+.founder-card,
+.doc-funnel,
+.principle-grid article,
+.featured-product-card {
+  border: 1px solid rgba(157, 168, 187, 0.22);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.018));
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.18);
+}
+.hero-panel {
+  padding: 24px;
+}
+.panel-kicker {
+  display: block;
+  color: #c7d3e6;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-bottom: 14px;
+}
+.hero-panel h2,
+.doc-funnel h3,
+.featured-product-card h3 {
+  margin: 0 0 10px;
+  letter-spacing: -0.035em;
+}
+.hero-panel p,
+.definition-band p,
+.split-section p,
+.section-note,
+.founder-card p,
+.doc-funnel p,
+.featured-product-card p {
+  color: #bdc8d8;
+  line-height: 1.65;
+}
+.definition-band,
+.split-section,
+.product-overview,
+.founder-section {
+  padding: 46px 0;
+  border-bottom: 1px solid var(--line);
+}
+.definition-band,
+.split-section,
+.founder-section {
+  display: grid;
+  grid-template-columns: minmax(240px, 0.7fr) minmax(0, 1.3fr);
+  gap: 28px;
+}
+.definition-band h2,
+.split-section h2,
+.product-overview h2,
+.founder-section h2 {
+  margin: 0;
+  font-size: clamp(1.65rem, 3vw, 2.65rem);
+  line-height: 1.08;
+}
+.split-section {
+  align-items: start;
+}
+.section-copy p {
+  max-width: 66ch;
+}
+.principle-grid {
+  display: grid;
+  gap: 12px;
+}
+.principle-grid article {
+  padding: 18px;
+}
+.principle-grid span {
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+}
+.principle-grid h3 {
+  margin: 8px 0;
+  font-size: 1rem;
+}
+.principle-grid p {
+  margin: 0;
+}
+.section-heading-row {
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+  align-items: end;
+}
+.section-note {
+  max-width: 78ch;
+  margin-bottom: 20px;
+}
+.featured-products {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+.featured-product-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  padding: 18px;
+}
+.featured-product-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: flex-start;
+}
+.featured-product-card h3 {
+  margin-top: 18px;
+  font-size: 1.18rem;
+}
+.featured-product-card p:last-of-type {
+  flex: 1;
+}
+.readiness-chip {
+  color: #08101b;
+  background: #d7e0ef;
+  font-size: 0.78rem;
+  font-weight: 800;
+  padding: 5px 8px;
+}
+.founder-section {
+  align-items: stretch;
+  border-bottom: 0;
+}
+.founder-card,
+.doc-funnel {
+  padding: 24px;
+}
+.doc-funnel {
+  flex-direction: column;
+  align-items: flex-start;
+}
+.doc-funnel .primary-link,
+.doc-funnel .secondary-link {
+  width: fit-content;
+}
+@media (max-width: 1080px) {
+  .featured-products {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (max-width: 860px) {
+  .landing-hero,
+  .definition-band,
+  .split-section,
+  .founder-section {
+    grid-template-columns: 1fr;
+  }
+  .landing-hero {
+    padding-top: 42px;
+  }
+  .landing-hero h1 {
+    max-width: none;
+    font-size: clamp(2.15rem, 12vw, 3.6rem);
+  }
+  .section-heading-row {
+    display: block;
+  }
+}
+@media (max-width: 620px) {
+  .shell {
+    width: min(100% - 28px, 1120px);
+  }
+  .header-inner {
+    min-height: 64px;
+  }
+  .brand span {
+    display: none;
+  }
+  .featured-products {
+    grid-template-columns: 1fr;
+  }
+  .hero-actions a,
+  .section-actions a,
+  .doc-funnel a {
+    width: 100%;
+  }
+  .card-head,
+  .featured-product-top {
+    flex-direction: column;
+  }
+}

--- a/assets/labs.js
+++ b/assets/labs.js
@@ -1,4 +1,7 @@
 ;(() => {
+  const currentScript = document.currentScript
+  const dataUrl = currentScript?.dataset?.labsData || 'assets/labs-data.json'
+
   const createElement = (tag, className, text) => {
     const node = document.createElement(tag)
     if (className) node.className = className
@@ -66,17 +69,80 @@
     return article
   }
 
-  const initPortfolio = async () => {
+  const compactProductTemplate = (product) => {
+    const article = createElement('article', 'featured-product-card')
+    article.dataset.id = product.id
+
+    const top = createElement('div', 'featured-product-top')
+    top.append(createElement('span', 'badge', product.status || 'Documented'))
+    top.append(
+      createElement('span', 'readiness-chip', product.readiness ? `${product.readiness}%` : 'Docs')
+    )
+
+    article.append(top)
+    article.append(createElement('h3', null, product.name || product.id))
+    article.append(
+      createElement(
+        'p',
+        'subtitle',
+        product.categoryLabel || product.category || 'Crown Labs system'
+      )
+    )
+    article.append(createElement('p', null, product.oneLiner || product.tagline || ''))
+
+    const actions = createElement('div', 'card-actions')
+    const brief = createElement('a', 'text-link', 'Brief')
+    brief.href = product.detailUrl?.replace(/^labs\//, '') || `products/${product.id}.html`
+    const docs = createElement('a', 'text-link muted', 'Docs')
+    docs.href = product.sourcePath ? `../${product.sourcePath}` : '../docs/crownlabsbible/'
+    actions.append(brief, docs)
+    article.append(actions)
+
+    return article
+  }
+
+  const updateMetrics = (items) => {
+    const total = document.getElementById('total-products')
+    const beta = document.getElementById('active-beta')
+    const avg = document.getElementById('avg-readiness')
+    if (!total || !beta || !avg) return
+    total.textContent = String(items.length)
+    beta.textContent = String(
+      items.filter((item) => /beta|active|functional/i.test(item.status || '')).length
+    )
+    const readiness = items
+      .map((item) => Number(item.readiness || 0))
+      .filter((value) => Number.isFinite(value))
+    const avgValue = readiness.length
+      ? Math.round(readiness.reduce((sum, value) => sum + value, 0) / readiness.length)
+      : 0
+    avg.textContent = `${avgValue}%`
+  }
+
+  const loadProducts = async () => {
+    const response = await fetch(dataUrl)
+    const payload = await response.json()
+    return (payload.products || []).sort((a, b) => (b.priority || 0) - (a.priority || 0))
+  }
+
+  const initFeaturedProducts = async (products) => {
+    const grid = document.getElementById('featured-products')
+    const empty = document.getElementById('empty-state')
+    if (!grid) return false
+
+    grid.replaceChildren(...products.map(compactProductTemplate))
+    if (empty) empty.hidden = products.length > 0
+    updateMetrics(products)
+    return true
+  }
+
+  const initPortfolio = async (products) => {
     const grid = document.getElementById('portfolio')
     const empty = document.getElementById('empty-state')
     const search = document.getElementById('search')
     const statusFilter = document.getElementById('status-filter')
     const categoryFilter = document.getElementById('category-filter')
-    if (!grid || !search || !statusFilter || !categoryFilter || !empty) return
-
-    const response = await fetch('assets/labs-data.json')
-    const payload = await response.json()
-    const products = (payload.products || []).sort((a, b) => (b.priority || 0) - (a.priority || 0))
+    if (!grid || !search || !statusFilter || !categoryFilter || !empty) return false
 
     const statuses = [...new Set(products.map((item) => item.status).filter(Boolean))]
     const categories = [...new Set(products.map((item) => item.category).filter(Boolean))]
@@ -94,24 +160,6 @@
       option.textContent = category
       categoryFilter.append(option)
     })
-
-    const updateMetrics = (items) => {
-      const total = document.getElementById('total-products')
-      const beta = document.getElementById('active-beta')
-      const avg = document.getElementById('avg-readiness')
-      if (!total || !beta || !avg) return
-      total.textContent = String(items.length)
-      beta.textContent = String(
-        items.filter((item) => /beta|active|functional/i.test(item.status || '')).length
-      )
-      const readiness = items
-        .map((item) => Number(item.readiness || 0))
-        .filter((value) => Number.isFinite(value))
-      const avgValue = readiness.length
-        ? Math.round(readiness.reduce((sum, value) => sum + value, 0) / readiness.length)
-        : 0
-      avg.textContent = `${avgValue}%`
-    }
 
     const render = () => {
       const term = search.value.trim().toLowerCase()
@@ -142,11 +190,21 @@
     statusFilter.addEventListener('change', render)
     categoryFilter.addEventListener('change', render)
     render()
+    return true
+  }
+
+  const initProducts = async () => {
+    const products = await loadProducts()
+    const didRenderFeatured = await initFeaturedProducts(products)
+    const didRenderPortfolio = await initPortfolio(products)
+    if (!didRenderFeatured && !didRenderPortfolio) updateMetrics(products)
   }
 
   setYear()
   drawScrollProgress()
-  initPortfolio().catch((error) => {
-    console.error('Failed to initialize portfolio', error)
+  initProducts().catch((error) => {
+    console.error('Failed to initialize Crown Labs products', error)
+    const empty = document.getElementById('empty-state')
+    if (empty) empty.hidden = false
   })
 })()

--- a/data/products.json
+++ b/data/products.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-01T03:49:12.299Z",
+  "generatedAt": "2026-06-01T04:28:12.394Z",
   "generatedFrom": "docs/crownlabsbible/",
   "authority": "Crown Labs product truth is governed by docs/crownlabsbible/. Do not hand-edit product definitions here.",
   "productCount": 8,

--- a/docs/BUILD_PIPELINE.md
+++ b/docs/BUILD_PIPELINE.md
@@ -33,7 +33,7 @@ This doc captures how assets are generated locally and served via GitHub Pages. 
 >
 > **Duck Calls reminder:** The `ots.html` command deck ships with inline layout styles and Iconify/Google Fonts links. Keep the page metadata aligned with the latest Duck Calls copy and rerun `npm run deploy` so GitHub Pages serves refreshed SEO output.
 >
-> **Crown Labs reminder:** `labs.html` and generated `labs/products/*.html` are now aligned to the Daren-Labs portfolio model. Keep Labs-specific social assets (`labs/assets/labs-opengraph.svg`) and favicon (`labs/assets/labs-favicon.svg`) committed, and regenerate product pages with `node scripts/generate-labs-product-pages.mjs` whenever `assets/labs-data.json` changes.
+> **Crown Labs reminder:** `/labs/` and generated `labs/products/*.html` are aligned to the Daren-Labs portfolio model, with `labs.html` retained as a redirect. Keep Labs-specific social assets (`labs/assets/labs-opengraph.svg`) and favicon (`labs/assets/labs-favicon.svg`) committed, and regenerate product pages with `node scripts/generate-labs-product-pages.mjs` whenever `assets/labs-data.json` changes.
 >
 > **Books surfaces reminder:** `book.html` now includes coming-soon CTA states (with notify modal triggers) and in-page anchor navigation. After touching Book UI or Game On landing styles, run `npm run build:site` so `assets/styles.css` is GitHub Pages-ready and the latest metadata + sharing assets remain deployable.
 
@@ -65,7 +65,7 @@ This doc captures how assets are generated locally and served via GitHub Pages. 
 ### Stylesheet ownership matrix
 
 - `assets/styles.css`: Global marketing site + shared page shell (source: `scss/styles.scss`).
-- `assets/labs.css`: Crown Labs landing page only (`labs.html`).
+- `assets/labs.css`: Crown Labs landing page and legacy redirect support (`/labs/`, with `labs.html` redirecting to it).
 - `assets/labs-product.css`: Generated product brief pages in `labs/products/`.
 - `emergency-911/dist/911.css`: Emergency 911 app surface only.
 - `nexuswho-assets/nexuswho.css`: React/Vite output for `nexuswho.html` only.
@@ -113,9 +113,9 @@ If a visual change appears to be ignored, verify you edited the stylesheet owned
 - [ ] Run `npm run lint:metadata` and resolve any missing/invalid favicon, OG/Twitter image, or `theme-color` references.
 - [ ] Confirm `ots.html` metadata (title, description, canonical + og:url) matches the current Duck Calls positioning before deploying.
 - [ ] Confirm `src/nexuswho/index.html` metadata (title, description, canonical + og:url) reflects the current Vibe Prism positioning before pushing.
-- [ ] Confirm `index.html` is the primary author homepage (no redirect), and `labs/index.html` still redirects cleanly to `labs.html`.
+- [ ] Confirm `index.html` is the primary author homepage (no redirect), `/labs/` is the canonical Crown Labs landing page, and `labs.html` redirects cleanly to `/labs/`.
 - [ ] Confirm homepage nav behavior: header toolbar share button works, mega-menu theme toggle works, and the first paint defaults to dark mode.
-- [ ] Confirm `labs.html` keeps brand-green browser chrome (`theme-color`, pinned-tab color, favicon links) and valid OG/Twitter social image URLs.
+- [ ] Confirm `/labs/` and the `labs.html` redirect keep Crown Labs browser chrome (`theme-color`, favicon links) and valid OG/Twitter social image URLs.
 - [ ] Verify `nexuswho.html` loads and that the latest `nexuswho-assets/*` chunks (vendor, scanner, charts, etc.) are committed for GitHub Pages.
 - [ ] Confirm `/nexuswho/` redirects to `nexuswho.html` and the fallback copy is visible if the bundle fails to load.
 - [ ] Commit generated artifacts (`assets/styles.css`, `assets/image-manifest.json`, `public/search/*.json`).

--- a/docs/LABS_PAGE_SYSTEM.md
+++ b/docs/LABS_PAGE_SYSTEM.md
@@ -1,30 +1,46 @@
-# Labs Page System (labs.html)
+# Labs Page System (`/labs/`)
 
 ## Canonical Route
 
-- `labs.html` is the public-facing Crown Labs portfolio page.
-- `labs/index.html` remains a redirect-only entrypoint to preserve canonical routing.
+- `/labs/` (`labs/index.html`) is the canonical public-facing Crown Labs landing page.
+- `labs.html` is a legacy compatibility redirect to `/labs/` and should not regain a separate shell or competing content model.
+- Generated product brief pages live under `labs/products/*.html` and link back to `/labs/#products`.
+
+## Public Landing Purpose
+
+The landing page is a discovery layer for visitors who need a high-level introduction before entering the documentation system. It must:
+
+- explain Crown Labs as the institutional product portfolio and systems lab;
+- explain CrownCode.ai as the reusable intelligence and engineering layer beneath Crown Labs;
+- display products from generated metadata only;
+- introduce founder context for Daren Prince;
+- funnel deeper exploration toward `/docs/` and `/docs/crownlabsbible/`.
+
+The page must not duplicate product dossiers, architecture, roadmap, valuation, or governance documentation. Those subjects remain owned by `docs/crownlabsbible/` and its generated documentation app.
 
 ## Rendering Rules
 
 - Product cards are rendered from `assets/labs-data.json` through `assets/labs.js`.
-- Filtering is state-driven through explicit search, status, and category controls.
-- Documentation narrative sections are statically authored from canonical `crowndocs/content/*.md` source text.
-- No unsafe `innerHTML` mutation from user input; only curated dataset fields are rendered.
+- The landing page passes `data-labs-data="../assets/labs-data.json"` so the shared renderer resolves data correctly from `/labs/`.
+- Product rendering uses explicit DOM creation and `textContent`; do not inject raw HTML or regex-rewrite rendered markup.
+- Public cards are summaries only. Brief and source links must point visitors into generated product pages or canonical documentation.
 
 ## Architecture Decisions
 
-- The page uses an institutional shell pattern and keeps a direct "Documentation Source" section that mirrors the Crown Docs master index purpose and integration model.
-- Product portfolio controls remain data-driven to preserve operational filtering and readiness metrics.
-- Header navigation now aligns the page with foundation, portfolio, and docs-sync anchors plus the documentation hub route.
+- `/labs/` is now a clean, public, marketing-safe route while `labs.html` remains only for backward compatibility.
+- The design follows a quiet luxury infrastructure UI: restrained contrast, measured spacing, square geometry, and documentation-forward hierarchy.
+- CrownCode.ai receives a high-level platform explanation on the landing page, but its authoritative source remains `docs/crownlabsbible/02-products/crowncode-ai.md`.
+- Product inventory remains generated from the Crown Labs Bible by `npm run build:labs`.
 
 ## Canonical Documentation Sources For This Page
 
-- `crowndocs/content/index.md`
-- `crowndocs/content/corporate-infrastructure/index.md`
-- `crowndocs/content/product-dossiers/index.md`
+- `docs/crownlabsbible/README.md`
+- `docs/crownlabsbible/02-products/crowncode-ai.md`
+- `assets/labs-data.json` generated from `docs/crownlabsbible/`
+- `meet-daren-prince.html` for public founder biography context
 
 ## Deprecated System Notes
 
-- Legacy hero copy that was not mapped to documented source text was replaced.
-- `labs.html` is now explicitly documented as a docs-synchronized surface instead of a standalone marketing layout.
+- The former `labs/index.html` redirect-only entrypoint is deprecated.
+- `labs.html` is deprecated as a content route and retained only as a redirect with valid metadata for existing links and deployment checks.
+- Do not reintroduce a second hand-maintained Crown Labs product inventory outside the generated metadata pipeline.

--- a/labs.html
+++ b/labs.html
@@ -2,159 +2,52 @@
 <html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0; url=labs/" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>Crown Labs | Institutional Product Portfolio</title>
+    <title>Crown Labs | Public Systems Landing Page</title>
     <meta
       name="description"
-      content="Institutional Crown Labs portfolio built directly from canonical Crown Docs content: governance, product dossiers, and operational intelligence."
+      content="Crown Labs has moved to the clean /labs/ public landing page for Crown Labs, CrownCode.ai, products, founder information, and documentation links."
     />
     <meta name="theme-color" content="#070b14" />
     <meta name="robots" content="index,follow,max-image-preview:large" />
-    <link rel="canonical" href="https://www.darenprince.com/labs.html" />
-
+    <link rel="canonical" href="https://www.darenprince.com/labs/" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Crown Labs | Institutional Product Portfolio" />
+    <meta property="og:title" content="Crown Labs | Public Systems Landing Page" />
     <meta
       property="og:description"
-      content="Canonical portfolio intelligence across Crown Labs product and documentation systems."
+      content="Explore Crown Labs, CrownCode.ai, products, founder information, and documentation entry points."
     />
-    <meta property="og:url" content="https://www.darenprince.com/labs.html" />
+    <meta property="og:url" content="https://www.darenprince.com/labs/" />
     <meta
       property="og:image"
       content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
     />
     <meta property="og:image:alt" content="Crown Labs portfolio dashboard" />
-
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Crown Labs | Institutional Product Portfolio" />
+    <meta name="twitter:title" content="Crown Labs | Public Systems Landing Page" />
     <meta
       name="twitter:description"
-      content="Product portfolio, readiness intelligence, and investor-aligned summaries sourced from canonical docs."
+      content="Explore Crown Labs, CrownCode.ai, products, founder information, and documentation entry points."
     />
     <meta
       name="twitter:image"
       content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
     />
-
     <link rel="icon" type="image/svg+xml" href="labs/assets/labs-favicon.svg" />
     <link rel="apple-touch-icon" href="labs/assets/labs-favicon.svg" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
-      rel="stylesheet"
-    />
-    <link rel="stylesheet" href="assets/labs.css" />
+    <script>
+      window.location.replace('labs/')
+    </script>
   </head>
-  <body id="top">
-    <div class="scroll-progress" aria-hidden="true"></div>
-    <header class="labs-header">
-      <div class="header-inner shell">
-        <a href="#top" class="brand" aria-label="Crown Labs home">
-          <img src="labs/assets/crown-labs-logo.png" alt="Crown Labs" class="logo" />
-          <span>Crown Labs Portfolio Console</span>
-        </a>
-        <nav class="site-menu" aria-label="Site menu">
-          <a href="#foundation">Foundation</a>
-          <a href="#portfolio">Portfolio</a>
-          <a href="#docs-sync">Docs Sync</a>
-          <a href="docs/crownlabsbible/docs/index.html">Docs App</a>
-        </nav>
-      </div>
-    </header>
-
-    <main class="shell">
-      <section class="hero" id="foundation">
-        <p class="eyebrow">Crown Labs • Institutional Systems Division</p>
-        <h1>Canonical Portfolio Surface<br />Synchronized to Crown Docs</h1>
-        <p class="intro">
-          This page now uses Crown Docs as the narrative source of truth for governance, product
-          taxonomy, and operating standards, while preserving data-driven product rendering for
-          filter and readiness workflows.
-        </p>
-      </section>
-
-      <section class="docs-source" id="docs-sync" aria-label="Canonical docs source">
-        <h2>Direct Documentation Source</h2>
-        <p>
-          Source: <code>docs/crownlabsbible/</code>. Product cards, public briefs, and delivery
-          metadata are generated from the Crown Labs Bible.
-        </p>
-        <div class="source-panels">
-          <article>
-            <h3>Purpose</h3>
-            <ul>
-              <li>Master executive dossier</li>
-              <li>Product inventory source of truth</li>
-              <li>Investor documentation system</li>
-              <li>Operational governance reference</li>
-            </ul>
-          </article>
-          <article>
-            <h3>Build Philosophy</h3>
-            <p>
-              The documentation stack is built incrementally so each product and system can preserve
-              formatting integrity, editorial consistency, legal readability, and clean
-              synchronization with the website ecosystem.
-            </p>
-          </article>
-          <article>
-            <h3>Website Integration</h3>
-            <ul>
-              <li>labs.html</li>
-              <li>data/products.json → assets/labs-data.json</li>
-              <li>investor product pages</li>
-              <li>valuation and presentation exports</li>
-            </ul>
-          </article>
-        </div>
-      </section>
-
-      <section class="metrics" aria-label="Executive metrics">
-        <article>
-          <h3>Total Products</h3>
-          <p id="total-products">—</p>
-        </article>
-        <article>
-          <h3>Active Beta</h3>
-          <p id="active-beta">—</p>
-        </article>
-        <article>
-          <h3>Average Readiness</h3>
-          <p id="avg-readiness">—</p>
-        </article>
-      </section>
-
-      <section class="controls" aria-label="Portfolio controls">
-        <div class="control-group">
-          <label for="search">Search products</label>
-          <input id="search" type="search" placeholder="Name, category, keyword" />
-        </div>
-        <div class="control-group">
-          <label for="status-filter">Status</label>
-          <select id="status-filter">
-            <option value="all">All statuses</option>
-          </select>
-        </div>
-        <div class="control-group">
-          <label for="category-filter">Category</label>
-          <select id="category-filter">
-            <option value="all">All categories</option>
-          </select>
-        </div>
-      </section>
-
-      <section id="portfolio" class="portfolio-grid" aria-live="polite"></section>
-      <p id="empty-state" class="empty-state" hidden>No products match this filter set.</p>
-    </main>
-
-    <footer class="footer shell">
+  <body>
+    <main>
+      <h1>Crown Labs has moved</h1>
+      <p>The canonical public landing page is now <a href="labs/">/labs/</a>.</p>
       <p>
-        © <span id="labs-year"></span> Crown Labs • Daren Prince Publishing • Built from canonical
-        documentation architecture.
+        For deeper exploration, open <a href="docs/">/docs/</a> or
+        <a href="docs/crownlabsbible/">/docs/crownlabsbible/</a>.
       </p>
-    </footer>
-
-    <script src="assets/labs.js" defer></script>
+    </main>
   </body>
 </html>

--- a/labs/index.html
+++ b/labs/index.html
@@ -1,16 +1,228 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="refresh" content="0; url=../labs.html" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Crown Labs Redirect</title>
-    <link rel="canonical" href="https://www.darenprince.com/labs.html" />
-    <script>
-      window.location.replace('../labs.html');
-    </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Crown Labs | Public Systems Landing Page</title>
+    <meta
+      name="description"
+      content="Meet Crown Labs and CrownCode.ai, explore the public product portfolio, and continue into the Crown Labs documentation system for deeper research."
+    />
+    <meta name="theme-color" content="#070b14" />
+    <meta name="robots" content="index,follow,max-image-preview:large" />
+    <link rel="canonical" href="https://www.darenprince.com/labs/" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Daren Prince" />
+    <meta property="og:title" content="Crown Labs | Public Systems Landing Page" />
+    <meta
+      property="og:description"
+      content="Crown Labs introduces the product ecosystem. CrownCode.ai is the reusable intelligence and engineering layer beneath it."
+    />
+    <meta property="og:url" content="https://www.darenprince.com/labs/" />
+    <meta
+      property="og:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <meta property="og:image:alt" content="Crown Labs portfolio dashboard" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Crown Labs | Public Systems Landing Page" />
+    <meta
+      name="twitter:description"
+      content="Explore Crown Labs, CrownCode.ai, founder information, products, and documentation entry points."
+    />
+    <meta
+      name="twitter:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+
+    <link rel="icon" type="image/svg+xml" href="assets/labs-favicon.svg" />
+    <link rel="apple-touch-icon" href="assets/labs-favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/labs.css" />
   </head>
-  <body>
-    <p>Redirecting to <a href="../labs.html">labs.html</a>…</p>
+  <body id="top" class="labs-landing">
+    <div class="scroll-progress" aria-hidden="true"></div>
+    <header class="labs-header">
+      <div class="header-inner shell">
+        <a href="#top" class="brand" aria-label="Crown Labs home">
+          <img src="assets/crown-labs-logo.png" alt="Crown Labs" class="logo" />
+          <span>Crown Labs</span>
+        </a>
+        <nav class="site-menu" aria-label="Crown Labs landing navigation">
+          <a href="#crown-labs">Crown Labs</a>
+          <a href="#crowncode">CrownCode.ai</a>
+          <a href="#products">Products</a>
+          <a href="#founder">Founder</a>
+          <a href="../docs/">Docs</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="landing-hero shell" aria-labelledby="labs-title">
+        <div class="hero-copy">
+          <p class="eyebrow">Crown Labs • Public Discovery Layer</p>
+          <h1 id="labs-title">
+            A product ecosystem for applied intelligence, documentation, and resilient digital
+            infrastructure.
+          </h1>
+          <p class="intro">
+            Crown Labs is the public entry point into a documented portfolio of software concepts,
+            product systems, and operating intelligence. This page introduces the ecosystem without
+            replacing the canonical documentation that governs it.
+          </p>
+          <div class="hero-actions" aria-label="Primary documentation links">
+            <a class="primary-link" href="../docs/">Enter documentation</a>
+            <a class="secondary-link" href="../docs/crownlabsbible/">Open Crown Labs Bible</a>
+          </div>
+        </div>
+        <aside class="hero-panel" aria-label="Documentation gateway">
+          <span class="panel-kicker">Docs-first governance</span>
+          <h2>The landing page introduces. The docs explain.</h2>
+          <p>
+            Product details, governance notes, architecture, and deeper exploration live in the
+            documentation tree so public copy does not drift into a competing source of truth.
+          </p>
+          <a class="text-link" href="../docs/crownlabsbible/docs/index.html"
+            >Open docs application</a
+          >
+        </aside>
+      </section>
+
+      <section id="crown-labs" class="definition-band shell" aria-labelledby="crown-labs-title">
+        <div>
+          <p class="eyebrow">What Crown Labs is</p>
+          <h2 id="crown-labs-title">An institutional product portfolio and systems lab.</h2>
+        </div>
+        <p>
+          Crown Labs organizes product research, applied AI workflows, documentation systems,
+          security concepts, behavioral technology, and investor-ready product intelligence under
+          one governed ecosystem. It is designed to make early-stage product work traceable,
+          reviewable, and easier to move from concept to disciplined execution.
+        </p>
+      </section>
+
+      <section id="crowncode" class="split-section shell" aria-labelledby="crowncode-title">
+        <div class="section-copy">
+          <p class="eyebrow">CrownCode.ai</p>
+          <h2 id="crowncode-title">
+            The reusable intelligence and engineering layer beneath Crown Labs.
+          </h2>
+          <p>
+            CrownCode.ai is positioned as the operational substrate behind the portfolio: shared AI
+            workflows, documentation rendering, reporting patterns, metadata systems, behavioral
+            analysis infrastructure, and modular product architecture. It exists to reduce duplicate
+            builds and keep each product aligned to the same standard of governance.
+          </p>
+          <div class="section-actions">
+            <a class="primary-link compact" href="products/crowncode-ai.html"
+              >View CrownCode.ai brief</a
+            >
+            <a
+              class="secondary-link compact"
+              href="../docs/crownlabsbible/02-products/crowncode-ai.md"
+              >Read source dossier</a
+            >
+          </div>
+        </div>
+        <div class="principle-grid" aria-label="CrownCode.ai platform principles">
+          <article>
+            <span>01</span>
+            <h3>Shared infrastructure</h3>
+            <p>Reusable patterns for documentation, metadata, navigation, and internal tooling.</p>
+          </article>
+          <article>
+            <span>02</span>
+            <h3>Intelligence layer</h3>
+            <p>
+              Structured reasoning, reporting, classification, and workflow logic across products.
+            </p>
+          </article>
+          <article>
+            <span>03</span>
+            <h3>Launch discipline</h3>
+            <p>
+              Consistent naming, product taxonomy, source traceability, and future licensing
+              readiness.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="metrics shell" aria-label="Crown Labs portfolio metrics">
+        <article>
+          <h3>Total Products</h3>
+          <p id="total-products">—</p>
+        </article>
+        <article>
+          <h3>Active Beta</h3>
+          <p id="active-beta">—</p>
+        </article>
+        <article>
+          <h3>Average Readiness</h3>
+          <p id="avg-readiness">—</p>
+        </article>
+      </section>
+
+      <section id="products" class="product-overview shell" aria-labelledby="products-title">
+        <div class="section-heading-row">
+          <div>
+            <p class="eyebrow">Products</p>
+            <h2 id="products-title">Portfolio display, generated from the Crown Labs Bible.</h2>
+          </div>
+          <a class="text-link" href="../docs/crownlabsbible/">Review source documentation</a>
+        </div>
+        <p class="section-note">
+          These cards are discovery previews, not duplicate documentation. Open an individual brief
+          or continue into the documentation system for product dossiers, governance, valuation, and
+          architecture.
+        </p>
+        <div id="featured-products" class="featured-products" aria-live="polite"></div>
+        <p id="empty-state" class="empty-state" hidden>Products are temporarily unavailable.</p>
+      </section>
+
+      <section id="founder" class="founder-section shell" aria-labelledby="founder-title">
+        <div class="founder-card">
+          <p class="eyebrow">Founder</p>
+          <h2 id="founder-title">Daren Prince</h2>
+          <p>
+            Daren Prince is an author, speaker, and systems builder whose public work centers on
+            clarity, connection, confidence, and practical psychology. Crown Labs extends that voice
+            into productized tools, documentation infrastructure, and governed technology systems.
+          </p>
+          <div class="founder-links">
+            <a class="text-link" href="../meet-daren-prince.html">Meet Daren</a>
+            <a class="text-link muted" href="../docs/crownlabsbible/README.md"
+              >Crown Labs documentation source</a
+            >
+          </div>
+        </div>
+        <div class="doc-funnel" aria-label="Deeper exploration links">
+          <h3>Continue deeper</h3>
+          <p>
+            For deeper exploration, use the documentation paths below. They remain the canonical
+            places for architecture, product detail, operating standards, and source governance.
+          </p>
+          <a class="primary-link compact" href="../docs/">/docs/</a>
+          <a class="secondary-link compact" href="../docs/crownlabsbible/">/docs/crownlabsbible/</a>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer shell">
+      <p>
+        © <span id="labs-year"></span> Crown Labs • Daren Prince Publishing • Public landing page
+        synchronized to canonical documentation architecture.
+      </p>
+    </footer>
+
+    <script src="../assets/labs.js" defer data-labs-data="../assets/labs-data.json"></script>
   </body>
 </html>

--- a/labs/products/ai-cherry-pie.html
+++ b/labs/products/ai-cherry-pie.html
@@ -29,7 +29,7 @@
       </div>
     </div>
     <div class="nav-actions">
-      <a class="back-link" href="../../labs.html#portfolio">Back to portfolio</a>
+      <a class="back-link" href="../#products">Back to Labs</a>
       <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
       <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
     </div>
@@ -47,7 +47,7 @@
         <p>AI Cherry Pie is a writing reconstruction engine designed to identify, reduce, and remove detectable AI writing fingerprints while restoring natural human flow, emotional realism, conversational rhythm, and believable language structure.</p>
         <div class="access-actions">
           <a class="primary-btn" href="../../docs/crownlabsbible/04-product-dossiers/ai-cherry-pie/overview.md">Open canonical dossier</a>
-          <a class="ghost-btn" href="../../labs.html#portfolio">Explore portfolio</a>
+          <a class="ghost-btn" href="../#products">Explore Labs</a>
         </div>
       </div>
     </section>

--- a/labs/products/crown-psychology.html
+++ b/labs/products/crown-psychology.html
@@ -29,7 +29,7 @@
       </div>
     </div>
     <div class="nav-actions">
-      <a class="back-link" href="../../labs.html#portfolio">Back to portfolio</a>
+      <a class="back-link" href="../#products">Back to Labs</a>
       <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
       <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
     </div>
@@ -47,7 +47,7 @@
         <p>Crown Psychology is an emotionally intelligent behavioral growth platform designed to help users better understand themselves, recognize patterns, improve emotional awareness, and actively work toward measurable personal growth.</p>
         <div class="access-actions">
           <a class="primary-btn" href="../../docs/crownlabsbible/04-product-dossiers/crown-psychology/overview.md">Open canonical dossier</a>
-          <a class="ghost-btn" href="../../labs.html#portfolio">Explore portfolio</a>
+          <a class="ghost-btn" href="../#products">Explore Labs</a>
         </div>
       </div>
     </section>

--- a/labs/products/crown-sos.html
+++ b/labs/products/crown-sos.html
@@ -29,7 +29,7 @@
       </div>
     </div>
     <div class="nav-actions">
-      <a class="back-link" href="../../labs.html#portfolio">Back to portfolio</a>
+      <a class="back-link" href="../#products">Back to Labs</a>
       <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
       <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
     </div>
@@ -47,7 +47,7 @@
         <p>Crown SOS is a real time crisis response and emergency coordination platform designed to help users maintain operational continuity, communicate during unstable situations, preserve critical evidence, and coordinate survivability workflows.</p>
         <div class="access-actions">
           <a class="primary-btn" href="../../docs/crownlabsbible/04-product-dossiers/crown-sos/overview.md">Open canonical dossier</a>
-          <a class="ghost-btn" href="../../labs.html#portfolio">Explore portfolio</a>
+          <a class="ghost-btn" href="../#products">Explore Labs</a>
         </div>
       </div>
     </section>

--- a/labs/products/crown-watchtower.html
+++ b/labs/products/crown-watchtower.html
@@ -29,7 +29,7 @@
       </div>
     </div>
     <div class="nav-actions">
-      <a class="back-link" href="../../labs.html#portfolio">Back to portfolio</a>
+      <a class="back-link" href="../#products">Back to Labs</a>
       <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
       <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
     </div>
@@ -47,7 +47,7 @@
         <p>Crown WatchTower is a forensic grade environmental signal intelligence and operational visibility platform designed to support threat awareness, monitoring coordination, ecosystem observability, and continuity focused intelligence workflows.</p>
         <div class="access-actions">
           <a class="primary-btn" href="../../docs/crownlabsbible/04-product-dossiers/crown-watchtower/overview.md">Open canonical dossier</a>
-          <a class="ghost-btn" href="../../labs.html#portfolio">Explore portfolio</a>
+          <a class="ghost-btn" href="../#products">Explore Labs</a>
         </div>
       </div>
     </section>

--- a/labs/products/crowncam.html
+++ b/labs/products/crowncam.html
@@ -29,7 +29,7 @@
       </div>
     </div>
     <div class="nav-actions">
-      <a class="back-link" href="../../labs.html#portfolio">Back to portfolio</a>
+      <a class="back-link" href="../#products">Back to Labs</a>
       <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
       <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
     </div>
@@ -47,7 +47,7 @@
         <p>CrownCam is a real time monitoring and remote camera infrastructure platform designed to transform everyday devices into scalable live monitoring systems.</p>
         <div class="access-actions">
           <a class="primary-btn" href="../../docs/crownlabsbible/04-product-dossiers/crowncam/overview.md">Open canonical dossier</a>
-          <a class="ghost-btn" href="../../labs.html#portfolio">Explore portfolio</a>
+          <a class="ghost-btn" href="../#products">Explore Labs</a>
         </div>
       </div>
     </section>

--- a/labs/products/crowncast.html
+++ b/labs/products/crowncast.html
@@ -29,7 +29,7 @@
       </div>
     </div>
     <div class="nav-actions">
-      <a class="back-link" href="../../labs.html#portfolio">Back to portfolio</a>
+      <a class="back-link" href="../#products">Back to Labs</a>
       <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
       <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
     </div>
@@ -47,7 +47,7 @@
         <p>CrownCast is a daily alignment and motivational platform designed to help users improve self awareness, emotional clarity, reflection, and personal alignment.</p>
         <div class="access-actions">
           <a class="primary-btn" href="../../docs/crownlabsbible/04-product-dossiers/crowncast/overview.md">Open canonical dossier</a>
-          <a class="ghost-btn" href="../../labs.html#portfolio">Explore portfolio</a>
+          <a class="ghost-btn" href="../#products">Explore Labs</a>
         </div>
       </div>
     </section>

--- a/labs/products/crowncode-ai.html
+++ b/labs/products/crowncode-ai.html
@@ -29,7 +29,7 @@
       </div>
     </div>
     <div class="nav-actions">
-      <a class="back-link" href="../../labs.html#portfolio">Back to portfolio</a>
+      <a class="back-link" href="../#products">Back to Labs</a>
       <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
       <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
     </div>
@@ -47,7 +47,7 @@
         <p>CrownCode.ai is not positioned as a single standalone application.</p>
         <div class="access-actions">
           <a class="primary-btn" href="../../docs/crownlabsbible/02-products/crowncode-ai.md">Open canonical dossier</a>
-          <a class="ghost-btn" href="../../labs.html#portfolio">Explore portfolio</a>
+          <a class="ghost-btn" href="../#products">Explore Labs</a>
         </div>
       </div>
     </section>

--- a/labs/products/sentinel-vault.html
+++ b/labs/products/sentinel-vault.html
@@ -29,7 +29,7 @@
       </div>
     </div>
     <div class="nav-actions">
-      <a class="back-link" href="../../labs.html#portfolio">Back to portfolio</a>
+      <a class="back-link" href="../#products">Back to Labs</a>
       <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
       <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
     </div>
@@ -47,7 +47,7 @@
         <p>Sentinel Vault is a privacy centered survivability and evidence continuity platform designed to help users preserve critical information, maintain emergency communication capability, and protect sensitive personal evidence during high stress, dangerous, or unstable situations.</p>
         <div class="access-actions">
           <a class="primary-btn" href="../../docs/crownlabsbible/04-product-dossiers/sentinel-vault/overview.md">Open canonical dossier</a>
-          <a class="ghost-btn" href="../../labs.html#portfolio">Explore portfolio</a>
+          <a class="ghost-btn" href="../#products">Explore Labs</a>
         </div>
       </div>
     </section>

--- a/scripts/check-deploy-metadata.mjs
+++ b/scripts/check-deploy-metadata.mjs
@@ -12,6 +12,7 @@ const pagesToValidate = [
   { file: 'contact.html', brandColor: '#456f3a' },
   { file: 'haley.html', brandColor: '#11162a' },
   { file: 'labs.html', brandColor: '#070b14' },
+  { file: 'labs/index.html', brandColor: '#070b14' },
   { file: 'src/nexuswho/index.html', brandColor: '#456f3a' },
 ]
 

--- a/scripts/generate-labs-product-pages.mjs
+++ b/scripts/generate-labs-product-pages.mjs
@@ -55,7 +55,7 @@ const template = (product) => `<!doctype html>
       </div>
     </div>
     <div class="nav-actions">
-      <a class="back-link" href="../../labs.html#portfolio">Back to portfolio</a>
+      <a class="back-link" href="../#products">Back to Labs</a>
       <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
       <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
     </div>
@@ -73,7 +73,7 @@ const template = (product) => `<!doctype html>
         <p>${escapeHtml(product.oneLiner)}</p>
         <div class="access-actions">
           <a class="primary-btn" href="../../${escapeHtml(product.sourcePath)}">Open canonical dossier</a>
-          <a class="ghost-btn" href="../../labs.html#portfolio">Explore portfolio</a>
+          <a class="ghost-btn" href="../#products">Explore Labs</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
### Motivation

- Provide a canonical, public-facing Crown Labs landing route at `/labs/` that introduces Crown Labs, explains CrownCode.ai, surfaces products, displays founder information, and funnels visitors into the canonical documentation without duplicating docs content.
- Keep product metadata authoritative to `docs/crownlabsbible/` and ensure public product previews are generated from the canonical Bible to avoid parallel inventories.
- Preserve backward compatibility for existing links by retaining `labs.html` as a metadata-complete redirect while moving the content to `/labs/`.

### Description

- Added a production-quality landing page at `labs/index.html` with full metadata, OG/Twitter tags, favicon wiring, documentation CTAs, founder section, and a generated product preview mount (`#featured-products`).
- Converted `labs.html` into a metadata-complete redirect to `/labs/` and updated product brief pages and generator logic so briefs link back to `/labs/#products` instead of the deprecated route.
- Extended the shared Labs renderer and assets: `assets/labs.js` now supports `data-labs-data` attribute, renders both compact featured cards and full portfolio cards safely via DOM APIs and `textContent`, and `assets/labs.css` gained a quiet-luxury landing stylesheet for hero, product grid, principles, founder funnel, and responsive breakpoints.
- Updated automation and documentation: regenerated `assets/labs-data.json` and `data/products.json` from `docs/crownlabsbible/`, updated `scripts/generate-labs-product-pages.mjs`, added `labs/index.html` to `scripts/check-deploy-metadata.mjs` validations, and documented routing and rendering rules in `docs/LABS_PAGE_SYSTEM.md` and `docs/BUILD_PIPELINE.md`.

### Testing

- Ran `npm run build:labs` to regenerate product metadata and pages; result: success (8 products generated). 
- Ran full site build with `npm run build`; result: success (search index, icons, images, and CSS regenerated). 
- Ran metadata and style linters with `npm run lint:metadata && npm run lint:buttons`; result: passed (metadata checks updated to include `/labs/`).
- Ran unit/smoke tests with `npm test` (Vitest); result: all tests passed. 
- Performed a route smoke check with a Node/cheerio script to assert required selectors (`canonical`, docs links, `data-labs-data` script, `#featured-products`, `#founder`); result: passed. 
- Captured a visual verification using Playwright screenshot of `http://127.0.0.1:4174/labs/`; result: screenshot produced (sanity visual check).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d0927a9148325bcc72e1b93bbad9e)