### PR TITLE
Modernize Crown Labs navigation and route public pages into Crown Labs Bible docs app

### DIFF
--- a/audit/navigation-map-after.md
+++ b/audit/navigation-map-after.md
@@ -1,0 +1,53 @@
+# Crown Labs Navigation Map — Planned After Modernization
+
+Generated before implementation as the target state for the Crown Labs navigation modernization directive.
+
+## Modern public Labs navigation target
+
+The public Labs shell will expose the same primary navigation labels on desktop and mobile:
+
+| Label         | Landing target                           | Product-page target                         | Purpose                                             |
+| ------------- | ---------------------------------------- | ------------------------------------------- | --------------------------------------------------- |
+| Home          | `#top`                                   | `../`                                       | Return to the Crown Labs public landing entry.      |
+| Products      | `#products`                              | `../#products`                              | Open the product portfolio grid.                    |
+| Technology    | `#crowncode`                             | `../#crowncode`                             | Open the CrownCode.ai technology/substrate section. |
+| Founder       | `#founder`                               | `../#founder`                               | Open founder positioning.                           |
+| Documentation | `../docs/crownlabsbible/docs/index.html` | `../../docs/crownlabsbible/docs/index.html` | Use the Crown Labs Bible documentation application. |
+| Contact       | `mailto:apps@crownlabs.tech`             | `mailto:apps@crownlabs.tech`                | Direct contact route.                               |
+
+## Documentation routing target
+
+| Previous public route pattern                                                            | New public route pattern                                                                                    | Reason                                                                                                   |
+| ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `../docs/`                                                                               | `../docs/crownlabsbible/docs/index.html`                                                                    | Avoid generic repo docs for Crown Labs public documentation.                                             |
+| `../docs/crownlabsbible/`                                                                | `../docs/crownlabsbible/docs/index.html`                                                                    | Avoid raw directory/source browsing.                                                                     |
+| `../docs/crownlabsbible/README.md`                                                       | `../docs/crownlabsbible/docs/viewer.html#Documentation%20Platform`                                          | Use docs app viewer route.                                                                               |
+| `../docs/crownlabsbible/02-products/crowncode-ai.md`                                     | `../docs/crownlabsbible/docs/crowncode-ai.html`                                                             | Use CrownCode.ai docs application page.                                                                  |
+| `../../docs/crownlabsbible/04-product-dossiers/<slug>/overview.md`                       | `../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/<slug>/overview.md#Overview`         | Use docs app viewer where all dossier navigation remains reachable.                                      |
+| `/docs/style-guide.html` and `/docs/buttons-demo.html` in the CrownCode microsite footer | `/docs/crownlabsbible/docs/index.html` and `/docs/crownlabsbible/docs/viewer.html#Documentation%20Platform` | Route Crown Labs documentation users to the Crown Labs Bible application instead of repo docs utilities. |
+
+## Product dossier documentation target map
+
+| Product page                          | Documentation application target                                                                              |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `labs/products/crowncode-ai.html`     | `../../docs/crownlabsbible/docs/crowncode-ai.html`                                                            |
+| `labs/products/ai-cherry-pie.html`    | `../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/ai-cherry-pie/overview.md#Overview`    |
+| `labs/products/crown-psychology.html` | `../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crown-psychology/overview.md#Overview` |
+| `labs/products/sentinel-vault.html`   | `../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/sentinel-vault/overview.md#Overview`   |
+| `labs/products/crowncam.html`         | `../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crowncam/overview.md#Overview`         |
+| `labs/products/crown-sos.html`        | `../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crown-sos/overview.md#Overview`        |
+| `labs/products/crown-watchtower.html` | `../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crown-watchtower/overview.md#Overview` |
+| `labs/products/crowncast.html`        | `../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crowncast/overview.md#Overview`        |
+
+The viewer will support a `doc` query parameter so product pages can deep-link to the exact dossier while preserving the existing sidebar tree, hash label, and documentation app experience.
+
+## Documentation application preservation target
+
+The existing Crown Labs Bible documentation app keeps its sidebar, quick links, mobile sidebar toggle, viewer tree, footer links, and all generated HTML app pages. Public Labs pages link into the app instead of replacing or bypassing it.
+
+## Mobile behavior target
+
+- Desktop: modern horizontal navigation with API-backed Tabler line icons rendered through Iconify.
+- Mobile/tablet: accessible hamburger button opens the same navigation stack.
+- Escape key and outside-click/scrim close behavior are supported on the landing page.
+- Product pages use the same modern navigation labels and hamburger pattern.

--- a/audit/navigation-map-before.md
+++ b/audit/navigation-map-before.md
@@ -1,0 +1,71 @@
+# Crown Labs Navigation Map — Before Modernization
+
+Generated before implementation for the Crown Labs navigation modernization directive.
+
+## Scope reviewed
+
+- `labs/index.html`
+- `labs/products/*.html`
+- `labs/crowncode/index.html`
+- `docs/crownlabsbible/docs/*.html`
+- `docs/crownlabsbible/docs/assets/js/navigation.js`
+
+## Public Labs landing navigation before
+
+Source: `labs/index.html`
+
+| Location           | Label                         | Target                                               | Finding                                                                              |
+| ------------------ | ----------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Header             | Crown Labs                    | `#crown-labs`                                        | Section anchor only; no Home item.                                                   |
+| Header             | CrownCode.ai                  | `#crowncode`                                         | Technology/product infrastructure section.                                           |
+| Header             | Products                      | `#products`                                          | Product grid anchor.                                                                 |
+| Header             | Founder                       | `#founder`                                           | Founder section anchor.                                                              |
+| Header             | Docs                          | `../docs/`                                           | Points to repository documentation index, not the Crown Labs Bible docs application. |
+| Hero primary CTA   | Enter documentation           | `../docs/`                                           | Points to repository docs.                                                           |
+| Hero secondary CTA | Open Crown Labs Bible         | `../docs/crownlabsbible/`                            | Points to raw documentation directory/index.                                         |
+| Hero panel         | Open docs application         | `../docs/crownlabsbible/docs/index.html`             | Correct Crown Labs Bible documentation application entry.                            |
+| CrownCode section  | Open CrownCode.ai dossier     | `../docs/crownlabsbible/02-products/crowncode-ai.md` | Points to raw Markdown material.                                                     |
+| Product section    | Review source documentation   | `../docs/crownlabsbible/`                            | Points to raw documentation directory/index.                                         |
+| Founder section    | Documentation governance note | `../docs/crownlabsbible/README.md`                   | Points to raw Markdown material.                                                     |
+| Footer/CTA         | `/docs/`                      | `../docs/`                                           | Points to repository docs.                                                           |
+| Footer/CTA         | `/docs/crownlabsbible/`       | `../docs/crownlabsbible/`                            | Points to raw documentation directory/index.                                         |
+
+## Product page navigation before
+
+Source: `labs/products/*.html`
+
+| Location      | Label                          | Target                                      | Finding                                                                   |
+| ------------- | ------------------------------ | ------------------------------------------- | ------------------------------------------------------------------------- |
+| Header        | Back to Labs                   | `../#products`                              | Returns to Labs product grid.                                             |
+| Header        | Crown Labs Bible               | `../../docs/crownlabsbible/docs/index.html` | Correct docs app entry.                                                   |
+| Hero CTA      | Open canonical dossier         | `../../docs/crownlabsbible/.../*.md`        | Points to raw Markdown dossier/source file.                               |
+| Hero CTA      | Explore Labs                   | `../#products`                              | Returns to Labs product grid.                                             |
+| Metadata text | Source file / Canonical source | `docs/crownlabsbible/.../*.md` text         | Presents raw source file paths as user-facing documentation destinations. |
+
+## CrownCode microsite navigation before
+
+Source: `labs/crowncode/index.html`
+
+| Location          | Label        | Target                    | Finding                                                                       |
+| ----------------- | ------------ | ------------------------- | ----------------------------------------------------------------------------- |
+| Footer docs links | Style Guide  | `/docs/style-guide.html`  | Points to repository docs utility page rather than Crown Labs Bible docs app. |
+| Footer docs links | Buttons Demo | `/docs/buttons-demo.html` | Points to repository docs utility page rather than Crown Labs Bible docs app. |
+
+## Crown Labs Bible documentation application before
+
+Source: `docs/crownlabsbible/docs/*.html` and `docs/crownlabsbible/docs/assets/js/navigation.js`
+
+| Area                | Existing behavior                                                                                  | Preservation requirement                                   |
+| ------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Sidebar quick links | Overview, Docs, Investor, Executive, Map, Roadmap                                                  | Preserve.                                                  |
+| Mobile menu         | Existing docs app sidebar toggle and scrim                                                         | Preserve.                                                  |
+| Viewer tree         | Corporate Foundation, Branding, Writing, Investor, Corporate Infrastructure, Product Documentation | Preserve and keep all documents reachable through the app. |
+| Footer docs links   | Viewer, Ecosystem Map, Roadmap, Investor Mode, Executive Dashboard, Contact                        | Preserve.                                                  |
+
+## Key risks identified before implementation
+
+1. Public Labs navigation does not provide the requested modern item set: Home, Products, Technology, Founder, Documentation, Contact.
+2. Public Labs navigation has no mobile hamburger behavior; the menu is simply hidden below 860px by shared CSS.
+3. Multiple public links route users to repo docs or raw Markdown/source directories rather than the Crown Labs Bible documentation application.
+4. Product pages expose raw Markdown as primary canonical dossier destinations instead of app-based documentation destinations.
+5. The existing Crown Labs Bible documentation app navigation is functional and should not be replaced or broken.

--- a/docs/LABS_PAGE_SYSTEM.md
+++ b/docs/LABS_PAGE_SYSTEM.md
@@ -14,28 +14,54 @@ The landing page is a discovery layer for visitors who need a high-level introdu
 - explain CrownCode.ai as the reusable intelligence and engineering layer beneath Crown Labs;
 - display products from generated metadata only;
 - introduce founder context for Daren Prince;
-- funnel deeper exploration toward `/docs/` and `/docs/crownlabsbible/`.
+- funnel deeper exploration toward the Crown Labs Bible documentation application at `/docs/crownlabsbible/docs/`.
 
-The page must not duplicate product dossiers, architecture, roadmap, valuation, or governance documentation. Those subjects remain owned by `docs/crownlabsbible/` and its generated documentation app.
+The page must not duplicate product dossiers, architecture, roadmap, valuation, or governance documentation. Those subjects remain owned by `docs/crownlabsbible/` and are consumed publicly through the generated Crown Labs Bible documentation app.
+
+## Public Navigation Contract
+
+The `/labs/` landing page and `labs/products/*.html` product brief pages share a modern Crown Labs navigation model:
+
+| Label         | Landing target                           | Product-page target                         |
+| ------------- | ---------------------------------------- | ------------------------------------------- |
+| Home          | `#top`                                   | `../`                                       |
+| Products      | `#products`                              | `../#products`                              |
+| Technology    | `#crowncode`                             | `../#crowncode`                             |
+| Founder       | `#founder`                               | `../#founder`                               |
+| Documentation | `../docs/crownlabsbible/docs/index.html` | `../../docs/crownlabsbible/docs/index.html` |
+| Contact       | `mailto:apps@crownlabs.tech`             | `mailto:apps@crownlabs.tech`                |
+
+Navigation uses API-backed Tabler icons through the existing Iconify web component (`iconify-icon`) and an accessible hamburger disclosure on mobile. The docs app has its own sidebar, quick links, mobile sidebar, reader toolbar, and footer navigation; preserve that documentation navigation rather than replacing it with the public marketing shell.
+
+## Documentation Routing Rules
+
+- Crown Labs public pages must not send users to generic repo docs (`/docs/`) for product documentation.
+- Crown Labs public pages must not use raw Markdown files or raw documentation directories as primary documentation destinations.
+- Use `/docs/crownlabsbible/docs/index.html` as the default documentation entry.
+- Use `/docs/crownlabsbible/docs/crowncode-ai.html` for CrownCode.ai documentation.
+- Use `/docs/crownlabsbible/docs/viewer.html?doc=<canonical-markdown-path>#<label>` when a public product page needs to deep-link to an exact Bible dossier through the documentation application.
+- The viewer supports the `doc` query parameter while preserving the hash label, sidebar tree, search, quick links, and all existing documentation routes.
 
 ## Rendering Rules
 
 - Product cards are rendered from `assets/labs-data.json` through `assets/labs.js`.
 - The landing page passes `data-labs-data="../assets/labs-data.json"` so the shared renderer resolves data correctly from `/labs/`.
 - Product rendering uses explicit DOM creation and `textContent`; do not inject raw HTML or regex-rewrite rendered markup.
-- Public cards are summaries only. Brief and source links must point visitors into generated product pages or canonical documentation.
+- Public cards are summaries only. Brief and documentation links must point visitors into generated product pages or the Crown Labs Bible documentation app.
 
 ## Architecture Decisions
 
 - `/labs/` is now a clean, public, marketing-safe route while `labs.html` remains only for backward compatibility.
 - The design follows a quiet luxury infrastructure UI: restrained contrast, measured spacing, square geometry, and documentation-forward hierarchy.
-- CrownCode.ai receives a high-level platform explanation on the landing page, but its authoritative source remains `docs/crownlabsbible/02-products/crowncode-ai.md`.
+- CrownCode.ai receives a high-level platform explanation on the landing page, but its authoritative source remains the Crown Labs Bible and its public destination is the documentation application.
 - Product inventory remains generated from the Crown Labs Bible by `npm run build:labs`.
+- Navigation audit files for this modernization live at `audit/navigation-map-before.md` and `audit/navigation-map-after.md`.
 
 ## Canonical Documentation Sources For This Page
 
-- `docs/crownlabsbible/README.md`
-- `docs/crownlabsbible/02-products/crowncode-ai.md`
+- Crown Labs Bible documentation app: `docs/crownlabsbible/docs/index.html`
+- Crown Labs Bible viewer: `docs/crownlabsbible/docs/viewer.html`
+- CrownCode.ai documentation app page: `docs/crownlabsbible/docs/crowncode-ai.html`
 - `assets/labs-data.json` generated from `docs/crownlabsbible/`
 - `meet-daren-prince.html` for public founder biography context
 
@@ -44,3 +70,4 @@ The page must not duplicate product dossiers, architecture, roadmap, valuation, 
 - The former `labs/index.html` redirect-only entrypoint is deprecated.
 - `labs.html` is deprecated as a content route and retained only as a redirect with valid metadata for existing links and deployment checks.
 - Do not reintroduce a second hand-maintained Crown Labs product inventory outside the generated metadata pipeline.
+- Do not route Crown Labs product documentation to repo utility docs or raw Markdown files when an equivalent Crown Labs Bible documentation app route exists.

--- a/docs/crownlabsbible/docs/viewer.html
+++ b/docs/crownlabsbible/docs/viewer.html
@@ -1,115 +1,701 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" data-theme="dark">
-<head>
-<meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Crown Labs Documentation</title>
-<link rel="icon" type="image/png" href="https://www.darenprince.com/app%20icons/crownicon.PNG" />
-<link rel="stylesheet" href="assets/css/platform.css" />
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100,0,-25" />
-</head>
-<body>
-<div class="cl-scrim" id="scrim"></div>
-<div class="cl-app" id="app">
-  <aside class="cl-sidebar">
-    <div class="cl-sidebar-header">
-      <img class="cl-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
-      <button class="cl-icon-btn" id="navToggle" title="Toggle navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
-    </div>
-    <div class="cl-title">Crown Labs Documentation</div>
-    <div class="cl-subtitle">Unified product, investor, executive, brand, and operating documentation.</div>
-    <div class="cl-quicklinks">
-      <a href="viewer.html#Company%20Overview"><span class="ms-icon" aria-hidden="true">home</span>Overview</a>
-      <a href="viewer.html"><span class="ms-icon" aria-hidden="true">description</span>Docs</a>
-      <a href="investor-mode.html"><span class="ms-icon" aria-hidden="true">account_balance_wallet</span>Investor</a>
-      <a href="executive-dashboard.html"><span class="ms-icon" aria-hidden="true">monitoring</span>Executive</a>
-      <a href="ecosystem-map.html"><span class="ms-icon" aria-hidden="true">map</span>Map</a>
-      <a href="roadmap-tracker.html"><span class="ms-icon" aria-hidden="true">route</span>Roadmap</a>
-    </div>
-    <div class="cl-search"><span class="ms-icon" aria-hidden="true">search</span><input id="searchInput" placeholder="Search documentation..." /></div>
-    <div class="cl-tree" id="navRoot"></div>
-  </aside>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Crown Labs Documentation</title>
+    <link
+      rel="icon"
+      type="image/png"
+      href="https://www.darenprince.com/app%20icons/crownicon.PNG"
+    />
+    <link rel="stylesheet" href="assets/css/platform.css" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100,0,-25"
+    />
+  </head>
+  <body>
+    <div class="cl-scrim" id="scrim"></div>
+    <div class="cl-app" id="app">
+      <aside class="cl-sidebar">
+        <div class="cl-sidebar-header">
+          <img
+            class="cl-logo"
+            src="https://www.darenprince.com/labs/assets/crown-labs-logo.png"
+            data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png"
+            data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png"
+            alt="Crown Labs"
+          />
+          <button class="cl-icon-btn" id="navToggle" title="Toggle navigation">
+            <span class="ms-icon" aria-hidden="true">menu</span>
+          </button>
+        </div>
+        <div class="cl-title">Crown Labs Documentation</div>
+        <div class="cl-subtitle">
+          Unified product, investor, executive, brand, and operating documentation.
+        </div>
+        <div class="cl-quicklinks">
+          <a href="viewer.html#Company%20Overview"
+            ><span class="ms-icon" aria-hidden="true">home</span>Overview</a
+          >
+          <a href="viewer.html"><span class="ms-icon" aria-hidden="true">description</span>Docs</a>
+          <a href="investor-mode.html"
+            ><span class="ms-icon" aria-hidden="true">account_balance_wallet</span>Investor</a
+          >
+          <a href="executive-dashboard.html"
+            ><span class="ms-icon" aria-hidden="true">monitoring</span>Executive</a
+          >
+          <a href="ecosystem-map.html"><span class="ms-icon" aria-hidden="true">map</span>Map</a>
+          <a href="roadmap-tracker.html"
+            ><span class="ms-icon" aria-hidden="true">route</span>Roadmap</a
+          >
+        </div>
+        <div class="cl-search">
+          <span class="ms-icon" aria-hidden="true">search</span
+          ><input id="searchInput" placeholder="Search documentation..." />
+        </div>
+        <div class="cl-tree" id="navRoot"></div>
+      </aside>
 
-  <main class="cl-main">
-    <div class="cl-reader">
-      <div class="cl-toolbar">
-        <button class="cl-icon-btn cl-toolbar-toggle" id="toolbarToggle" title="Toggle top toolbar"><span class="ms-icon" aria-hidden="true">expand_less</span></button>
-        <div class="cl-toolbar-body">
-        <div class="cl-toolbar-meta">
-          <div class="cl-toolbar-head">
-            <img class="cl-header-logo" src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" />
-            <button class="cl-icon-btn cl-mobile-menu" id="mobileMenu" title="Open navigation"><span class="ms-icon" aria-hidden="true">menu</span></button>
+      <main class="cl-main">
+        <div class="cl-reader">
+          <div class="cl-toolbar">
+            <button
+              class="cl-icon-btn cl-toolbar-toggle"
+              id="toolbarToggle"
+              title="Toggle top toolbar"
+            >
+              <span class="ms-icon" aria-hidden="true">expand_less</span>
+            </button>
+            <div class="cl-toolbar-body">
+              <div class="cl-toolbar-meta">
+                <div class="cl-toolbar-head">
+                  <img
+                    class="cl-header-logo"
+                    src="https://www.darenprince.com/labs/assets/crown-labs-logo.png"
+                    data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png"
+                    data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png"
+                    alt="Crown Labs"
+                  />
+                  <button
+                    class="cl-icon-btn cl-mobile-menu"
+                    id="mobileMenu"
+                    title="Open navigation"
+                  >
+                    <span class="ms-icon" aria-hidden="true">menu</span>
+                  </button>
+                </div>
+                <div class="cl-breadcrumbs" id="breadcrumbRoot"></div>
+              </div>
+              <div class="cl-tools">
+                <button class="cl-tool-btn" id="themeToggle">
+                  <span class="ms-icon" aria-hidden="true">dark_mode</span><span>Theme</span>
+                </button>
+                <button class="cl-tool-btn" id="fontDown">
+                  <span class="ms-icon" aria-hidden="true">text_fields</span>A−
+                </button>
+                <button class="cl-tool-btn" id="fontReset">
+                  <span class="ms-icon" aria-hidden="true">format_size</span>A
+                </button>
+                <button class="cl-tool-btn" id="fontUp">
+                  <span class="ms-icon" aria-hidden="true">text_increase</span>A+
+                </button>
+                <button class="cl-tool-btn" id="copyDoc">
+                  <span class="ms-icon" aria-hidden="true">content_copy</span>Copy
+                </button>
+                <button class="cl-tool-btn" id="printDoc">
+                  <span class="ms-icon" aria-hidden="true">print</span>Print
+                </button>
+                <button class="cl-tool-btn" id="shareDoc">
+                  <span class="ms-icon" aria-hidden="true">share</span>Share
+                </button>
+              </div>
+            </div>
           </div>
-          <div class="cl-breadcrumbs" id="breadcrumbRoot"></div>
-                  </div>
-        <div class="cl-tools">
-          <button class="cl-tool-btn" id="themeToggle"><span class="ms-icon" aria-hidden="true">dark_mode</span><span>Theme</span></button>
-          <button class="cl-tool-btn" id="fontDown"><span class="ms-icon" aria-hidden="true">text_fields</span>A−</button>
-          <button class="cl-tool-btn" id="fontReset"><span class="ms-icon" aria-hidden="true">format_size</span>A</button>
-          <button class="cl-tool-btn" id="fontUp"><span class="ms-icon" aria-hidden="true">text_increase</span>A+</button>
-          <button class="cl-tool-btn" id="copyDoc"><span class="ms-icon" aria-hidden="true">content_copy</span>Copy</button>
-          <button class="cl-tool-btn" id="printDoc"><span class="ms-icon" aria-hidden="true">print</span>Print</button>
-          <button class="cl-tool-btn" id="shareDoc"><span class="ms-icon" aria-hidden="true">share</span>Share</button>
+          <article class="cl-content" id="content">
+            <p class="cl-empty">Choose a document from the navigation.</p>
+          </article>
+          <footer class="cl-footer">
+            <div class="cl-footer-grid">
+              <div>
+                <img
+                  src="https://www.darenprince.com/labs/assets/crown-labs-logo.png"
+                  data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png"
+                  data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png"
+                  alt="Crown Labs"
+                />
+                <p>
+                  Institutional documentation, product intelligence, and operational infrastructure
+                  for the Crown Labs ecosystem.
+                </p>
+                <div class="cl-social">
+                  <a href="https://www.darenprince.com"
+                    ><span class="ms-icon" aria-hidden="true">language</span></a
+                  ><a href="https://github.com/darenprince"
+                    ><span class="ms-icon" aria-hidden="true">code</span></a
+                  ><a href="#"><span class="ms-icon" aria-hidden="true">work</span></a
+                  ><a href="#"><span class="ms-icon" aria-hidden="true">alternate_email</span></a>
+                </div>
+              </div>
+              <div>
+                <h4>Documentation</h4>
+                <a href="viewer.html"
+                  ><span class="ms-icon" aria-hidden="true">description</span>Viewer</a
+                ><a href="ecosystem-map.html"
+                  ><span class="ms-icon" aria-hidden="true">map</span>Ecosystem Map</a
+                ><a href="roadmap-tracker.html"
+                  ><span class="ms-icon" aria-hidden="true">route</span>Roadmap</a
+                >
+              </div>
+              <div>
+                <h4>Business</h4>
+                <a href="investor-mode.html"
+                  ><span class="ms-icon" aria-hidden="true">account_balance_wallet</span>Investor
+                  Mode</a
+                ><a href="executive-dashboard.html"
+                  ><span class="ms-icon" aria-hidden="true">monitoring</span>Executive Dashboard</a
+                ><a href="mailto:apps@crownlabs.tech"
+                  ><span class="ms-icon" aria-hidden="true">mail</span>Contact</a
+                >
+              </div>
+              <div>
+                <h4>Updates</h4>
+                <p>Get release notes and documentation updates.</p>
+                <form
+                  class="cl-signup"
+                  onsubmit="event.preventDefault();toast('Signup captured. Connect mailing provider next.');"
+                >
+                  <input type="email" placeholder="Email address" required /><button>
+                    <span class="ms-icon" aria-hidden="true">arrow_forward</span>
+                  </button>
+                </form>
+              </div>
+            </div>
+          </footer>
         </div>
-        </div>
-      </div>
-      <article class="cl-content" id="content"><p class="cl-empty">Choose a document from the navigation.</p></article>
-      <footer class="cl-footer">
-        <div class="cl-footer-grid">
-          <div><img src="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-dark-logo="https://www.darenprince.com/labs/assets/crown-labs-logo.png" data-light-logo="https://www.darenprince.com/assets/images/30F807E6-DA8A-413C-8564-116375DDE082%202.png" alt="Crown Labs" /><p>Institutional documentation, product intelligence, and operational infrastructure for the Crown Labs ecosystem.</p><div class="cl-social"><a href="https://www.darenprince.com"><span class="ms-icon" aria-hidden="true">language</span></a><a href="https://github.com/darenprince"><span class="ms-icon" aria-hidden="true">code</span></a><a href="#"><span class="ms-icon" aria-hidden="true">work</span></a><a href="#"><span class="ms-icon" aria-hidden="true">alternate_email</span></a></div></div>
-          <div><h4>Documentation</h4><a href="viewer.html"><span class="ms-icon" aria-hidden="true">description</span>Viewer</a><a href="ecosystem-map.html"><span class="ms-icon" aria-hidden="true">map</span>Ecosystem Map</a><a href="roadmap-tracker.html"><span class="ms-icon" aria-hidden="true">route</span>Roadmap</a></div>
-          <div><h4>Business</h4><a href="investor-mode.html"><span class="ms-icon" aria-hidden="true">account_balance_wallet</span>Investor Mode</a><a href="executive-dashboard.html"><span class="ms-icon" aria-hidden="true">monitoring</span>Executive Dashboard</a><a href="mailto:apps@crownlabs.tech"><span class="ms-icon" aria-hidden="true">mail</span>Contact</a></div>
-          <div><h4>Updates</h4><p>Get release notes and documentation updates.</p><form class="cl-signup" onsubmit="event.preventDefault();toast('Signup captured. Connect mailing provider next.');"><input type="email" placeholder="Email address" required /><button><span class="ms-icon" aria-hidden="true">arrow_forward</span></button></form></div>
-        </div>
-      </footer>
+      </main>
     </div>
-  </main>
-</div>
-<button class="cl-back-top" id="backTop"><span class="ms-icon" aria-hidden="true">arrow_upward</span></button>
-<div class="cl-toast" id="toast"></div>
-<script>
-const iconMap={
-'Corporate Foundation':'solar:buildings-2-linear','Branding & Visual Identity':'solar:pallete-2-linear','Writing & Communication':'solar:pen-new-square-linear','Investor Framework':'solar:chart-2-linear','Corporate Infrastructure':'solar:server-square-linear','Product Documentation':'solar:box-linear','AI Cherry Pie':'solar:text-field-focus-linear','Crown Psychology':'solar:brain-linear','Sentinel Vault':'solar:shield-keyhole-linear','CrownCam':'solar:camera-linear','Crown SOS':'solar:siren-rounded-linear','Crown WatchTower':'solar:tower-linear','CrownCast':'solar:podcast-linear'};
-const tree=[
-{label:'Corporate Foundation',children:[{label:'Corporate Identity',path:'../01-corporate-foundation/crown-labs-corporate-identity.md'},{label:'Product Classification Framework',path:'../01-corporate-foundation/product-classification-framework.md'}]},
-{label:'Branding & Visual Identity',children:[{label:'Branding & Visual Identity Standards',path:'../05-corporate-infrastructure/brand-standards.md'}]},
-{label:'Writing & Communication',children:[{label:'Writing Standards Overview',path:'../02-writing-standards/README.md'},{label:'Brand Voice System',path:'../02-writing-standards/brand-voice-system.md'},{label:'Corporate Writing Standards',path:'../05-corporate-infrastructure/writing-standards.md'},{label:'Communication Standards',path:'../05-corporate-infrastructure/communication-standards.md'}]},
-{label:'Investor Framework',children:[{label:'Licensing Structures',path:'../03-investor-framework/licensing-structures.md'},{label:'Monetization Models',path:'../03-investor-framework/monetization-models.md'},{label:'Valuation Methodology',path:'../03-investor-framework/valuation-methodology.md'},{label:'Investor Relations',path:'../05-corporate-infrastructure/investor-relations.md'},{label:'Licensing Governance',path:'../05-corporate-infrastructure/licensing-governance.md'}]},
-{label:'Corporate Infrastructure',children:[{label:'Company Overview',path:'../05-corporate-infrastructure/company-overview.md'},{label:'Executive Positioning',path:'../05-corporate-infrastructure/executive-positioning.md'},{label:'Holdings Structure',path:'../05-corporate-infrastructure/holdings-structure.md'},{label:'Portfolio Governance',path:'../05-corporate-infrastructure/portfolio-governance.md'},{label:'Ecosystem Philosophy',path:'../05-corporate-infrastructure/ecosystem-philosophy.md'},{label:'Expansion Roadmap',path:'../05-corporate-infrastructure/expansion-roadmap.md'},{label:'Acquisition Strategy',path:'../05-corporate-infrastructure/acquisition-strategy.md'}]},
-{label:'Product Documentation',children:[
-product('AI Cherry Pie','ai-cherry-pie',['Overview','Architecture','Positioning','Valuation','Monetization','Licensing','Website Copy']),
-product('Crown Psychology','crown-psychology',['Overview','Architecture','Positioning','Valuation','Monetization','Licensing','Website Copy','Ecosystem Role']),
-product('Sentinel Vault','sentinel-vault',['Overview','Architecture','Positioning','Valuation','Monetization','Licensing','Website Copy','Ecosystem Role']),
-product('CrownCam','crowncam',['Overview','Architecture','Positioning','Valuation','Monetization','Licensing','Website Copy','Ecosystem Role']),
-product('Crown SOS','crown-sos',['Overview','Architecture','Positioning','Valuation','Monetization','Licensing','Website Copy','Ecosystem Role']),
-product('Crown WatchTower','crown-watchtower',['Overview','Architecture','Positioning','Valuation','Licensing','Website Copy','Ecosystem Role']),
-product('CrownCast','crowncast',['Overview','Positioning','Valuation','Monetization','Licensing','Website Copy','Ecosystem Role'])
-]}];
-function product(label,slug,items){return{label,children:items.map(x=>({label:x,path:'../04-product-dossiers/'+slug+'/'+x.toLowerCase().replaceAll(' ','-')+'.md'}))};}
-const $=s=>document.querySelector(s), app=$('#app'), navRoot=$('#navRoot'), content=$('#content'), crumbs=$('#breadcrumbRoot'), search=$('#searchInput');
-let currentDoc=null,currentPath='',scale=Number(localStorage.getItem('readerScale')||1);
-function applyTheme(theme){document.documentElement.dataset.theme=theme;document.querySelectorAll('[data-dark-logo]').forEach(img=>{img.src=theme==='light'?img.dataset.lightLogo:img.dataset.darkLogo;});}
-applyTheme(localStorage.getItem('theme')||'dark');document.documentElement.style.setProperty('--reader-scale',scale);if(localStorage.getItem('navCollapsed')==='true')app.classList.add('nav-collapsed');
-function esc(s){return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));}
-function icon(s){return '<span class="ms-icon" aria-hidden="true">radio_button_unchecked</span>';}
-function flatten(nodes,p=[]){return nodes.flatMap(n=>n.children?flatten(n.children,[...p,n.label]):[{...n,crumb:[...p,n.label]}]);}
-const flat=flatten(tree);
-flat.unshift({label:'Documentation Platform',path:'../05-corporate-infrastructure/documentation-platform.md',crumb:['Corporate Infrastructure','Documentation Platform']});
-function match(n,q){return (n.label+' '+(n.path||'')).toLowerCase().includes(q)||(n.children||[]).some(x=>match(x,q));}
-function renderNav(q=''){q=q.toLowerCase().trim();navRoot.innerHTML='';tree.forEach(sec=>{if(q&&!match(sec,q))return;const s=document.createElement('div');s.className='cl-section';s.dataset.section=sec.label;s.innerHTML='<button class="cl-section-toggle"><span class="cl-label">'+icon(sec.label)+'<span>'+esc(sec.label)+'</span></span><span class="cl-chevron">⌄</span></button><div class="cl-children"></div>';s.querySelector('button').onclick=()=>s.classList.toggle('closed');const kids=s.querySelector('.cl-children');sec.children.forEach(ch=>{if(q&&!match(ch,q))return;if(ch.children){const g=document.createElement('div');g.className='cl-product';g.dataset.group=ch.label;g.innerHTML='<button class="cl-product-toggle"><span class="cl-label">'+icon(ch.label)+'<span>'+esc(ch.label)+'</span></span><span class="cl-chevron">⌄</span></button><div class="cl-leaves"></div>';g.querySelector('button').onclick=()=>g.classList.toggle('closed');ch.children.forEach(d=>{if(!q||match(d,q))g.querySelector('.cl-leaves').appendChild(link(d,[sec.label,ch.label,d.label]));});kids.appendChild(g);}else kids.appendChild(link(ch,[sec.label,ch.label]));});navRoot.appendChild(s);});syncActive();}
-function link(doc,crumb){const a=document.createElement('a');a.className='cl-doc-link';a.href='#'+encodeURIComponent(doc.label);a.dataset.path=doc.path;a.innerHTML='<span class="ms-icon" aria-hidden="true">description</span><span>'+esc(doc.label)+'</span>';a.onclick=e=>{e.preventDefault();openDoc({...doc,crumb});};return a;}
-function breadcrumbs(doc){crumbs.innerHTML='';['Home',...doc.crumb].forEach((p,i,arr)=>{if(i){const sep=document.createElement('span');sep.className='sep';sep.textContent='/';crumbs.appendChild(sep);}if(i===arr.length-1){const cur=document.createElement('span');cur.className='current';cur.textContent=p;crumbs.appendChild(cur);}else{const b=document.createElement('button');b.innerHTML=(i?'':'<span class="ms-icon" aria-hidden="true">home</span>')+esc(p);b.onclick=()=>{if(!i)location.href='index.html';else expand(doc.crumb.slice(0,i));};crumbs.appendChild(b);}});}
-function expand(parts){document.querySelectorAll('.cl-section').forEach(s=>s.classList.toggle('closed',s.dataset.section!==parts[0]));document.querySelectorAll('.cl-product').forEach(g=>{if(parts[1])g.classList.toggle('closed',g.dataset.group!==parts[1]);});}
-function syncActive(){document.querySelectorAll('.cl-doc-link').forEach(a=>a.classList.toggle('active',a.dataset.path===currentPath));}
-function mdToHtml(md){let html='',list=false;const add=t=>esc(t).replace(/\[\[([^\]]+)\]\]/g,(m,name)=>{const d=flat.find(x=>x.label.toLowerCase()===name.toLowerCase()||x.crumb.join(' ').toLowerCase()===name.toLowerCase());return d?'<a class="cl-doc-ref" href="#'+encodeURIComponent(d.label)+'" data-path="'+esc(d.path)+'">'+esc(name)+'</a>':esc(name);});md.split('\n').forEach(line=>{const t=line.trim();if(!t){if(list){html+='</ul>';list=false;}return;}if(t.startsWith('# ')){if(list){html+='</ul>';list=false;}html+='<h1>'+add(t.slice(2))+'</h1>';return;}if(t.startsWith('## ')){if(list){html+='</ul>';list=false;}html+='<h2>'+add(t.slice(3))+'</h2>';return;}if(t.startsWith('### ')){if(list){html+='</ul>';list=false;}html+='<h3>'+add(t.slice(4))+'</h3>';return;}if(t.startsWith('- ')){if(!list){html+='<ul>';list=true;}html+='<li>'+add(t.slice(2))+'</li>';return;}if(list){html+='</ul>';list=false;}html+='<p>'+add(t)+'</p>';});if(list)html+='</ul>';return html;}
-async function openDoc(doc){currentDoc=doc;currentPath=doc.path;renderNav(search.value);expand(doc.crumb);syncActive();breadcrumbs(doc);content.innerHTML='<p class="cl-empty">Loading documentation...</p>';try{const res=await fetch(doc.path);if(!res.ok)throw new Error('missing');const md=await res.text();content.innerHTML=mdToHtml(md);content.querySelectorAll('.cl-doc-ref').forEach(a=>a.onclick=e=>{e.preventDefault();const next=flat.find(d=>d.path===a.dataset.path);if(next)openDoc(next);});location.hash=encodeURIComponent(doc.label);if(innerWidth<981)document.body.classList.remove('nav-open');scrollTo({top:0});}catch{content.innerHTML='<p class="cl-empty">Unable to load this document: '+esc(doc.path)+'</p>';}}
-function toast(msg){const t=$('#toast');t.textContent=msg;t.classList.add('visible');setTimeout(()=>t.classList.remove('visible'),2200);}
-$('#navToggle').onclick=()=>{if(innerWidth<981)document.body.classList.toggle('nav-open');else{app.classList.toggle('nav-collapsed');localStorage.setItem('navCollapsed',app.classList.contains('nav-collapsed'));}};$('#mobileMenu').onclick=()=>document.body.classList.add('nav-open');$('#scrim').onclick=()=>document.body.classList.remove('nav-open');
-$('#themeToggle').onclick=()=>{const n=document.documentElement.dataset.theme==='dark'?'light':'dark';applyTheme(n);localStorage.setItem('theme',n);};
-const toolbarToggle=$('#toolbarToggle'),toolbar=document.querySelector('.cl-toolbar');if(toolbarToggle&&toolbar){const collapsed=localStorage.getItem('toolbarCollapsed')==='true';toolbar.classList.toggle('toolbar-collapsed',collapsed);toolbarToggle.querySelector('.ms-icon').textContent=collapsed?'expand_more':'expand_less';toolbarToggle.onclick=()=>{const next=!toolbar.classList.contains('toolbar-collapsed');toolbar.classList.toggle('toolbar-collapsed',next);toolbarToggle.querySelector('.ms-icon').textContent=next?'expand_more':'expand_less';localStorage.setItem('toolbarCollapsed',String(next));};}
-$('#fontDown').onclick=()=>{scale=Math.max(.9,scale-.08);localStorage.setItem('readerScale',scale);document.documentElement.style.setProperty('--reader-scale',scale);};$('#fontReset').onclick=()=>{scale=1;localStorage.setItem('readerScale',scale);document.documentElement.style.setProperty('--reader-scale',1);};$('#fontUp').onclick=()=>{scale=Math.min(1.28,scale+.08);localStorage.setItem('readerScale',scale);document.documentElement.style.setProperty('--reader-scale',scale);};
-$('#copyDoc').onclick=async()=>{await navigator.clipboard.writeText(content.innerText.trim());toast('Document copied');};$('#printDoc').onclick=()=>print();$('#shareDoc').onclick=async()=>{if(navigator.share)await navigator.share({title:'Crown Labs Documentation',text:currentDoc?currentDoc.crumb.join(' / '):'Crown Labs Documentation',url:location.href});else{await navigator.clipboard.writeText(location.href);toast('Link copied');}};$('#backTop').onclick=()=>scrollTo({top:0,behavior:'smooth'});addEventListener('scroll',()=>$('#backTop').classList.toggle('visible',scrollY>420));search.oninput=e=>renderNav(e.target.value);
-renderNav();openDoc(flat.find(d=>d.label===decodeURIComponent(location.hash.slice(1)))||flat.find(d=>d.label==='Company Overview')||flat[0]);
-</script>
-</body>
+    <button class="cl-back-top" id="backTop">
+      <span class="ms-icon" aria-hidden="true">arrow_upward</span>
+    </button>
+    <div class="cl-toast" id="toast"></div>
+    <script>
+      const iconMap = {
+        'Corporate Foundation': 'solar:buildings-2-linear',
+        'Branding & Visual Identity': 'solar:pallete-2-linear',
+        'Writing & Communication': 'solar:pen-new-square-linear',
+        'Investor Framework': 'solar:chart-2-linear',
+        'Corporate Infrastructure': 'solar:server-square-linear',
+        'Product Documentation': 'solar:box-linear',
+        'AI Cherry Pie': 'solar:text-field-focus-linear',
+        'Crown Psychology': 'solar:brain-linear',
+        'Sentinel Vault': 'solar:shield-keyhole-linear',
+        CrownCam: 'solar:camera-linear',
+        'Crown SOS': 'solar:siren-rounded-linear',
+        'Crown WatchTower': 'solar:tower-linear',
+        CrownCast: 'solar:podcast-linear',
+      }
+      const tree = [
+        {
+          label: 'Corporate Foundation',
+          children: [
+            {
+              label: 'Corporate Identity',
+              path: '../01-corporate-foundation/crown-labs-corporate-identity.md',
+            },
+            {
+              label: 'Product Classification Framework',
+              path: '../01-corporate-foundation/product-classification-framework.md',
+            },
+          ],
+        },
+        {
+          label: 'Branding & Visual Identity',
+          children: [
+            {
+              label: 'Branding & Visual Identity Standards',
+              path: '../05-corporate-infrastructure/brand-standards.md',
+            },
+          ],
+        },
+        {
+          label: 'Writing & Communication',
+          children: [
+            { label: 'Writing Standards Overview', path: '../02-writing-standards/README.md' },
+            { label: 'Brand Voice System', path: '../02-writing-standards/brand-voice-system.md' },
+            {
+              label: 'Corporate Writing Standards',
+              path: '../05-corporate-infrastructure/writing-standards.md',
+            },
+            {
+              label: 'Communication Standards',
+              path: '../05-corporate-infrastructure/communication-standards.md',
+            },
+          ],
+        },
+        {
+          label: 'Investor Framework',
+          children: [
+            {
+              label: 'Licensing Structures',
+              path: '../03-investor-framework/licensing-structures.md',
+            },
+            {
+              label: 'Monetization Models',
+              path: '../03-investor-framework/monetization-models.md',
+            },
+            {
+              label: 'Valuation Methodology',
+              path: '../03-investor-framework/valuation-methodology.md',
+            },
+            {
+              label: 'Investor Relations',
+              path: '../05-corporate-infrastructure/investor-relations.md',
+            },
+            {
+              label: 'Licensing Governance',
+              path: '../05-corporate-infrastructure/licensing-governance.md',
+            },
+          ],
+        },
+        {
+          label: 'Corporate Infrastructure',
+          children: [
+            {
+              label: 'Company Overview',
+              path: '../05-corporate-infrastructure/company-overview.md',
+            },
+            {
+              label: 'Executive Positioning',
+              path: '../05-corporate-infrastructure/executive-positioning.md',
+            },
+            {
+              label: 'Holdings Structure',
+              path: '../05-corporate-infrastructure/holdings-structure.md',
+            },
+            {
+              label: 'Portfolio Governance',
+              path: '../05-corporate-infrastructure/portfolio-governance.md',
+            },
+            {
+              label: 'Ecosystem Philosophy',
+              path: '../05-corporate-infrastructure/ecosystem-philosophy.md',
+            },
+            {
+              label: 'Expansion Roadmap',
+              path: '../05-corporate-infrastructure/expansion-roadmap.md',
+            },
+            {
+              label: 'Acquisition Strategy',
+              path: '../05-corporate-infrastructure/acquisition-strategy.md',
+            },
+          ],
+        },
+        {
+          label: 'Product Documentation',
+          children: [
+            product('AI Cherry Pie', 'ai-cherry-pie', [
+              'Overview',
+              'Architecture',
+              'Positioning',
+              'Valuation',
+              'Monetization',
+              'Licensing',
+              'Website Copy',
+            ]),
+            product('Crown Psychology', 'crown-psychology', [
+              'Overview',
+              'Architecture',
+              'Positioning',
+              'Valuation',
+              'Monetization',
+              'Licensing',
+              'Website Copy',
+              'Ecosystem Role',
+            ]),
+            product('Sentinel Vault', 'sentinel-vault', [
+              'Overview',
+              'Architecture',
+              'Positioning',
+              'Valuation',
+              'Monetization',
+              'Licensing',
+              'Website Copy',
+              'Ecosystem Role',
+            ]),
+            product('CrownCam', 'crowncam', [
+              'Overview',
+              'Architecture',
+              'Positioning',
+              'Valuation',
+              'Monetization',
+              'Licensing',
+              'Website Copy',
+              'Ecosystem Role',
+            ]),
+            product('Crown SOS', 'crown-sos', [
+              'Overview',
+              'Architecture',
+              'Positioning',
+              'Valuation',
+              'Monetization',
+              'Licensing',
+              'Website Copy',
+              'Ecosystem Role',
+            ]),
+            product('Crown WatchTower', 'crown-watchtower', [
+              'Overview',
+              'Architecture',
+              'Positioning',
+              'Valuation',
+              'Licensing',
+              'Website Copy',
+              'Ecosystem Role',
+            ]),
+            product('CrownCast', 'crowncast', [
+              'Overview',
+              'Positioning',
+              'Valuation',
+              'Monetization',
+              'Licensing',
+              'Website Copy',
+              'Ecosystem Role',
+            ]),
+          ],
+        },
+      ]
+      function product(label, slug, items) {
+        return {
+          label,
+          children: items.map((x) => ({
+            label: x,
+            path:
+              '../04-product-dossiers/' + slug + '/' + x.toLowerCase().replaceAll(' ', '-') + '.md',
+          })),
+        }
+      }
+      const $ = (s) => document.querySelector(s),
+        app = $('#app'),
+        navRoot = $('#navRoot'),
+        content = $('#content'),
+        crumbs = $('#breadcrumbRoot'),
+        search = $('#searchInput')
+      let currentDoc = null,
+        currentPath = '',
+        scale = Number(localStorage.getItem('readerScale') || 1)
+      function applyTheme(theme) {
+        document.documentElement.dataset.theme = theme
+        document.querySelectorAll('[data-dark-logo]').forEach((img) => {
+          img.src = theme === 'light' ? img.dataset.lightLogo : img.dataset.darkLogo
+        })
+      }
+      applyTheme(localStorage.getItem('theme') || 'dark')
+      document.documentElement.style.setProperty('--reader-scale', scale)
+      if (localStorage.getItem('navCollapsed') === 'true') app.classList.add('nav-collapsed')
+      function esc(s) {
+        return String(s).replace(
+          /[&<>"]/g,
+          (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c]
+        )
+      }
+      function icon(s) {
+        return '<span class="ms-icon" aria-hidden="true">radio_button_unchecked</span>'
+      }
+      function flatten(nodes, p = []) {
+        return nodes.flatMap((n) =>
+          n.children ? flatten(n.children, [...p, n.label]) : [{ ...n, crumb: [...p, n.label] }]
+        )
+      }
+      const flat = flatten(tree)
+      flat.unshift({
+        label: 'Documentation Platform',
+        path: '../05-corporate-infrastructure/documentation-platform.md',
+        crumb: ['Corporate Infrastructure', 'Documentation Platform'],
+      })
+      function match(n, q) {
+        return (
+          (n.label + ' ' + (n.path || '')).toLowerCase().includes(q) ||
+          (n.children || []).some((x) => match(x, q))
+        )
+      }
+      function renderNav(q = '') {
+        q = q.toLowerCase().trim()
+        navRoot.innerHTML = ''
+        tree.forEach((sec) => {
+          if (q && !match(sec, q)) return
+          const s = document.createElement('div')
+          s.className = 'cl-section'
+          s.dataset.section = sec.label
+          s.innerHTML =
+            '<button class="cl-section-toggle"><span class="cl-label">' +
+            icon(sec.label) +
+            '<span>' +
+            esc(sec.label) +
+            '</span></span><span class="cl-chevron">⌄</span></button><div class="cl-children"></div>'
+          s.querySelector('button').onclick = () => s.classList.toggle('closed')
+          const kids = s.querySelector('.cl-children')
+          sec.children.forEach((ch) => {
+            if (q && !match(ch, q)) return
+            if (ch.children) {
+              const g = document.createElement('div')
+              g.className = 'cl-product'
+              g.dataset.group = ch.label
+              g.innerHTML =
+                '<button class="cl-product-toggle"><span class="cl-label">' +
+                icon(ch.label) +
+                '<span>' +
+                esc(ch.label) +
+                '</span></span><span class="cl-chevron">⌄</span></button><div class="cl-leaves"></div>'
+              g.querySelector('button').onclick = () => g.classList.toggle('closed')
+              ch.children.forEach((d) => {
+                if (!q || match(d, q))
+                  g.querySelector('.cl-leaves').appendChild(link(d, [sec.label, ch.label, d.label]))
+              })
+              kids.appendChild(g)
+            } else kids.appendChild(link(ch, [sec.label, ch.label]))
+          })
+          navRoot.appendChild(s)
+        })
+        syncActive()
+      }
+      function link(doc, crumb) {
+        const a = document.createElement('a')
+        a.className = 'cl-doc-link'
+        a.href = '#' + encodeURIComponent(doc.label)
+        a.dataset.path = doc.path
+        a.innerHTML =
+          '<span class="ms-icon" aria-hidden="true">description</span><span>' +
+          esc(doc.label) +
+          '</span>'
+        a.onclick = (e) => {
+          e.preventDefault()
+          openDoc({ ...doc, crumb })
+        }
+        return a
+      }
+      function breadcrumbs(doc) {
+        crumbs.innerHTML = ''
+        ;['Home', ...doc.crumb].forEach((p, i, arr) => {
+          if (i) {
+            const sep = document.createElement('span')
+            sep.className = 'sep'
+            sep.textContent = '/'
+            crumbs.appendChild(sep)
+          }
+          if (i === arr.length - 1) {
+            const cur = document.createElement('span')
+            cur.className = 'current'
+            cur.textContent = p
+            crumbs.appendChild(cur)
+          } else {
+            const b = document.createElement('button')
+            b.innerHTML = (i ? '' : '<span class="ms-icon" aria-hidden="true">home</span>') + esc(p)
+            b.onclick = () => {
+              if (!i) location.href = 'index.html'
+              else expand(doc.crumb.slice(0, i))
+            }
+            crumbs.appendChild(b)
+          }
+        })
+      }
+      function expand(parts) {
+        document
+          .querySelectorAll('.cl-section')
+          .forEach((s) => s.classList.toggle('closed', s.dataset.section !== parts[0]))
+        document.querySelectorAll('.cl-product').forEach((g) => {
+          if (parts[1]) g.classList.toggle('closed', g.dataset.group !== parts[1])
+        })
+      }
+      function syncActive() {
+        document
+          .querySelectorAll('.cl-doc-link')
+          .forEach((a) => a.classList.toggle('active', a.dataset.path === currentPath))
+      }
+      function mdToHtml(md) {
+        let html = '',
+          list = false
+        const add = (t) =>
+          esc(t).replace(/\[\[([^\]]+)\]\]/g, (m, name) => {
+            const d = flat.find(
+              (x) =>
+                x.label.toLowerCase() === name.toLowerCase() ||
+                x.crumb.join(' ').toLowerCase() === name.toLowerCase()
+            )
+            return d
+              ? '<a class="cl-doc-ref" href="#' +
+                  encodeURIComponent(d.label) +
+                  '" data-path="' +
+                  esc(d.path) +
+                  '">' +
+                  esc(name) +
+                  '</a>'
+              : esc(name)
+          })
+        md.split('\n').forEach((line) => {
+          const t = line.trim()
+          if (!t) {
+            if (list) {
+              html += '</ul>'
+              list = false
+            }
+            return
+          }
+          if (t.startsWith('# ')) {
+            if (list) {
+              html += '</ul>'
+              list = false
+            }
+            html += '<h1>' + add(t.slice(2)) + '</h1>'
+            return
+          }
+          if (t.startsWith('## ')) {
+            if (list) {
+              html += '</ul>'
+              list = false
+            }
+            html += '<h2>' + add(t.slice(3)) + '</h2>'
+            return
+          }
+          if (t.startsWith('### ')) {
+            if (list) {
+              html += '</ul>'
+              list = false
+            }
+            html += '<h3>' + add(t.slice(4)) + '</h3>'
+            return
+          }
+          if (t.startsWith('- ')) {
+            if (!list) {
+              html += '<ul>'
+              list = true
+            }
+            html += '<li>' + add(t.slice(2)) + '</li>'
+            return
+          }
+          if (list) {
+            html += '</ul>'
+            list = false
+          }
+          html += '<p>' + add(t) + '</p>'
+        })
+        if (list) html += '</ul>'
+        return html
+      }
+      async function openDoc(doc) {
+        currentDoc = doc
+        currentPath = doc.path
+        renderNav(search.value)
+        expand(doc.crumb)
+        syncActive()
+        breadcrumbs(doc)
+        content.innerHTML = '<p class="cl-empty">Loading documentation...</p>'
+        try {
+          const res = await fetch(doc.path)
+          if (!res.ok) throw new Error('missing')
+          const md = await res.text()
+          content.innerHTML = mdToHtml(md)
+          content.querySelectorAll('.cl-doc-ref').forEach(
+            (a) =>
+              (a.onclick = (e) => {
+                e.preventDefault()
+                const next = flat.find((d) => d.path === a.dataset.path)
+                if (next) openDoc(next)
+              })
+          )
+          const params = new URLSearchParams(location.search)
+          params.set('doc', doc.path)
+          history.replaceState(
+            null,
+            '',
+            '?' + params.toString() + '#' + encodeURIComponent(doc.label)
+          )
+          if (innerWidth < 981) document.body.classList.remove('nav-open')
+          scrollTo({ top: 0 })
+        } catch {
+          content.innerHTML =
+            '<p class="cl-empty">Unable to load this document: ' + esc(doc.path) + '</p>'
+        }
+      }
+      function toast(msg) {
+        const t = $('#toast')
+        t.textContent = msg
+        t.classList.add('visible')
+        setTimeout(() => t.classList.remove('visible'), 2200)
+      }
+      $('#navToggle').onclick = () => {
+        if (innerWidth < 981) document.body.classList.toggle('nav-open')
+        else {
+          app.classList.toggle('nav-collapsed')
+          localStorage.setItem('navCollapsed', app.classList.contains('nav-collapsed'))
+        }
+      }
+      $('#mobileMenu').onclick = () => document.body.classList.add('nav-open')
+      $('#scrim').onclick = () => document.body.classList.remove('nav-open')
+      $('#themeToggle').onclick = () => {
+        const n = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark'
+        applyTheme(n)
+        localStorage.setItem('theme', n)
+      }
+      const toolbarToggle = $('#toolbarToggle'),
+        toolbar = document.querySelector('.cl-toolbar')
+      if (toolbarToggle && toolbar) {
+        const collapsed = localStorage.getItem('toolbarCollapsed') === 'true'
+        toolbar.classList.toggle('toolbar-collapsed', collapsed)
+        toolbarToggle.querySelector('.ms-icon').textContent = collapsed
+          ? 'expand_more'
+          : 'expand_less'
+        toolbarToggle.onclick = () => {
+          const next = !toolbar.classList.contains('toolbar-collapsed')
+          toolbar.classList.toggle('toolbar-collapsed', next)
+          toolbarToggle.querySelector('.ms-icon').textContent = next ? 'expand_more' : 'expand_less'
+          localStorage.setItem('toolbarCollapsed', String(next))
+        }
+      }
+      $('#fontDown').onclick = () => {
+        scale = Math.max(0.9, scale - 0.08)
+        localStorage.setItem('readerScale', scale)
+        document.documentElement.style.setProperty('--reader-scale', scale)
+      }
+      $('#fontReset').onclick = () => {
+        scale = 1
+        localStorage.setItem('readerScale', scale)
+        document.documentElement.style.setProperty('--reader-scale', 1)
+      }
+      $('#fontUp').onclick = () => {
+        scale = Math.min(1.28, scale + 0.08)
+        localStorage.setItem('readerScale', scale)
+        document.documentElement.style.setProperty('--reader-scale', scale)
+      }
+      $('#copyDoc').onclick = async () => {
+        await navigator.clipboard.writeText(content.innerText.trim())
+        toast('Document copied')
+      }
+      $('#printDoc').onclick = () => print()
+      $('#shareDoc').onclick = async () => {
+        if (navigator.share)
+          await navigator.share({
+            title: 'Crown Labs Documentation',
+            text: currentDoc ? currentDoc.crumb.join(' / ') : 'Crown Labs Documentation',
+            url: location.href,
+          })
+        else {
+          await navigator.clipboard.writeText(location.href)
+          toast('Link copied')
+        }
+      }
+      $('#backTop').onclick = () => scrollTo({ top: 0, behavior: 'smooth' })
+      addEventListener('scroll', () => $('#backTop').classList.toggle('visible', scrollY > 420))
+      search.oninput = (e) => renderNav(e.target.value)
+      renderNav()
+      const initialParams = new URLSearchParams(location.search)
+      const initialDocPath = initialParams.get('doc')
+      openDoc(
+        flat.find((d) => d.path === initialDocPath) ||
+          flat.find((d) => d.label === decodeURIComponent(location.hash.slice(1))) ||
+          flat.find((d) => d.label === 'Company Overview') ||
+          flat[0]
+      )
+    </script>
+  </body>
 </html>

--- a/labs/crowncode/index.html
+++ b/labs/crowncode/index.html
@@ -1,31 +1,33 @@
-<!DOCTYPE html>
+<!doctype html>
 <html data-site-root="darenprince-author" lang="en" class="ccai-page" data-theme="dark">
   <head>
     <script>
-      (function () {
-        const html = document.documentElement;
-        const explicitRoot = html.getAttribute('data-site-root');
-        const host = window.location.hostname || '';
-        const pathSegments = window.location.pathname.split('/').filter(Boolean);
-        const normalizedExplicit = explicitRoot ? explicitRoot.trim().replace(/^\/+|\/+$/g, '') : '';
-        let prefix = '';
+      ;(function () {
+        const html = document.documentElement
+        const explicitRoot = html.getAttribute('data-site-root')
+        const host = window.location.hostname || ''
+        const pathSegments = window.location.pathname.split('/').filter(Boolean)
+        const normalizedExplicit = explicitRoot ? explicitRoot.trim().replace(/^\/+|\/+$/g, '') : ''
+        let prefix = ''
         if (normalizedExplicit) {
-          prefix = '/' + normalizedExplicit;
+          prefix = '/' + normalizedExplicit
         } else if (host.endsWith('.github.io') && pathSegments.length) {
-          prefix = '/' + pathSegments[0];
+          prefix = '/' + pathSegments[0]
         }
-        const firstSegment = pathSegments[0] || '';
+        const firstSegment = pathSegments[0] || ''
         const shouldUsePrefix =
           Boolean(prefix) &&
-          (host.endsWith('.github.io') ? Boolean(pathSegments.length) : firstSegment === normalizedExplicit);
+          (host.endsWith('.github.io')
+            ? Boolean(pathSegments.length)
+            : firstSegment === normalizedExplicit)
         if (!shouldUsePrefix || prefix === '/') {
-          html.dataset.assetPrefix = '';
-          return;
+          html.dataset.assetPrefix = ''
+          return
         }
         if (prefix.endsWith('/')) {
-          prefix = prefix.slice(0, -1);
+          prefix = prefix.slice(0, -1)
         }
-        html.dataset.assetPrefix = prefix;
+        html.dataset.assetPrefix = prefix
         const URL_ATTRS = new Map([
           ['A', ['href']],
           ['LINK', ['href']],
@@ -37,134 +39,124 @@
           ['IFRAME', ['src']],
           ['USE', ['href', 'xlink:href']],
           ['FORM', ['action']],
-        ]);
+        ])
         const shouldIgnore = (value) =>
-          !value || /^(?:[a-z]+:|\/\/|#|data:|mailto:|tel:)/i.test(value);
+          !value || /^(?:[a-z]+:|\/\/|#|data:|mailto:|tel:)/i.test(value)
         const resolve = (value) => {
-          if (!value || shouldIgnore(value)) return value;
+          if (!value || shouldIgnore(value)) return value
           if (value === prefix || value.startsWith(prefix + '/')) {
-            return value;
+            return value
           }
           if (value.startsWith('/')) {
-            return prefix + value;
+            return prefix + value
           }
-          return value;
-        };
+          return value
+        }
         const patchSrcset = (value) =>
           value
             .split(',')
             .map((chunk) => {
-              const parts = chunk.trim().split(/\s+/);
+              const parts = chunk.trim().split(/\s+/)
               if (!parts.length || !parts[0]) {
-                return chunk;
+                return chunk
               }
-              parts[0] = resolve(parts[0]);
-              return parts.join(' ');
+              parts[0] = resolve(parts[0])
+              return parts.join(' ')
             })
-            .join(', ');
+            .join(', ')
         const patchNode = (node) => {
-          if (!node || node.nodeType !== Node.ELEMENT_NODE) return;
-          const attrs = URL_ATTRS.get(node.tagName);
-          if (!attrs) return;
+          if (!node || node.nodeType !== Node.ELEMENT_NODE) return
+          const attrs = URL_ATTRS.get(node.tagName)
+          if (!attrs) return
           for (const attr of attrs) {
-            const current = node.getAttribute(attr);
-            if (!current) continue;
+            const current = node.getAttribute(attr)
+            if (!current) continue
             if (attr === 'srcset') {
-              const next = patchSrcset(current);
+              const next = patchSrcset(current)
               if (next !== current) {
-                node.setAttribute(attr, next);
+                node.setAttribute(attr, next)
               }
-              continue;
+              continue
             }
-            const next = resolve(current);
-            if (next === current) continue;
+            const next = resolve(current)
+            if (next === current) continue
             if (node.tagName === 'SCRIPT' && attr === 'src') {
-              const replacement = document.createElement('script');
+              const replacement = document.createElement('script')
               node.getAttributeNames().forEach((name) => {
-                if (name === 'src') return;
-                replacement.setAttribute(name, node.getAttribute(name));
-              });
-              replacement.src = next;
+                if (name === 'src') return
+                replacement.setAttribute(name, node.getAttribute(name))
+              })
+              replacement.src = next
               if (node.parentNode) {
-                node.parentNode.insertBefore(replacement, node.nextSibling);
+                node.parentNode.insertBefore(replacement, node.nextSibling)
               } else {
-                document.head.appendChild(replacement);
+                document.head.appendChild(replacement)
               }
-              node.remove();
+              node.remove()
             } else {
-              node.setAttribute(attr, next);
+              node.setAttribute(attr, next)
             }
           }
-        };
+        }
         const patchSubtree = (root) => {
-          if (!root || !root.querySelectorAll) return;
+          if (!root || !root.querySelectorAll) return
           URL_ATTRS.forEach((_, tag) => {
-            root.querySelectorAll(tag.toLowerCase()).forEach(patchNode);
-          });
-        };
+            root.querySelectorAll(tag.toLowerCase()).forEach(patchNode)
+          })
+        }
         const observer = new MutationObserver((records) => {
           records.forEach((record) => {
             record.addedNodes.forEach((added) => {
               if (added.nodeType === Node.ELEMENT_NODE) {
-                patchNode(added);
+                patchNode(added)
                 if (added.querySelectorAll) {
-                  added.querySelectorAll('*').forEach(patchNode);
+                  added.querySelectorAll('*').forEach(patchNode)
                 }
               }
-            });
-          });
-        });
-        observer.observe(document.documentElement, { childList: true, subtree: true });
+            })
+          })
+        })
+        observer.observe(document.documentElement, { childList: true, subtree: true })
         const finalize = () => {
-          patchSubtree(document);
-          observer.disconnect();
-        };
-        if (document.readyState === 'loading') {
-          document.addEventListener('DOMContentLoaded', finalize, { once: true });
-        } else {
-          finalize();
+          patchSubtree(document)
+          observer.disconnect()
         }
-      })();
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', finalize, { once: true })
+        } else {
+          finalize()
+        }
+      })()
     </script>
-
-
 
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="CrownCode.ai Intelligence Systems laboratory experience and secure access gate." />
+    <meta
+      name="description"
+      content="CrownCode.ai Intelligence Systems laboratory experience and secure access gate."
+    />
     <title>CrownCode.ai Intelligence Systems Laboratory</title>
     <link
       rel="preload"
       as="image"
       href="https://placehold.co/1600x900/png?text=CrownCode.ai+Feature+Banner"
     />
-    <link
-      rel="preload"
-      as="image"
-      href="https://placehold.co/512x512/png?text=CrownTrace"
-    />
-    <link
-      rel="preload"
-      as="image"
-      href="https://placehold.co/512x512/png?text=CrownScene"
-    />
-    <link
-      rel="preload"
-      as="image"
-      href="https://placehold.co/512x512/png?text=CrownSignal"
-    />
-    <link
-      rel="preload"
-      as="image"
-      href="https://placehold.co/512x512/png?text=CrownVault"
-    />
+    <link rel="preload" as="image" href="https://placehold.co/512x512/png?text=CrownTrace" />
+    <link rel="preload" as="image" href="https://placehold.co/512x512/png?text=CrownScene" />
+    <link rel="preload" as="image" href="https://placehold.co/512x512/png?text=CrownSignal" />
+    <link rel="preload" as="image" href="https://placehold.co/512x512/png?text=CrownVault" />
     <link rel="icon" type="image/png" href="icons/crowncode-fav.png" />
     <script
       src="https://cdn.designsystem.digital.gov/uswds@3.7.2/js/uswds-init.min.js"
       integrity="sha384-9NHuO4H9+4Vo7viWM8A0aNslxmTQSWlDTjbDcVYyqDeNNMR++c8nAt+1YTazE5Pq"
       crossorigin="anonymous"
     ></script>
-    <link rel="stylesheet" href="https://cdn.designsystem.digital.gov/uswds@3.7.2/css/uswds.min.css" integrity="sha384-iiz7O+n+JrEP6O6pZXVFZF7h5DLaNUVg60Aw7Yb0lF8y3r+U5L0tjXR01Wk2Xyw6" crossorigin="anonymous" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.designsystem.digital.gov/uswds@3.7.2/css/uswds.min.css"
+      integrity="sha384-iiz7O+n+JrEP6O6pZXVFZF7h5DLaNUVg60Aw7Yb0lF8y3r+U5L0tjXR01Wk2Xyw6"
+      crossorigin="anonymous"
+    />
     <link rel="stylesheet" href="stylesheets/global.css" />
     <link rel="stylesheet" href="stylesheets/packages/ccai-overrides.css" />
     <script async src="https://js.stripe.com/v3/buy-button.js"></script>
@@ -210,8 +202,8 @@
               />
               <div class="usa-media-block__body">
                 <p>
-                  Official CrownCode.ai portals operate on secured .ai domains with TLS 1.3 encryption and
-                  ongoing compliance reviews.
+                  Official CrownCode.ai portals operate on secured .ai domains with TLS 1.3
+                  encryption and ongoing compliance reviews.
                 </p>
               </div>
             </div>
@@ -223,7 +215,10 @@
                 alt=""
               />
               <div class="usa-media-block__body">
-                <p>Look for the “https://” prefix or padlock to confirm you are interacting with vetted infrastructure.</p>
+                <p>
+                  Look for the “https://” prefix or padlock to confirm you are interacting with
+                  vetted infrastructure.
+                </p>
               </div>
             </div>
           </div>
@@ -233,16 +228,30 @@
 
     <div class="ccai-loader" id="ccai-page-loader" role="status" aria-live="assertive">
       <div class="ccai-loader__panel">
-        <img class="ccai-loader__image" src="images/Crowncode-OG.png.PNG" alt="CrownCode.ai rotating insignia" />
+        <img
+          class="ccai-loader__image"
+          src="images/Crowncode-OG.png.PNG"
+          alt="CrownCode.ai rotating insignia"
+        />
         <div class="usa-spinner" role="progressbar" aria-label="Loading CrownCode.ai systems"></div>
         <p class="ccai-loader__title">Calibrating Intelligence Lattice</p>
         <p class="ccai-loader__meta">Please stand by while security systems initialize.</p>
       </div>
     </div>
 
-    <div class="ccai-brief-loader" id="ccai-brief-loader" role="status" aria-live="assertive" hidden>
+    <div
+      class="ccai-brief-loader"
+      id="ccai-brief-loader"
+      role="status"
+      aria-live="assertive"
+      hidden
+    >
       <div class="ccai-brief-loader__panel">
-        <img class="ccai-loader__image" src="images/Crowncode-OG.png.PNG" alt="CrownCode.ai verification insignia" />
+        <img
+          class="ccai-loader__image"
+          src="images/Crowncode-OG.png.PNG"
+          alt="CrownCode.ai verification insignia"
+        />
         <div class="usa-spinner" role="progressbar" aria-label="Verifying clearance"></div>
         <p class="ccai-loader__title">Authorizing Clearance</p>
         <p class="ccai-loader__meta">Validating token &amp; preparing the secure brief.</p>
@@ -267,7 +276,9 @@
       </div>
       <nav aria-label="Primary navigation" class="usa-nav">
         <div class="usa-nav__inner">
-          <button type="button" class="usa-nav__close"><span class="usa-sr-only">Close</span></button>
+          <button type="button" class="usa-nav__close">
+            <span class="usa-sr-only">Close</span>
+          </button>
           <ul class="usa-nav__primary usa-accordion">
             <li class="usa-nav__primary-item">
               <a class="usa-nav__link" href="/#labs">
@@ -303,10 +314,16 @@
               Secure Intelligence Systems
             </h1>
             <p class="usa-intro">
-              Precision-grade behavioral, forensic, and OSINT tooling built for high consequence missions. Designed to meet the United States Web Design System standards for speed, accessibility, and mobile readiness.
+              Precision-grade behavioral, forensic, and OSINT tooling built for high consequence
+              missions. Designed to meet the United States Web Design System standards for speed,
+              accessibility, and mobile readiness.
             </p>
             <div class="ccai-access-actions">
-              <button type="button" class="usa-button usa-button--accent-warm ccai-pulse" data-access-trigger>
+              <button
+                type="button"
+                class="usa-button usa-button--accent-warm ccai-pulse"
+                data-access-trigger
+              >
                 Access Secure Brief
               </button>
               <button type="button" class="usa-button usa-button--outline" data-gate-trigger>
@@ -315,21 +332,28 @@
               <button type="button" class="usa-button usa-button--outline" data-beta-trigger>
                 Become a beta tester
               </button>
-              <a class="usa-button usa-button--unstyled" href="mailto:security@crowncode.ai">Report a security incident</a>
+              <a class="usa-button usa-button--unstyled" href="mailto:security@crowncode.ai"
+                >Report a security incident</a
+              >
             </div>
           </div>
         </div>
       </section>
 
-      <section class="usa-section usa-dark-background ccai-feature-banner ccai-animate-in" aria-labelledby="banner-heading" data-ccai-animate>
+      <section
+        class="usa-section usa-dark-background ccai-feature-banner ccai-animate-in"
+        aria-labelledby="banner-heading"
+        data-ccai-animate
+      >
         <div class="grid-container">
           <div class="grid-row grid-gap-lg ccai-feature-banner__grid">
             <div class="tablet:grid-col-6">
               <p class="ccai-section-header__eyebrow">System Focus</p>
               <h2 id="banner-heading" class="margin-top-0">CrownCode.ai Feature Banner</h2>
               <p class="usa-prose">
-                A high-impact visual that anchors the lab experience. Swap this PNG with the final CrownCode.ai hero
-                artwork to spotlight the intelligence lattice, mission hardware, and secured workflows.
+                A high-impact visual that anchors the lab experience. Swap this PNG with the final
+                CrownCode.ai hero artwork to spotlight the intelligence lattice, mission hardware,
+                and secured workflows.
               </p>
               <ul class="usa-list">
                 <li>Designed for 16:9 hero placements across landing and login gates.</li>
@@ -339,23 +363,31 @@
             </div>
             <div class="tablet:grid-col-6">
               <figure class="ccai-feature-banner__image">
-                <img src="https://placehold.co/1600x900/png?text=CrownCode.ai+Feature+Banner" alt="CrownCode.ai feature banner PNG placeholder with dark gradient lighting." />
-                <figcaption>PNG placeholder ready for final CrownCode.ai banner artwork.</figcaption>
+                <img
+                  src="https://placehold.co/1600x900/png?text=CrownCode.ai+Feature+Banner"
+                  alt="CrownCode.ai feature banner PNG placeholder with dark gradient lighting."
+                />
+                <figcaption>
+                  PNG placeholder ready for final CrownCode.ai banner artwork.
+                </figcaption>
               </figure>
             </div>
           </div>
         </div>
       </section>
 
-      <section class="usa-section usa-dark-background ccai-app-suite" aria-labelledby="apps-heading">
+      <section
+        class="usa-section usa-dark-background ccai-app-suite"
+        aria-labelledby="apps-heading"
+      >
         <div class="grid-container">
           <div class="ccai-section-header">
             <p class="ccai-section-header__eyebrow">Lab Stack</p>
             <h2 id="apps-heading" class="margin-0">CrownCode.ai App Suite</h2>
           </div>
           <p class="usa-prose ccai-app-suite__intro">
-            Placeholder PNG icons for the upcoming intelligence apps. Replace each tile with the final 512x512 icon export
-            to keep storefront, mobile, and desktop badges aligned.
+            Placeholder PNG icons for the upcoming intelligence apps. Replace each tile with the
+            final 512x512 icon export to keep storefront, mobile, and desktop badges aligned.
           </p>
           <div class="usa-card-group ccai-app-suite__grid" data-ccai-animate>
             <div class="usa-card">
@@ -364,7 +396,10 @@
                   <h3 class="usa-card__heading">CrownTrace</h3>
                 </header>
                 <div class="usa-card__media">
-                  <img src="https://placehold.co/512x512/png?text=CrownTrace" alt="PNG app icon placeholder for CrownTrace." />
+                  <img
+                    src="https://placehold.co/512x512/png?text=CrownTrace"
+                    alt="PNG app icon placeholder for CrownTrace."
+                  />
                 </div>
                 <div class="usa-card__body">
                   <p>Behavioral signal tracking and persona diffing for mission-ready analysts.</p>
@@ -377,7 +412,10 @@
                   <h3 class="usa-card__heading">CrownScene</h3>
                 </header>
                 <div class="usa-card__media">
-                  <img src="https://placehold.co/512x512/png?text=CrownScene" alt="PNG app icon placeholder for CrownScene." />
+                  <img
+                    src="https://placehold.co/512x512/png?text=CrownScene"
+                    alt="PNG app icon placeholder for CrownScene."
+                  />
                 </div>
                 <div class="usa-card__body">
                   <p>Forensic reconstruction modules with chain-of-custody export controls.</p>
@@ -390,7 +428,10 @@
                   <h3 class="usa-card__heading">CrownSignal</h3>
                 </header>
                 <div class="usa-card__media">
-                  <img src="https://placehold.co/512x512/png?text=CrownSignal" alt="PNG app icon placeholder for CrownSignal." />
+                  <img
+                    src="https://placehold.co/512x512/png?text=CrownSignal"
+                    alt="PNG app icon placeholder for CrownSignal."
+                  />
                 </div>
                 <div class="usa-card__body">
                   <p>OSINT fusion engine for multi-channel, multi-lingual signal awareness.</p>
@@ -403,10 +444,15 @@
                   <h3 class="usa-card__heading">CrownVault</h3>
                 </header>
                 <div class="usa-card__media">
-                  <img src="https://placehold.co/512x512/png?text=CrownVault" alt="PNG app icon placeholder for CrownVault." />
+                  <img
+                    src="https://placehold.co/512x512/png?text=CrownVault"
+                    alt="PNG app icon placeholder for CrownVault."
+                  />
                 </div>
                 <div class="usa-card__body">
-                  <p>Encrypted evidence locker with automated audit trails and compliance exports.</p>
+                  <p>
+                    Encrypted evidence locker with automated audit trails and compliance exports.
+                  </p>
                 </div>
               </div>
             </div>
@@ -430,8 +476,8 @@
                 Crafted with United States Web Design System guardrails
               </h3>
               <p>
-                Every control below implements USWDS typography, spacing, and interaction guidance across dark-mode contexts to
-                ensure federal-grade accessibility and resilience.
+                Every control below implements USWDS typography, spacing, and interaction guidance
+                across dark-mode contexts to ensure federal-grade accessibility and resilience.
               </p>
               <ul class="usa-summary-box__list">
                 <li>WCAG 2.1 AA contrast maintained in dark palette tokens</li>
@@ -443,7 +489,10 @@
           <div class="grid-row grid-gap">
             <div class="tablet:grid-col-6">
               <p class="usa-prose">
-                CrownCode.ai transforms behavioral intelligence, forensic analysis, and open-source intelligence into a single operational picture. Every module is built around evidence handling principles, auditability, and the ability to share case files securely with interagency partners.
+                CrownCode.ai transforms behavioral intelligence, forensic analysis, and open-source
+                intelligence into a single operational picture. Every module is built around
+                evidence handling principles, auditability, and the ability to share case files
+                securely with interagency partners.
               </p>
             </div>
             <div class="tablet:grid-col-6">
@@ -451,7 +500,9 @@
                 <div class="usa-alert__body">
                   <h3 class="usa-alert__heading">Federated Readiness</h3>
                   <p class="usa-alert__text">
-                    Interfaces and workflows mirror federal accessibility requirements: keyboard operable controls, high-contrast experiences, and responsive layouts validated against USWDS checklists.
+                    Interfaces and workflows mirror federal accessibility requirements: keyboard
+                    operable controls, high-contrast experiences, and responsive layouts validated
+                    against USWDS checklists.
                   </p>
                 </div>
               </div>
@@ -465,11 +516,15 @@
                   <h3 class="usa-card__heading">Behavioral Analytics</h3>
                 </header>
                 <div class="usa-card__media">
-                  <img src="images/1F7289CE-4AD2-4AAC-AFB4-26A34DE47312.png" alt="Neural activity visualization" />
+                  <img
+                    src="images/1F7289CE-4AD2-4AAC-AFB4-26A34DE47312.png"
+                    alt="Neural activity visualization"
+                  />
                 </div>
                 <div class="usa-card__body">
                   <p>
-                    Persona modeling, intent classification, and micro-expression review align with investigative interview protocols while staying fully auditable.
+                    Persona modeling, intent classification, and micro-expression review align with
+                    investigative interview protocols while staying fully auditable.
                   </p>
                 </div>
               </div>
@@ -480,11 +535,15 @@
                   <h3 class="usa-card__heading">Forensic Scene Fusion</h3>
                 </header>
                 <div class="usa-card__media">
-                  <img src="images/449B5B0C-3BCD-483F-A6BC-B2CE2EF417CD.png" alt="Evidence chain visualization" />
+                  <img
+                    src="images/449B5B0C-3BCD-483F-A6BC-B2CE2EF417CD.png"
+                    alt="Evidence chain visualization"
+                  />
                 </div>
                 <div class="usa-card__body">
                   <p>
-                    High-trust ingestion with automated chain-of-custody logs, tamper-evident exports, and court-ready reporting templates.
+                    High-trust ingestion with automated chain-of-custody logs, tamper-evident
+                    exports, and court-ready reporting templates.
                   </p>
                 </div>
               </div>
@@ -495,11 +554,15 @@
                   <h3 class="usa-card__heading">OSINT Coordination</h3>
                 </header>
                 <div class="usa-card__media">
-                  <img src="images/55522274-9716-46B4-A76C-0A18D263F523.png" alt="Network intelligence visualization" />
+                  <img
+                    src="images/55522274-9716-46B4-A76C-0A18D263F523.png"
+                    alt="Network intelligence visualization"
+                  />
                 </div>
                 <div class="usa-card__body">
                   <p>
-                    Structured ingestion from open networks, social ecosystems, and broadcast channels with confidence scoring rooted in federal tradecraft.
+                    Structured ingestion from open networks, social ecosystems, and broadcast
+                    channels with confidence scoring rooted in federal tradecraft.
                   </p>
                 </div>
               </div>
@@ -508,15 +571,25 @@
         </div>
       </section>
 
-      <section class="usa-section usa-dark-background ccai-animate-in" aria-labelledby="access-heading" data-ccai-animate>
+      <section
+        class="usa-section usa-dark-background ccai-animate-in"
+        aria-labelledby="access-heading"
+        data-ccai-animate
+      >
         <div class="grid-container">
           <div class="ccai-section-header">
             <p class="ccai-section-header__eyebrow">Access Control</p>
             <h2 id="access-heading" class="margin-0">Secure Briefing Gateway</h2>
           </div>
-          <div class="usa-step-indicator usa-step-indicator--counters" aria-label="Clearance workflow">
+          <div
+            class="usa-step-indicator usa-step-indicator--counters"
+            aria-label="Clearance workflow"
+          >
             <ol class="usa-step-indicator__segments">
-              <li class="usa-step-indicator__segment usa-step-indicator__segment--complete" aria-label="Step 1: Numeric verification">
+              <li
+                class="usa-step-indicator__segment usa-step-indicator__segment--complete"
+                aria-label="Step 1: Numeric verification"
+              >
                 <span class="usa-step-indicator__segment-number">1</span>
                 <span class="usa-step-indicator__segment-label">Numeric verification</span>
               </li>
@@ -536,34 +609,47 @@
             <div class="usa-step-indicator__header">
               <h3 class="usa-step-indicator__heading">Follow each step in sequence</h3>
               <p class="usa-step-indicator__description">
-                Steps align with USWDS process guidance to keep tasks legible and accessible on any device.
+                Steps align with USWDS process guidance to keep tasks legible and accessible on any
+                device.
               </p>
             </div>
           </div>
           <div class="grid-row grid-gap-lg">
             <div class="tablet:grid-col-6 usa-prose">
               <p>
-                Access to the operational brief requires both a rotating alphanumeric token and a numeric keypad verification. The workflow below honors USWDS interaction guidance with clear focus states, error messaging, and mobile-friendly layouts.
+                Access to the operational brief requires both a rotating alphanumeric token and a
+                numeric keypad verification. The workflow below honors USWDS interaction guidance
+                with clear focus states, error messaging, and mobile-friendly layouts.
               </p>
               <ol class="usa-process-list">
                 <li class="usa-process-list__item">
                   <h4 class="usa-process-list__heading">Request access token</h4>
-                  <p>Initiate the call tree or contact the watch floor for the current token, delivered over approved channels.</p>
+                  <p>
+                    Initiate the call tree or contact the watch floor for the current token,
+                    delivered over approved channels.
+                  </p>
                 </li>
                 <li class="usa-process-list__item">
                   <h4 class="usa-process-list__heading">Validate numeric clearance</h4>
-                  <p>Enter the rotating keypad code with full focus management support for keyboard and assistive technologies.</p>
+                  <p>
+                    Enter the rotating keypad code with full focus management support for keyboard
+                    and assistive technologies.
+                  </p>
                 </li>
                 <li class="usa-process-list__item">
                   <h4 class="usa-process-list__heading">Review classified brief</h4>
-                  <p>Authorized analysts receive responsive, high-contrast intel cards inside the secure shell for short-term review.</p>
+                  <p>
+                    Authorized analysts receive responsive, high-contrast intel cards inside the
+                    secure shell for short-term review.
+                  </p>
                 </li>
               </ol>
               <div class="usa-alert usa-alert--warning" role="alert">
                 <div class="usa-alert__body">
                   <h3 class="usa-alert__heading">Monitoring Enabled</h3>
                   <p class="usa-alert__text">
-                    Defensive logging captures blocked capture attempts, context menu suppression, and unusual key combinations for audit review.
+                    Defensive logging captures blocked capture attempts, context menu suppression,
+                    and unusual key combinations for audit review.
                   </p>
                 </div>
               </div>
@@ -572,7 +658,9 @@
               <div class="ccai-brief-shell" id="ccai-brief-shell" hidden aria-live="polite">
                 <h3>Operational Brief</h3>
                 <p class="usa-prose">
-                  Authorized analysts gain access to near real-time updates on behavioral indicators, forensic scene reconstruction, and OSINT signal pivots. All activity is recorded under session clearance ID <span id="ccai-clearance-id">-</span>.
+                  Authorized analysts gain access to near real-time updates on behavioral
+                  indicators, forensic scene reconstruction, and OSINT signal pivots. All activity
+                  is recorded under session clearance ID <span id="ccai-clearance-id">-</span>.
                 </p>
                 <div class="ccai-brief-shell__grid">
                   <div class="ccai-brief-shell__panel">
@@ -602,7 +690,8 @@
                   <div class="ccai-brief-shell__panel">
                     <h4>Support Contacts</h4>
                     <p class="margin-bottom-0">
-                      Security Desk: <a href="mailto:security@crowncode.ai">security@crowncode.ai</a><br />
+                      Security Desk: <a href="mailto:security@crowncode.ai">security@crowncode.ai</a
+                      ><br />
                       Mission Success: <a href="mailto:sales@crowncode.ai">sales@crowncode.ai</a>
                     </p>
                   </div>
@@ -621,7 +710,11 @@
         </div>
       </section>
 
-      <section class="usa-section usa-dark-background ccai-beta ccai-animate-in" aria-labelledby="beta-heading" data-ccai-animate>
+      <section
+        class="usa-section usa-dark-background ccai-beta ccai-animate-in"
+        aria-labelledby="beta-heading"
+        data-ccai-animate
+      >
         <div class="grid-container">
           <div class="grid-row grid-gap-lg ccai-beta__grid">
             <div class="tablet:grid-col-7">
@@ -630,8 +723,9 @@
                 <h2 id="beta-heading" class="margin-0">Become a CrownCode.ai beta tester</h2>
               </div>
               <p class="usa-prose ccai-beta__copy">
-                Join the closed beta wave to pressure-test new intelligence modules, provide feedback on the secure
-                workflow, and earn priority access to field-ready deployments.
+                Join the closed beta wave to pressure-test new intelligence modules, provide
+                feedback on the secure workflow, and earn priority access to field-ready
+                deployments.
               </p>
               <ul class="usa-list">
                 <li>Private release notes and tactical walkthroughs.</li>
@@ -643,9 +737,15 @@
               </button>
             </div>
             <div class="tablet:grid-col-5">
-              <div class="usa-summary-box usa-summary-box--dark ccai-beta__summary" role="region" aria-labelledby="beta-summary-heading">
+              <div
+                class="usa-summary-box usa-summary-box--dark ccai-beta__summary"
+                role="region"
+                aria-labelledby="beta-summary-heading"
+              >
                 <div class="usa-summary-box__body">
-                  <h3 class="usa-summary-box__heading" id="beta-summary-heading">Beta readiness checklist</h3>
+                  <h3 class="usa-summary-box__heading" id="beta-summary-heading">
+                    Beta readiness checklist
+                  </h3>
                   <ul class="usa-summary-box__list">
                     <li>Accept NDA and data handling protocols.</li>
                     <li>Provide operational role and test environment.</li>
@@ -658,7 +758,11 @@
         </div>
       </section>
 
-      <section class="usa-section usa-dark-background ccai-animate-in" aria-labelledby="ccai-support-heading" data-ccai-animate>
+      <section
+        class="usa-section usa-dark-background ccai-animate-in"
+        aria-labelledby="ccai-support-heading"
+        data-ccai-animate
+      >
         <div class="grid-container">
           <div class="ccai-section-header">
             <p class="ccai-section-header__eyebrow">Support the Project</p>
@@ -667,15 +771,21 @@
           <div class="grid-row grid-gap-lg ccai-support">
             <div class="tablet:grid-col-7">
               <p class="usa-prose ccai-support__copy">
-                Keep the incident response lab, AI reconnaissance, and rapid prototyping pipeline online for teams that rely on CrownCode.ai.
-                Contributions route through our encrypted Stripe checkout so you can fund the mission in seconds.
+                Keep the incident response lab, AI reconnaissance, and rapid prototyping pipeline
+                online for teams that rely on CrownCode.ai. Contributions route through our
+                encrypted Stripe checkout so you can fund the mission in seconds.
               </p>
               <div class="ccai-support__actions">
                 <stripe-buy-button
                   buy-button-id="buy_btn_1SF1aK0ZKpxSDkDjsGt83Wqr"
                   publishable-key="pk_live_51SF0xe0ZKpxSDkDjkTHzx9O5PVIUCk1AkZjnK0Z2369CK2xabZuXRcSFyyaAqISKXZw7Qz2tVnl3SPXPSrX5pgIj00eGPK9sYg"
                 ></stripe-buy-button>
-                <a class="ccai-support__link" href="https://buy.stripe.com/7sY5kv9pF8xM6lDd5z1VK00" target="_blank" rel="noopener">
+                <a
+                  class="ccai-support__link"
+                  href="https://buy.stripe.com/7sY5kv9pF8xM6lDd5z1VK00"
+                  target="_blank"
+                  rel="noopener"
+                >
                   <svg class="ccai-support__icon" viewBox="0 0 24 24" aria-hidden="true">
                     <path
                       d="M7 17L17 7M7 7h10v10"
@@ -690,7 +800,8 @@
                 </a>
               </div>
               <p class="ccai-support__note">
-                Funding fuels dark-site simulations, AI co-pilot training, and reader-first safety tooling across the Daren Prince network.
+                Funding fuels dark-site simulations, AI co-pilot training, and reader-first safety
+                tooling across the Daren Prince network.
               </p>
             </div>
             <div class="tablet:grid-col-5">
@@ -703,7 +814,9 @@
                   <span class="support-author-qr__placeholder-title">QR PENDING</span>
                   <span class="support-author-qr__placeholder-subtitle">Upload Stripe asset</span>
                 </div>
-                <p class="ccai-support__note"><strong>Scan to contribute.</strong> Point your camera and Stripe opens instantly.</p>
+                <p class="ccai-support__note">
+                  <strong>Scan to contribute.</strong> Point your camera and Stripe opens instantly.
+                </p>
               </div>
             </div>
           </div>
@@ -718,24 +831,44 @@
         <div class="grid-container">
           <div class="ccai-section-header">
             <p class="ccai-section-header__eyebrow">Financial Ops</p>
-            <h2 id="financial-heading" class="margin-0">Financial projections + full-stack readiness</h2>
+            <h2 id="financial-heading" class="margin-0">
+              Financial projections + full-stack readiness
+            </h2>
           </div>
           <div class="ccai-projection-controls" role="group" aria-label="Financial scenarios">
-            <button type="button" class="usa-button usa-button--outline" data-projection-trigger="baseline">
+            <button
+              type="button"
+              class="usa-button usa-button--outline"
+              data-projection-trigger="baseline"
+            >
               Baseline build program
             </button>
-            <button type="button" class="usa-button usa-button--outline" data-projection-trigger="accelerated">
+            <button
+              type="button"
+              class="usa-button usa-button--outline"
+              data-projection-trigger="accelerated"
+            >
               Accelerated enterprise lift
             </button>
-            <button type="button" class="usa-button usa-button--outline" data-projection-trigger="field">
+            <button
+              type="button"
+              class="usa-button usa-button--outline"
+              data-projection-trigger="field"
+            >
               Field-ready government ops
             </button>
           </div>
           <div class="grid-row grid-gap-lg">
             <div class="tablet:grid-col-7">
-              <div class="usa-summary-box usa-summary-box--dark ccai-financials__box" role="region" aria-labelledby="financial-metrics-heading">
+              <div
+                class="usa-summary-box usa-summary-box--dark ccai-financials__box"
+                role="region"
+                aria-labelledby="financial-metrics-heading"
+              >
                 <div class="usa-summary-box__body">
-                  <h3 class="usa-summary-box__heading" id="financial-metrics-heading">Capital + revenue plan</h3>
+                  <h3 class="usa-summary-box__heading" id="financial-metrics-heading">
+                    Capital + revenue plan
+                  </h3>
                   <div class="ccai-metric-grid">
                     <div class="ccai-metric" data-trend>
                       <p class="ccai-metric__label">Annual recurring revenue</p>
@@ -788,7 +921,12 @@
                       </li>
                     </ul>
                   </div>
-                  <div class="usa-card__footer ccai-ops__footer" id="ccai-ops-indicator" role="status" aria-live="polite">
+                  <div
+                    class="usa-card__footer ccai-ops__footer"
+                    id="ccai-ops-indicator"
+                    role="status"
+                    aria-live="polite"
+                  >
                     Ops health: <span data-operations-value="health"></span>
                   </div>
                 </div>
@@ -798,7 +936,11 @@
         </div>
       </section>
 
-      <section class="usa-section usa-dark-background ccai-animate-in" aria-labelledby="inquiry-heading" data-ccai-animate>
+      <section
+        class="usa-section usa-dark-background ccai-animate-in"
+        aria-labelledby="inquiry-heading"
+        data-ccai-animate
+      >
         <div class="grid-container">
           <div class="ccai-section-header">
             <p class="ccai-section-header__eyebrow">Partnerships</p>
@@ -808,29 +950,62 @@
             <div class="grid-row grid-gap">
               <div class="tablet:grid-col-6">
                 <label class="usa-label" for="inquiry-name">Full name</label>
-                <input class="usa-input" id="inquiry-name" name="name" autocomplete="name" required />
+                <input
+                  class="usa-input"
+                  id="inquiry-name"
+                  name="name"
+                  autocomplete="name"
+                  required
+                />
               </div>
               <div class="tablet:grid-col-6">
                 <label class="usa-label" for="inquiry-email">Official email</label>
-                <input class="usa-input" id="inquiry-email" name="email" type="email" autocomplete="email" required />
+                <input
+                  class="usa-input"
+                  id="inquiry-email"
+                  name="email"
+                  type="email"
+                  autocomplete="email"
+                  required
+                />
               </div>
             </div>
             <div class="grid-row grid-gap">
               <div class="tablet:grid-col-6">
                 <label class="usa-label" for="inquiry-organization">Organization</label>
-                <input class="usa-input" id="inquiry-organization" name="organization" autocomplete="organization" />
+                <input
+                  class="usa-input"
+                  id="inquiry-organization"
+                  name="organization"
+                  autocomplete="organization"
+                />
               </div>
               <div class="tablet:grid-col-6">
                 <label class="usa-label" for="inquiry-role">Role</label>
-                <input class="usa-input" id="inquiry-role" name="role" autocomplete="organization-title" />
+                <input
+                  class="usa-input"
+                  id="inquiry-role"
+                  name="role"
+                  autocomplete="organization-title"
+                />
               </div>
             </div>
             <label class="usa-label" for="inquiry-message">Mission need</label>
-            <textarea class="usa-textarea" id="inquiry-message" name="message" rows="5" required></textarea>
-            <button class="usa-button usa-button--accent-warm margin-top-3" type="submit">Submit secure request</button>
+            <textarea
+              class="usa-textarea"
+              id="inquiry-message"
+              name="message"
+              rows="5"
+              required
+            ></textarea>
+            <button class="usa-button usa-button--accent-warm margin-top-3" type="submit">
+              Submit secure request
+            </button>
             <div class="usa-alert usa-alert--success margin-top-2" id="ccai-inquiry-success" hidden>
               <div class="usa-alert__body">
-                <p class="usa-alert__text">Request transmitted. A mission specialist will respond shortly.</p>
+                <p class="usa-alert__text">
+                  Request transmitted. A mission specialist will respond shortly.
+                </p>
               </div>
             </div>
           </form>
@@ -838,11 +1013,21 @@
       </section>
     </main>
 
-    <div class="usa-modal ccai-gate" id="ccai-gate" role="dialog" aria-modal="true" aria-labelledby="ccai-gate-heading" aria-describedby="ccai-gate-status" hidden>
+    <div
+      class="usa-modal ccai-gate"
+      id="ccai-gate"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ccai-gate-heading"
+      aria-describedby="ccai-gate-status"
+      hidden
+    >
       <div class="usa-modal__content">
         <div class="usa-modal__main">
           <h2 id="ccai-gate-heading">Numeric Clearance Verification</h2>
-          <p class="usa-intro">Enter the rotating clearance code issued by the CrownCode.ai watch floor.</p>
+          <p class="usa-intro">
+            Enter the rotating clearance code issued by the CrownCode.ai watch floor.
+          </p>
           <div class="ccai-gate__monitor" id="ccai-gate-display">Awaiting input</div>
           <div class="ccai-gate__keypad" role="group" aria-label="Secure numeric keypad">
             <button type="button" data-keypad="1">1</button>
@@ -860,61 +1045,114 @@
           </div>
           <p class="ccai-gate__status" id="ccai-gate-status" role="status" aria-live="polite"></p>
           <div class="usa-button-group">
-            <button type="button" class="usa-button usa-button--accent-warm" data-gate-submit>Verify clearance</button>
-            <button type="button" class="usa-button usa-button--outline" data-modal-close>Cancel</button>
+            <button type="button" class="usa-button usa-button--accent-warm" data-gate-submit>
+              Verify clearance
+            </button>
+            <button type="button" class="usa-button usa-button--outline" data-modal-close>
+              Cancel
+            </button>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="usa-modal" id="ccai-access-modal" role="dialog" aria-modal="true" aria-labelledby="ccai-access-heading" hidden>
+    <div
+      class="usa-modal"
+      id="ccai-access-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ccai-access-heading"
+      hidden
+    >
       <div class="usa-modal__content">
         <div class="usa-modal__main">
           <h2 id="ccai-access-heading">Access Token Verification</h2>
-          <p class="usa-intro">Provide the current alphanumeric token to unlock the secure briefing sequence.</p>
+          <p class="usa-intro">
+            Provide the current alphanumeric token to unlock the secure briefing sequence.
+          </p>
           <form class="usa-form" id="ccai-access-form">
             <label class="usa-label" for="ccai-token-input">Access token</label>
-            <input class="usa-input" id="ccai-token-input" name="token" autocomplete="off" autocapitalize="characters" required />
+            <input
+              class="usa-input"
+              id="ccai-token-input"
+              name="token"
+              autocomplete="off"
+              autocapitalize="characters"
+              required
+            />
             <p class="usa-error-message" id="ccai-token-error" role="alert"></p>
             <div class="usa-button-group">
               <button type="submit" class="usa-button usa-button--accent-warm">Authenticate</button>
-              <button type="button" class="usa-button usa-button--outline" data-modal-close>Cancel</button>
+              <button type="button" class="usa-button usa-button--outline" data-modal-close>
+                Cancel
+              </button>
             </div>
           </form>
         </div>
       </div>
     </div>
 
-    <div class="usa-modal" id="ccai-warning-modal" role="dialog" aria-modal="true" aria-labelledby="ccai-warning-heading" hidden>
+    <div
+      class="usa-modal"
+      id="ccai-warning-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ccai-warning-heading"
+      hidden
+    >
       <div class="usa-modal__content">
         <div class="usa-modal__main">
           <h2 id="ccai-warning-heading">Controlled Material</h2>
           <p>
-            The briefing contains controlled technical data. Confirm you are in an authorized environment and your device meets protection standards.
+            The briefing contains controlled technical data. Confirm you are in an authorized
+            environment and your device meets protection standards.
           </p>
           <div class="usa-alert usa-alert--warning" role="alert">
             <div class="usa-alert__body">
-              <p class="usa-alert__text">Recording, screen capture, and distribution are prohibited. Violations will trigger automatic escalation.</p>
+              <p class="usa-alert__text">
+                Recording, screen capture, and distribution are prohibited. Violations will trigger
+                automatic escalation.
+              </p>
             </div>
           </div>
           <div class="usa-button-group">
-            <button type="button" class="usa-button usa-button--accent-warm" data-brief-proceed>Proceed to brief</button>
-            <button type="button" class="usa-button usa-button--outline" data-modal-close>Cancel</button>
+            <button type="button" class="usa-button usa-button--accent-warm" data-brief-proceed>
+              Proceed to brief
+            </button>
+            <button type="button" class="usa-button usa-button--outline" data-modal-close>
+              Cancel
+            </button>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="usa-modal" id="ccai-beta-modal" role="dialog" aria-modal="true" aria-labelledby="ccai-beta-modal-heading" hidden>
+    <div
+      class="usa-modal"
+      id="ccai-beta-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ccai-beta-modal-heading"
+      hidden
+    >
       <div class="usa-modal__content">
         <div class="usa-modal__main">
           <h2 id="ccai-beta-modal-heading">CrownCode.ai Beta Tester Intake</h2>
-          <p class="usa-intro">Submit your details to receive the beta onboarding packet and clearance questionnaire.</p>
+          <p class="usa-intro">
+            Submit your details to receive the beta onboarding packet and clearance questionnaire.
+          </p>
           <form class="usa-form" id="ccai-beta-form" novalidate>
             <label class="usa-label" for="beta-name">Full name</label>
             <input class="usa-input" id="beta-name" name="name" autocomplete="name" required />
             <label class="usa-label" for="beta-email">Work email</label>
-            <input class="usa-input" id="beta-email" name="email" type="email" autocomplete="email" required />
+            <input
+              class="usa-input"
+              id="beta-email"
+              name="email"
+              type="email"
+              autocomplete="email"
+              required
+            />
             <label class="usa-label" for="beta-role">Operational role</label>
             <input class="usa-input" id="beta-role" name="role" autocomplete="organization-title" />
             <label class="usa-label" for="beta-focus">Program track</label>
@@ -924,14 +1162,26 @@
               <option value="research">Research and analytics partner</option>
             </select>
             <label class="usa-label" for="beta-notes">Testing focus</label>
-            <textarea class="usa-textarea" id="beta-notes" name="notes" rows="4" required></textarea>
+            <textarea
+              class="usa-textarea"
+              id="beta-notes"
+              name="notes"
+              rows="4"
+              required
+            ></textarea>
             <div class="usa-button-group margin-top-2">
-              <button type="submit" class="usa-button usa-button--accent-warm">Submit beta request</button>
-              <button type="button" class="usa-button usa-button--outline" data-modal-close>Cancel</button>
+              <button type="submit" class="usa-button usa-button--accent-warm">
+                Submit beta request
+              </button>
+              <button type="button" class="usa-button usa-button--outline" data-modal-close>
+                Cancel
+              </button>
             </div>
             <div class="usa-alert usa-alert--success margin-top-2" id="ccai-beta-success" hidden>
               <div class="usa-alert__body">
-                <p class="usa-alert__text" id="ccai-beta-success-text">Request received. Beta briefing packet will follow shortly.</p>
+                <p class="usa-alert__text" id="ccai-beta-success-text">
+                  Request received. Beta briefing packet will follow shortly.
+                </p>
               </div>
             </div>
           </form>
@@ -939,99 +1189,122 @@
       </div>
     </div>
 
-    <div class="usa-alert usa-alert--warning ccai-security-toast" id="ccai-security-toast" role="status" aria-live="assertive" data-visible="false">
+    <div
+      class="usa-alert usa-alert--warning ccai-security-toast"
+      id="ccai-security-toast"
+      role="status"
+      aria-live="assertive"
+      data-visible="false"
+    >
       <div class="usa-alert__body">
         <p class="usa-alert__text" id="ccai-security-text">Security notice ready.</p>
       </div>
     </div>
 
-        <footer class="site-footer">
-    <div class="container footer-grid">
-      <div class="footer-brand">
-        <img src="/assets/logos/logo-footer-white.png" alt="Daren Prince" class="footer-logo" />
-        <p class="footer-tagline">Confident, psychology-backed storytelling, systems, and tools for real transformation.</p>
-        <div class="footer-socials">
-          <a href="#" aria-label="Follow on Facebook">
-            <img src="/assets/icons/facebook-32.png" alt="" />
-            <span>Facebook</span>
-          </a>
-          <a href="#" aria-label="Follow on X">
-            <img src="/assets/icons/twitter-x-32.png" alt="" />
-            <span>X (Twitter)</span>
-          </a>
-          <a href="#" aria-label="Follow on YouTube">
-            <img src="/assets/icons/youtube-32.png" alt="" />
-            <span>YouTube</span>
-          </a>
-          <a href="#" aria-label="Follow on TikTok">
-            <img src="/assets/icons/tiktok-32.png" alt="" />
-            <span>TikTok</span>
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div class="footer-brand">
+          <img src="/assets/logos/logo-footer-white.png" alt="Daren Prince" class="footer-logo" />
+          <p class="footer-tagline">
+            Confident, psychology-backed storytelling, systems, and tools for real transformation.
+          </p>
+          <div class="footer-socials">
+            <a href="#" aria-label="Follow on Facebook">
+              <img src="/assets/icons/facebook-32.png" alt="" />
+              <span>Facebook</span>
+            </a>
+            <a href="#" aria-label="Follow on X">
+              <img src="/assets/icons/twitter-x-32.png" alt="" />
+              <span>X (Twitter)</span>
+            </a>
+            <a href="#" aria-label="Follow on YouTube">
+              <img src="/assets/icons/youtube-32.png" alt="" />
+              <span>YouTube</span>
+            </a>
+            <a href="#" aria-label="Follow on TikTok">
+              <img src="/assets/icons/tiktok-32.png" alt="" />
+              <span>TikTok</span>
+            </a>
+          </div>
+        </div>
+        <div>
+          <h4>Explore</h4>
+          <ul class="footer-links">
+            <li><a href="/index.html">Home</a></li>
+            <li><a href="/book.html">Book</a></li>
+            <li><a href="/meet-daren-prince.html">Meet Daren</a></li>
+            <li><a href="/press.html">Press</a></li>
+            <li><a href="/contact.html">Contact</a></li>
+            <li><a href="/sitemap.html">Site Index</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Components</h4>
+          <ul class="footer-links">
+            <li><a href="/components.html">Components</a></li>
+            <li><a href="/themes.html">Themes</a></li>
+            <li><a href="/style-classes.html">Style Classes</a></li>
+            <li><a href="/loaders.html">Loaders</a></li>
+            <li><a href="/promotion-tools.html">Promotion Tools</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Developers</h4>
+          <ul class="footer-links">
+            <li><a href="/iconifty.html">Iconify</a></li>
+            <li><a href="/docs/crownlabsbible/docs/index.html">Crown Labs Docs</a></li>
+            <li>
+              <a href="/docs/crownlabsbible/docs/viewer.html#Documentation%20Platform"
+                >Documentation Platform</a
+              >
+            </li>
+            <li><a href="/style-classes.html">Utility Classes</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Other</h4>
+          <ul class="footer-links">
+            <li><a href="/login.html">Login</a></li>
+            <li><a href="/dashboard.html">Dashboard</a></li>
+            <li><a href="/reset-password.html">Reset Password</a></li>
+            <li><a href="/verify-email.html">Verify Email</a></li>
+            <li><a href="/admin-dashboard.html">Admin Dashboard</a></li>
+            <li><a href="/admin-user-management.html">User Management</a></li>
+          </ul>
+        </div>
+        <div class="footer-signup">
+          <h4>Mailing List</h4>
+          <p class="footer-note">Join for drops, tools, and private updates.</p>
+          <form action="#" method="post">
+            <label for="footer-email-index" class="sr-only">Email address</label>
+            <input
+              id="footer-email-index"
+              name="email"
+              type="email"
+              placeholder="you@email.com"
+              required
+            />
+            <button type="submit" class="primary-btn">Join the List</button>
+          </form>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <div class="footer-bottom-inner">
+          <span>© 2025 Daren Prince. All rights reserved.</span>
+          <a href="/labs.html" class="footer-labs-link">
+            <img src="/labs/assets/crown-labs-logo.png" alt="Crown Labs" class="footer-labs-logo" />
+            <span>Visit Crown Labs</span>
           </a>
         </div>
       </div>
-      <div>
-        <h4>Explore</h4>
-        <ul class="footer-links">
-          <li><a href="/index.html">Home</a></li>
-          <li><a href="/book.html">Book</a></li>
-          <li><a href="/meet-daren-prince.html">Meet Daren</a></li>
-          <li><a href="/press.html">Press</a></li>
-          <li><a href="/contact.html">Contact</a></li>
-          <li><a href="/sitemap.html">Site Index</a></li>
-        </ul>
-      </div>
-      <div>
-        <h4>Components</h4>
-        <ul class="footer-links">
-          <li><a href="/components.html">Components</a></li>
-          <li><a href="/themes.html">Themes</a></li>
-          <li><a href="/style-classes.html">Style Classes</a></li>
-          <li><a href="/loaders.html">Loaders</a></li>
-          <li><a href="/promotion-tools.html">Promotion Tools</a></li>
-        </ul>
-      </div>
-      <div>
-        <h4>Developers</h4>
-        <ul class="footer-links">
-          <li><a href="/iconifty.html">Iconify</a></li>
-          <li><a href="/docs/style-guide.html">Style Guide</a></li>
-          <li><a href="/docs/buttons-demo.html">Buttons Demo</a></li>
-          <li><a href="/style-classes.html">Utility Classes</a></li>
-        </ul>
-      </div>
-      <div>
-        <h4>Other</h4>
-        <ul class="footer-links">
-          <li><a href="/login.html">Login</a></li>
-          <li><a href="/dashboard.html">Dashboard</a></li>
-          <li><a href="/reset-password.html">Reset Password</a></li>
-          <li><a href="/verify-email.html">Verify Email</a></li>
-          <li><a href="/admin-dashboard.html">Admin Dashboard</a></li>
-          <li><a href="/admin-user-management.html">User Management</a></li>
-        </ul>
-      </div>
-      <div class="footer-signup">
-        <h4>Mailing List</h4>
-        <p class="footer-note">Join for drops, tools, and private updates.</p>
-        <form action="#" method="post">
-          <label for="footer-email-index" class="sr-only">Email address</label>
-          <input id="footer-email-index" name="email" type="email" placeholder="you@email.com" required />
-          <button type="submit" class="primary-btn">Join the List</button>
-        </form>
-      </div>
-    </div>
-    <div class="footer-bottom">
-      <div class="footer-bottom-inner">
-        <span>© 2025 Daren Prince. All rights reserved.</span>
-        <a href="/labs.html" class="footer-labs-link">
-          <img src="/labs/assets/crown-labs-logo.png" alt="Crown Labs" class="footer-labs-logo" />
-          <span>Visit Crown Labs</span>
-        </a>
-      </div>
-    </div>
-  </footer>
+    </footer>
 
-    <script src="https://cdn.designsystem.digital.gov/uswds@3.7.2/js/uswds.min.js" integrity="sha384-kW2kRl6VwB3Q+VQwlREYVeuN1m5/27uwXCYxULqYwL5DL1uMFsQPiQf5Mcd6Pva9" crossorigin="anonymous" defer></script>
+    <script
+      src="https://cdn.designsystem.digital.gov/uswds@3.7.2/js/uswds.min.js"
+      integrity="sha384-kW2kRl6VwB3Q+VQwlREYVeuN1m5/27uwXCYxULqYwL5DL1uMFsQPiQf5Mcd6Pva9"
+      crossorigin="anonymous"
+      defer
+    ></script>
     <script type="module" src="scripts/ccai.js"></script>
   </body>
 </html>

--- a/labs/index.html
+++ b/labs/index.html
@@ -45,7 +45,60 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
+    <script src="https://code.iconify.design/iconify-icon/2.1.0/iconify-icon.min.js"></script>
     <link rel="stylesheet" href="../assets/labs.css" />
+
+    <style>
+      .labs-menu-toggle {
+        display: none;
+        align-items: center;
+        justify-content: center;
+        width: 42px;
+        height: 42px;
+        border: 1px solid rgba(231, 237, 246, 0.16);
+        background: rgba(18, 26, 39, 0.84);
+        color: var(--text);
+        font-size: 1.35rem;
+      }
+      .site-menu a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        border-radius: 999px;
+      }
+      .site-menu iconify-icon {
+        color: var(--accent);
+        font-size: 1.05rem;
+      }
+      @media (max-width: 860px) {
+        .header-inner {
+          position: relative;
+        }
+        .labs-menu-toggle {
+          display: inline-flex;
+        }
+        .site-menu {
+          position: absolute;
+          top: calc(100% + 10px);
+          left: 20px;
+          right: 20px;
+          display: none;
+          flex-direction: column;
+          gap: 8px;
+          padding: 12px;
+          border: 1px solid var(--line);
+          background: rgba(8, 12, 19, 0.98);
+          box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+        }
+        .labs-header.nav-open .site-menu {
+          display: flex;
+        }
+        .site-menu a {
+          justify-content: flex-start;
+          padding: 13px 14px;
+        }
+      }
+    </style>
   </head>
   <body id="top" class="labs-landing">
     <div class="scroll-progress" aria-hidden="true"></div>
@@ -55,12 +108,40 @@
           <img src="assets/crown-labs-logo.png" alt="Crown Labs" class="logo" />
           <span>Crown Labs</span>
         </a>
-        <nav class="site-menu" aria-label="Crown Labs landing navigation">
-          <a href="#crown-labs">Crown Labs</a>
-          <a href="#crowncode">CrownCode.ai</a>
-          <a href="#products">Products</a>
-          <a href="#founder">Founder</a>
-          <a href="../docs/">Docs</a>
+        <button
+          class="labs-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="labs-site-menu"
+          aria-label="Open Crown Labs navigation"
+        >
+          <iconify-icon icon="tabler:menu-2" aria-hidden="true"></iconify-icon>
+        </button>
+        <nav class="site-menu" id="labs-site-menu" aria-label="Crown Labs navigation">
+          <a href="#top"
+            ><iconify-icon icon="tabler:home-2" aria-hidden="true"></iconify-icon
+            ><span>Home</span></a
+          >
+          <a href="#products"
+            ><iconify-icon icon="tabler:box" aria-hidden="true"></iconify-icon
+            ><span>Products</span></a
+          >
+          <a href="#crowncode"
+            ><iconify-icon icon="tabler:cpu-2" aria-hidden="true"></iconify-icon
+            ><span>Technology</span></a
+          >
+          <a href="#founder"
+            ><iconify-icon icon="tabler:crown" aria-hidden="true"></iconify-icon
+            ><span>Founder</span></a
+          >
+          <a href="../docs/crownlabsbible/docs/index.html"
+            ><iconify-icon icon="tabler:file-text" aria-hidden="true"></iconify-icon
+            ><span>Documentation</span></a
+          >
+          <a href="mailto:apps@crownlabs.tech"
+            ><iconify-icon icon="tabler:mail" aria-hidden="true"></iconify-icon
+            ><span>Contact</span></a
+          >
         </nav>
       </div>
     </header>
@@ -79,8 +160,12 @@
             replacing the canonical documentation that governs it.
           </p>
           <div class="hero-actions" aria-label="Primary documentation links">
-            <a class="primary-link" href="../docs/">Enter documentation</a>
-            <a class="secondary-link" href="../docs/crownlabsbible/">Open Crown Labs Bible</a>
+            <a class="primary-link" href="../docs/crownlabsbible/docs/index.html"
+              >Enter documentation</a
+            >
+            <a class="secondary-link" href="../docs/crownlabsbible/docs/index.html"
+              >Open Crown Labs Bible</a
+            >
           </div>
         </div>
         <aside class="hero-panel" aria-label="Documentation gateway">
@@ -125,9 +210,7 @@
             <a class="primary-link compact" href="products/crowncode-ai.html"
               >View CrownCode.ai brief</a
             >
-            <a
-              class="secondary-link compact"
-              href="../docs/crownlabsbible/02-products/crowncode-ai.md"
+            <a class="secondary-link compact" href="../docs/crownlabsbible/docs/crowncode-ai.html"
               >Read source dossier</a
             >
           </div>
@@ -177,7 +260,9 @@
             <p class="eyebrow">Products</p>
             <h2 id="products-title">Portfolio display, generated from the Crown Labs Bible.</h2>
           </div>
-          <a class="text-link" href="../docs/crownlabsbible/">Review source documentation</a>
+          <a class="text-link" href="../docs/crownlabsbible/docs/index.html"
+            >Review source documentation</a
+          >
         </div>
         <p class="section-note">
           These cards are discovery previews, not duplicate documentation. Open an individual brief
@@ -199,7 +284,9 @@
           </p>
           <div class="founder-links">
             <a class="text-link" href="../meet-daren-prince.html">Meet Daren</a>
-            <a class="text-link muted" href="../docs/crownlabsbible/README.md"
+            <a
+              class="text-link muted"
+              href="../docs/crownlabsbible/docs/viewer.html#Documentation%20Platform"
               >Crown Labs documentation source</a
             >
           </div>
@@ -210,8 +297,12 @@
             For deeper exploration, use the documentation paths below. They remain the canonical
             places for architecture, product detail, operating standards, and source governance.
           </p>
-          <a class="primary-link compact" href="../docs/">/docs/</a>
-          <a class="secondary-link compact" href="../docs/crownlabsbible/">/docs/crownlabsbible/</a>
+          <a class="primary-link compact" href="../docs/crownlabsbible/docs/index.html"
+            >Crown Labs docs app</a
+          >
+          <a class="secondary-link compact" href="../docs/crownlabsbible/docs/index.html"
+            >Crown Labs Bible app</a
+          >
         </div>
       </section>
     </main>
@@ -224,5 +315,49 @@
     </footer>
 
     <script src="../assets/labs.js" defer data-labs-data="../assets/labs-data.json"></script>
+
+    <script>
+      ;(() => {
+        const header = document.querySelector('.labs-header')
+        const toggle = document.querySelector('.labs-menu-toggle')
+        const menu = document.getElementById('labs-site-menu')
+        const docsApp = '../docs/crownlabsbible/docs/index.html'
+        if (toggle && header && menu) {
+          const close = () => {
+            header.classList.remove('nav-open')
+            toggle.setAttribute('aria-expanded', 'false')
+          }
+          toggle.addEventListener('click', () => {
+            const open = !header.classList.contains('nav-open')
+            header.classList.toggle('nav-open', open)
+            toggle.setAttribute('aria-expanded', String(open))
+          })
+          menu.addEventListener('click', (event) => {
+            if (event.target.closest('a')) close()
+          })
+          document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') close()
+          })
+          document.addEventListener('click', (event) => {
+            if (!header.contains(event.target)) close()
+          })
+        }
+        const normalizeDocumentationLinks = () => {
+          document.querySelectorAll('a[href]').forEach((link) => {
+            const href = link.getAttribute('href') || ''
+            if (href === '../docs/' || href === '../docs/crownlabsbible/' || href.endsWith('.md')) {
+              link.setAttribute('href', docsApp)
+              if (/source dossier/i.test(link.textContent || ''))
+                link.textContent = 'Open documentation app'
+            }
+          })
+        }
+        normalizeDocumentationLinks()
+        new MutationObserver(normalizeDocumentationLinks).observe(document.body, {
+          childList: true,
+          subtree: true,
+        })
+      })()
+    </script>
   </body>
 </html>

--- a/labs/products/ai-cherry-pie.html
+++ b/labs/products/ai-cherry-pie.html
@@ -1,102 +1,318 @@
 <!doctype html>
 <html lang="en" data-theme="dark">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-  <title>AI Cherry Pie | Crown Labs</title>
-  <meta name="description" content="AI Cherry Pie is a writing reconstruction engine designed to identify, reduce, and remove detectable AI writing fingerprints while restoring natural human flow, emotional realism, conversational rhythm, and believable language structure." />
-  <meta name="theme-color" content="#0b0f17" />
-  <link rel="canonical" href="https://www.darenprince.com/labs/products/ai-cherry-pie.html" />
-  <meta property="og:type" content="article" />
-  <meta property="og:title" content="AI Cherry Pie | Crown Labs" />
-  <meta property="og:description" content="AI Cherry Pie is a writing reconstruction engine designed to identify, reduce, and remove detectable AI writing fingerprints while restoring natural human flow, emotional realism, conversational rhythm, and believable language structure." />
-  <meta property="og:url" content="https://www.darenprince.com/labs/products/ai-cherry-pie.html" />
-  <meta property="og:image" content="https://www.darenprince.com/labs/assets/labs-opengraph.svg" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="AI Cherry Pie | Crown Labs" />
-  <meta name="twitter:description" content="AI Cherry Pie is a writing reconstruction engine designed to identify, reduce, and remove detectable AI writing fingerprints while restoring natural human flow, emotional realism, conversational rhythm, and believable language structure." />
-  <meta name="twitter:image" content="https://www.darenprince.com/labs/assets/labs-opengraph.svg" />
-  <link rel="icon" type="image/svg+xml" href="../assets/labs-favicon.svg" />
-  <link rel="stylesheet" href="../../assets/labs-product.css" />
-</head>
-<body class="theme-dark product-page">
-  <header class="top-nav">
-    <div class="nav-brand">
-      <img src="../assets/crown-labs-logo.png" alt="Crown Labs" />
-      <div>
-        <strong>AI Cherry Pie</strong>
-        <div class="footer-note">Sourced from docs/crownlabsbible/04-product-dossiers/ai-cherry-pie/overview.md</div>
-      </div>
-    </div>
-    <div class="nav-actions">
-      <a class="back-link" href="../#products">Back to Labs</a>
-      <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
-      <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
-    </div>
-  </header>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>AI Cherry Pie | Crown Labs</title>
+    <meta
+      name="description"
+      content="AI Cherry Pie is a writing reconstruction engine designed to identify, reduce, and remove detectable AI writing fingerprints while restoring natural human flow, emotional realism, conversational rhythm, and believable language structure."
+    />
+    <meta name="theme-color" content="#0b0f17" />
+    <link rel="canonical" href="https://www.darenprince.com/labs/products/ai-cherry-pie.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="AI Cherry Pie | Crown Labs" />
+    <meta
+      property="og:description"
+      content="AI Cherry Pie is a writing reconstruction engine designed to identify, reduce, and remove detectable AI writing fingerprints while restoring natural human flow, emotional realism, conversational rhythm, and believable language structure."
+    />
+    <meta
+      property="og:url"
+      content="https://www.darenprince.com/labs/products/ai-cherry-pie.html"
+    />
+    <meta
+      property="og:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="AI Cherry Pie | Crown Labs" />
+    <meta
+      name="twitter:description"
+      content="AI Cherry Pie is a writing reconstruction engine designed to identify, reduce, and remove detectable AI writing fingerprints while restoring natural human flow, emotional realism, conversational rhythm, and believable language structure."
+    />
+    <meta
+      name="twitter:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <link rel="icon" type="image/svg+xml" href="../assets/labs-favicon.svg" />
+    <script src="https://code.iconify.design/iconify-icon/2.1.0/iconify-icon.min.js"></script>
+    <link rel="stylesheet" href="../../assets/labs-product.css" />
 
-  <main>
-    <section class="product-hero">
-      <div>
-        <div class="hero-tags">
-          <span class="tag">Functional standalone software product and framework</span>
-          <span class="tag">Writing reconstruction and language refinement platform</span>
+    <style>
+      .top-nav {
+        gap: 1rem;
+      }
+      .nav-actions {
+        align-items: center;
+      }
+      .product-menu-toggle {
+        display: none;
+        align-items: center;
+        justify-content: center;
+        width: 42px;
+        height: 42px;
+        border: 1px solid rgba(231, 237, 246, 0.16);
+        background: rgba(18, 26, 39, 0.84);
+        color: currentColor;
+        font-size: 1.35rem;
+      }
+      .modern-product-nav {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 0.5rem;
+      }
+      .modern-product-nav a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.42rem;
+      }
+      .modern-product-nav iconify-icon {
+        color: #8ea2ff;
+        font-size: 1.02rem;
+      }
+      @media (max-width: 860px) {
+        .top-nav {
+          position: sticky;
+          top: 0;
+          z-index: 50;
+        }
+        .product-menu-toggle {
+          display: inline-flex;
+        }
+        .nav-actions {
+          position: relative;
+          margin-left: auto;
+        }
+        .modern-product-nav {
+          position: absolute;
+          top: calc(100% + 10px);
+          right: 0;
+          min-width: min(82vw, 320px);
+          display: none;
+          flex-direction: column;
+          padding: 12px;
+          border: 1px solid rgba(231, 237, 246, 0.16);
+          background: rgba(8, 12, 19, 0.98);
+          box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+        }
+        .top-nav.nav-open .modern-product-nav {
+          display: flex;
+        }
+        .modern-product-nav a {
+          justify-content: flex-start;
+          padding: 12px 14px;
+        }
+      }
+    </style>
+  </head>
+  <body class="theme-dark product-page">
+    <header class="top-nav">
+      <div class="nav-brand">
+        <img src="../assets/crown-labs-logo.png" alt="Crown Labs" />
+        <div>
+          <strong>AI Cherry Pie</strong>
+          <div class="footer-note">Sourced from Crown Labs Bible documentation application.</div>
         </div>
-        <h1>AI Cherry Pie</h1>
-        <p class="subtitle">AI Cherry Pie is a writing reconstruction engine designed to identify, reduce, and remove detectable AI writing fingerprints while restoring natural human flow, emotional realism, conversational rhythm, and believable language structure.</p>
-        <p>AI Cherry Pie is a writing reconstruction engine designed to identify, reduce, and remove detectable AI writing fingerprints while restoring natural human flow, emotional realism, conversational rhythm, and believable language structure.</p>
-        <div class="access-actions">
-          <a class="primary-btn" href="../../docs/crownlabsbible/04-product-dossiers/ai-cherry-pie/overview.md">Open canonical dossier</a>
-          <a class="ghost-btn" href="../#products">Explore Labs</a>
+      </div>
+      <div class="nav-actions">
+        <button
+          class="product-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="product-site-menu"
+          aria-label="Open Crown Labs navigation"
+        >
+          <iconify-icon icon="tabler:menu-2" aria-hidden="true"></iconify-icon>
+        </button>
+        <nav class="modern-product-nav" id="product-site-menu" aria-label="Crown Labs navigation">
+          <a class="back-link" href="../"
+            ><iconify-icon icon="tabler:home-2" aria-hidden="true"></iconify-icon
+            ><span>Home</span></a
+          >
+          <a class="back-link" href="../#products"
+            ><iconify-icon icon="tabler:box" aria-hidden="true"></iconify-icon
+            ><span>Products</span></a
+          >
+          <a class="back-link" href="../#crowncode"
+            ><iconify-icon icon="tabler:cpu-2" aria-hidden="true"></iconify-icon
+            ><span>Technology</span></a
+          >
+          <a class="back-link" href="../#founder"
+            ><iconify-icon icon="tabler:crown" aria-hidden="true"></iconify-icon
+            ><span>Founder</span></a
+          >
+          <a class="back-link" href="../../docs/crownlabsbible/docs/index.html"
+            ><iconify-icon icon="tabler:file-text" aria-hidden="true"></iconify-icon
+            ><span>Documentation</span></a
+          >
+          <a class="back-link" href="mailto:apps@crownlabs.tech"
+            ><iconify-icon icon="tabler:mail" aria-hidden="true"></iconify-icon
+            ><span>Contact</span></a
+          >
+          <button
+            class="theme-toggle"
+            id="theme-toggle"
+            type="button"
+            aria-pressed="false"
+            aria-label="Toggle light and dark mode"
+          >
+            Theme
+          </button>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="product-hero">
+        <div>
+          <div class="hero-tags">
+            <span class="tag">Functional standalone software product and framework</span>
+            <span class="tag">Writing reconstruction and language refinement platform</span>
+          </div>
+          <h1>AI Cherry Pie</h1>
+          <p class="subtitle">
+            AI Cherry Pie is a writing reconstruction engine designed to identify, reduce, and
+            remove detectable AI writing fingerprints while restoring natural human flow, emotional
+            realism, conversational rhythm, and believable language structure.
+          </p>
+          <p>
+            AI Cherry Pie is a writing reconstruction engine designed to identify, reduce, and
+            remove detectable AI writing fingerprints while restoring natural human flow, emotional
+            realism, conversational rhythm, and believable language structure.
+          </p>
+          <div class="access-actions">
+            <a
+              class="primary-btn"
+              href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/ai-cherry-pie/overview.md#Overview"
+              >Open documentation app</a
+            >
+            <a class="ghost-btn" href="../#products">Explore Labs</a>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <section class="panel-grid">
-      <div class="panel-card">
-        <h2>Canonical status</h2>
-        <p><strong>Status:</strong> Functional standalone software product and framework</p>
-        <p><strong>Classification:</strong> Executable software utility, subscription capable platform, and licensing ready language engine</p>
-        <p><strong>Readiness signal:</strong> 68% documentation readiness signal</p>
-      </div>
-      <div class="panel-card">
-        <h2>Source governance</h2>
-        <p><strong>Authority:</strong> docs/crownlabsbible/</p>
-        <p><strong>Source file:</strong> docs/crownlabsbible/04-product-dossiers/ai-cherry-pie/overview.md</p>
-        <p><strong>Update rule:</strong> edit the dossier first, then regenerate metadata.</p>
-      </div>
-      <div class="panel-card">
-        <h2>Valuation reference</h2>
-        <p>$500,000 to $1,500,000</p>
-        <p class="footer-note">Financial language remains directional and must be verified against canonical valuation dossiers.</p>
-      </div>
-    </section>
+      <section class="panel-grid">
+        <div class="panel-card">
+          <h2>Canonical status</h2>
+          <p><strong>Status:</strong> Functional standalone software product and framework</p>
+          <p>
+            <strong>Classification:</strong> Executable software utility, subscription capable
+            platform, and licensing ready language engine
+          </p>
+          <p><strong>Readiness signal:</strong> 68% documentation readiness signal</p>
+        </div>
+        <div class="panel-card">
+          <h2>Source governance</h2>
+          <p><strong>Authority:</strong> Crown Labs Bible documentation application</p>
+          <p>
+            <strong>Documentation route:</strong>
+            <a
+              href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/ai-cherry-pie/overview.md#Overview"
+              >Crown Labs Bible viewer</a
+            >
+          </p>
+          <p><strong>Update rule:</strong> edit the dossier first, then regenerate metadata.</p>
+        </div>
+        <div class="panel-card">
+          <h2>Valuation reference</h2>
+          <p>$500,000 to $1,500,000</p>
+          <p class="footer-note">
+            Financial language remains directional and must be verified against canonical valuation
+            dossiers.
+          </p>
+        </div>
+      </section>
 
-    <section class="section-block">
-      <h2>What it is</h2>
-      <p>AI Cherry Pie is a writing reconstruction engine designed to identify, reduce, and remove detectable AI writing fingerprints while restoring natural human flow, emotional realism, conversational rhythm, and believable language structure.</p><p>The platform functions as both:</p><p>Unlike traditional AI writing tools that optimize primarily for speed or polish, AI Cherry Pie focuses on believability, readability, emotional texture, and human sounding communication.</p>
-    </section>
+      <section class="section-block">
+        <h2>What it is</h2>
+        <p>
+          AI Cherry Pie is a writing reconstruction engine designed to identify, reduce, and remove
+          detectable AI writing fingerprints while restoring natural human flow, emotional realism,
+          conversational rhythm, and believable language structure.
+        </p>
+        <p>The platform functions as both:</p>
+        <p>
+          Unlike traditional AI writing tools that optimize primarily for speed or polish, AI Cherry
+          Pie focuses on believability, readability, emotional texture, and human sounding
+          communication.
+        </p>
+      </section>
 
-    <section class="panel-grid">
-      <div class="panel-card">
-        <h2>Product signals</h2>
-        <ul><li>a standalone software utility</li><li>and a reusable language reconstruction framework inside the broader Crown Labs ecosystem</li></ul>
-      </div>
-      <div class="panel-card">
-        <h2>Core capabilities</h2>
-        <ul><li>repetitive phrasing</li><li>synthetic cadence</li><li>robotic pacing</li><li>over structured transitions</li><li>detectable language model patterns</li><li>conversational rhythm</li><li>sentence variation</li><li>emotional pacing</li></ul>
-      </div>
-      <div class="panel-card">
-        <h2>Metadata checks</h2>
-        <ul><li><strong>Canonical source:</strong> docs/crownlabsbible/04-product-dossiers/ai-cherry-pie/overview.md</li><li><strong>Classification:</strong> Writing reconstruction and language refinement platform</li><li><strong>Status:</strong> Functional standalone software product and framework</li></ul>
-      </div>
-    </section>
-  </main>
+      <section class="panel-grid">
+        <div class="panel-card">
+          <h2>Product signals</h2>
+          <ul>
+            <li>a standalone software utility</li>
+            <li>
+              and a reusable language reconstruction framework inside the broader Crown Labs
+              ecosystem
+            </li>
+          </ul>
+        </div>
+        <div class="panel-card">
+          <h2>Core capabilities</h2>
+          <ul>
+            <li>repetitive phrasing</li>
+            <li>synthetic cadence</li>
+            <li>robotic pacing</li>
+            <li>over structured transitions</li>
+            <li>detectable language model patterns</li>
+            <li>conversational rhythm</li>
+            <li>sentence variation</li>
+            <li>emotional pacing</li>
+          </ul>
+        </div>
+        <div class="panel-card">
+          <h2>Metadata checks</h2>
+          <ul>
+            <li>
+              <strong>Canonical route:</strong>
+              <a
+                href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/ai-cherry-pie/overview.md#Overview"
+                >Crown Labs Bible documentation app</a
+              >
+            </li>
+            <li>
+              <strong>Classification:</strong> Writing reconstruction and language refinement
+              platform
+            </li>
+            <li><strong>Status:</strong> Functional standalone software product and framework</li>
+          </ul>
+        </div>
+      </section>
+    </main>
 
-  <footer class="product-footer">
-    <p>© Crown Labs • Generated from canonical Crown Labs Bible metadata.</p>
-  </footer>
+    <footer class="product-footer">
+      <p>© Crown Labs • Generated from canonical Crown Labs Bible metadata.</p>
+    </footer>
 
-  <script src="../../assets/labs-product.js" defer></script>
-</body>
+    <script>
+      ;(() => {
+        const header = document.querySelector('.top-nav')
+        const toggle = document.querySelector('.product-menu-toggle')
+        const menu = document.getElementById('product-site-menu')
+        if (!header || !toggle || !menu) return
+        const close = () => {
+          header.classList.remove('nav-open')
+          toggle.setAttribute('aria-expanded', 'false')
+        }
+        toggle.addEventListener('click', () => {
+          const open = !header.classList.contains('nav-open')
+          header.classList.toggle('nav-open', open)
+          toggle.setAttribute('aria-expanded', String(open))
+        })
+        menu.addEventListener('click', (event) => {
+          if (event.target.closest('a')) close()
+        })
+        document.addEventListener('keydown', (event) => {
+          if (event.key === 'Escape') close()
+        })
+        document.addEventListener('click', (event) => {
+          if (!header.contains(event.target)) close()
+        })
+      })()
+    </script>
+    <script src="../../assets/labs-product.js" defer></script>
+  </body>
 </html>

--- a/labs/products/crown-psychology.html
+++ b/labs/products/crown-psychology.html
@@ -1,102 +1,324 @@
 <!doctype html>
 <html lang="en" data-theme="dark">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-  <title>Crown Psychology | Crown Labs</title>
-  <meta name="description" content="Crown Psychology is an emotionally intelligent behavioral growth platform designed to help users better understand themselves, recognize patterns, improve emotional awareness, and actively work toward measurable personal growth." />
-  <meta name="theme-color" content="#0b0f17" />
-  <link rel="canonical" href="https://www.darenprince.com/labs/products/crown-psychology.html" />
-  <meta property="og:type" content="article" />
-  <meta property="og:title" content="Crown Psychology | Crown Labs" />
-  <meta property="og:description" content="Crown Psychology is an emotionally intelligent behavioral growth platform designed to help users better understand themselves, recognize patterns, improve emotional awareness, and actively work toward measurable personal growth." />
-  <meta property="og:url" content="https://www.darenprince.com/labs/products/crown-psychology.html" />
-  <meta property="og:image" content="https://www.darenprince.com/labs/assets/labs-opengraph.svg" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Crown Psychology | Crown Labs" />
-  <meta name="twitter:description" content="Crown Psychology is an emotionally intelligent behavioral growth platform designed to help users better understand themselves, recognize patterns, improve emotional awareness, and actively work toward measurable personal growth." />
-  <meta name="twitter:image" content="https://www.darenprince.com/labs/assets/labs-opengraph.svg" />
-  <link rel="icon" type="image/svg+xml" href="../assets/labs-favicon.svg" />
-  <link rel="stylesheet" href="../../assets/labs-product.css" />
-</head>
-<body class="theme-dark product-page">
-  <header class="top-nav">
-    <div class="nav-brand">
-      <img src="../assets/crown-labs-logo.png" alt="Crown Labs" />
-      <div>
-        <strong>Crown Psychology</strong>
-        <div class="footer-note">Sourced from docs/crownlabsbible/04-product-dossiers/crown-psychology/overview.md</div>
-      </div>
-    </div>
-    <div class="nav-actions">
-      <a class="back-link" href="../#products">Back to Labs</a>
-      <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
-      <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
-    </div>
-  </header>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Crown Psychology | Crown Labs</title>
+    <meta
+      name="description"
+      content="Crown Psychology is an emotionally intelligent behavioral growth platform designed to help users better understand themselves, recognize patterns, improve emotional awareness, and actively work toward measurable personal growth."
+    />
+    <meta name="theme-color" content="#0b0f17" />
+    <link rel="canonical" href="https://www.darenprince.com/labs/products/crown-psychology.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="Crown Psychology | Crown Labs" />
+    <meta
+      property="og:description"
+      content="Crown Psychology is an emotionally intelligent behavioral growth platform designed to help users better understand themselves, recognize patterns, improve emotional awareness, and actively work toward measurable personal growth."
+    />
+    <meta
+      property="og:url"
+      content="https://www.darenprince.com/labs/products/crown-psychology.html"
+    />
+    <meta
+      property="og:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Crown Psychology | Crown Labs" />
+    <meta
+      name="twitter:description"
+      content="Crown Psychology is an emotionally intelligent behavioral growth platform designed to help users better understand themselves, recognize patterns, improve emotional awareness, and actively work toward measurable personal growth."
+    />
+    <meta
+      name="twitter:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <link rel="icon" type="image/svg+xml" href="../assets/labs-favicon.svg" />
+    <script src="https://code.iconify.design/iconify-icon/2.1.0/iconify-icon.min.js"></script>
+    <link rel="stylesheet" href="../../assets/labs-product.css" />
 
-  <main>
-    <section class="product-hero">
-      <div>
-        <div class="hero-tags">
-          <span class="tag">Advanced active platform architecture with production deployment infrastructure</span>
-          <span class="tag">Behavioral intelligence and self improvement platform</span>
+    <style>
+      .top-nav {
+        gap: 1rem;
+      }
+      .nav-actions {
+        align-items: center;
+      }
+      .product-menu-toggle {
+        display: none;
+        align-items: center;
+        justify-content: center;
+        width: 42px;
+        height: 42px;
+        border: 1px solid rgba(231, 237, 246, 0.16);
+        background: rgba(18, 26, 39, 0.84);
+        color: currentColor;
+        font-size: 1.35rem;
+      }
+      .modern-product-nav {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 0.5rem;
+      }
+      .modern-product-nav a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.42rem;
+      }
+      .modern-product-nav iconify-icon {
+        color: #8ea2ff;
+        font-size: 1.02rem;
+      }
+      @media (max-width: 860px) {
+        .top-nav {
+          position: sticky;
+          top: 0;
+          z-index: 50;
+        }
+        .product-menu-toggle {
+          display: inline-flex;
+        }
+        .nav-actions {
+          position: relative;
+          margin-left: auto;
+        }
+        .modern-product-nav {
+          position: absolute;
+          top: calc(100% + 10px);
+          right: 0;
+          min-width: min(82vw, 320px);
+          display: none;
+          flex-direction: column;
+          padding: 12px;
+          border: 1px solid rgba(231, 237, 246, 0.16);
+          background: rgba(8, 12, 19, 0.98);
+          box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+        }
+        .top-nav.nav-open .modern-product-nav {
+          display: flex;
+        }
+        .modern-product-nav a {
+          justify-content: flex-start;
+          padding: 12px 14px;
+        }
+      }
+    </style>
+  </head>
+  <body class="theme-dark product-page">
+    <header class="top-nav">
+      <div class="nav-brand">
+        <img src="../assets/crown-labs-logo.png" alt="Crown Labs" />
+        <div>
+          <strong>Crown Psychology</strong>
+          <div class="footer-note">Sourced from Crown Labs Bible documentation application.</div>
         </div>
-        <h1>Crown Psychology</h1>
-        <p class="subtitle">Crown Psychology is an emotionally intelligent behavioral growth platform designed to help users better understand themselves, recognize patterns, improve emotional awareness, and actively work toward measurable personal growth.</p>
-        <p>Crown Psychology is an emotionally intelligent behavioral growth platform designed to help users better understand themselves, recognize patterns, improve emotional awareness, and actively work toward measurable personal growth.</p>
-        <div class="access-actions">
-          <a class="primary-btn" href="../../docs/crownlabsbible/04-product-dossiers/crown-psychology/overview.md">Open canonical dossier</a>
-          <a class="ghost-btn" href="../#products">Explore Labs</a>
+      </div>
+      <div class="nav-actions">
+        <button
+          class="product-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="product-site-menu"
+          aria-label="Open Crown Labs navigation"
+        >
+          <iconify-icon icon="tabler:menu-2" aria-hidden="true"></iconify-icon>
+        </button>
+        <nav class="modern-product-nav" id="product-site-menu" aria-label="Crown Labs navigation">
+          <a class="back-link" href="../"
+            ><iconify-icon icon="tabler:home-2" aria-hidden="true"></iconify-icon
+            ><span>Home</span></a
+          >
+          <a class="back-link" href="../#products"
+            ><iconify-icon icon="tabler:box" aria-hidden="true"></iconify-icon
+            ><span>Products</span></a
+          >
+          <a class="back-link" href="../#crowncode"
+            ><iconify-icon icon="tabler:cpu-2" aria-hidden="true"></iconify-icon
+            ><span>Technology</span></a
+          >
+          <a class="back-link" href="../#founder"
+            ><iconify-icon icon="tabler:crown" aria-hidden="true"></iconify-icon
+            ><span>Founder</span></a
+          >
+          <a class="back-link" href="../../docs/crownlabsbible/docs/index.html"
+            ><iconify-icon icon="tabler:file-text" aria-hidden="true"></iconify-icon
+            ><span>Documentation</span></a
+          >
+          <a class="back-link" href="mailto:apps@crownlabs.tech"
+            ><iconify-icon icon="tabler:mail" aria-hidden="true"></iconify-icon
+            ><span>Contact</span></a
+          >
+          <button
+            class="theme-toggle"
+            id="theme-toggle"
+            type="button"
+            aria-pressed="false"
+            aria-label="Toggle light and dark mode"
+          >
+            Theme
+          </button>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="product-hero">
+        <div>
+          <div class="hero-tags">
+            <span class="tag"
+              >Advanced active platform architecture with production deployment infrastructure</span
+            >
+            <span class="tag">Behavioral intelligence and self improvement platform</span>
+          </div>
+          <h1>Crown Psychology</h1>
+          <p class="subtitle">
+            Crown Psychology is an emotionally intelligent behavioral growth platform designed to
+            help users better understand themselves, recognize patterns, improve emotional
+            awareness, and actively work toward measurable personal growth.
+          </p>
+          <p>
+            Crown Psychology is an emotionally intelligent behavioral growth platform designed to
+            help users better understand themselves, recognize patterns, improve emotional
+            awareness, and actively work toward measurable personal growth.
+          </p>
+          <div class="access-actions">
+            <a
+              class="primary-btn"
+              href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crown-psychology/overview.md#Overview"
+              >Open documentation app</a
+            >
+            <a class="ghost-btn" href="../#products">Explore Labs</a>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <section class="panel-grid">
-      <div class="panel-card">
-        <h2>Canonical status</h2>
-        <p><strong>Status:</strong> Advanced active platform architecture with production deployment infrastructure</p>
-        <p><strong>Classification:</strong> AI assisted behavioral guidance ecosystem and emotionally intelligent self improvement platform</p>
-        <p><strong>Readiness signal:</strong> 82% documentation readiness signal</p>
-      </div>
-      <div class="panel-card">
-        <h2>Source governance</h2>
-        <p><strong>Authority:</strong> docs/crownlabsbible/</p>
-        <p><strong>Source file:</strong> docs/crownlabsbible/04-product-dossiers/crown-psychology/overview.md</p>
-        <p><strong>Update rule:</strong> edit the dossier first, then regenerate metadata.</p>
-      </div>
-      <div class="panel-card">
-        <h2>Valuation reference</h2>
-        <p>$2,000,000 to $6,000,000</p>
-        <p class="footer-note">Financial language remains directional and must be verified against canonical valuation dossiers.</p>
-      </div>
-    </section>
+      <section class="panel-grid">
+        <div class="panel-card">
+          <h2>Canonical status</h2>
+          <p>
+            <strong>Status:</strong> Advanced active platform architecture with production
+            deployment infrastructure
+          </p>
+          <p>
+            <strong>Classification:</strong> AI assisted behavioral guidance ecosystem and
+            emotionally intelligent self improvement platform
+          </p>
+          <p><strong>Readiness signal:</strong> 82% documentation readiness signal</p>
+        </div>
+        <div class="panel-card">
+          <h2>Source governance</h2>
+          <p><strong>Authority:</strong> Crown Labs Bible documentation application</p>
+          <p>
+            <strong>Documentation route:</strong>
+            <a
+              href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crown-psychology/overview.md#Overview"
+              >Crown Labs Bible viewer</a
+            >
+          </p>
+          <p><strong>Update rule:</strong> edit the dossier first, then regenerate metadata.</p>
+        </div>
+        <div class="panel-card">
+          <h2>Valuation reference</h2>
+          <p>$2,000,000 to $6,000,000</p>
+          <p class="footer-note">
+            Financial language remains directional and must be verified against canonical valuation
+            dossiers.
+          </p>
+        </div>
+      </section>
 
-    <section class="section-block">
-      <h2>What it is</h2>
-      <p>Crown Psychology is an emotionally intelligent behavioral growth platform designed to help users better understand themselves, recognize patterns, improve emotional awareness, and actively work toward measurable personal growth.</p><p>The platform combines:</p><p>Unlike passive wellness applications focused only on mood tracking, Crown Psychology is designed to function as an interactive self improvement ecosystem that actively helps users move toward healthier behavioral patterns and stronger self awareness.</p>
-    </section>
+      <section class="section-block">
+        <h2>What it is</h2>
+        <p>
+          Crown Psychology is an emotionally intelligent behavioral growth platform designed to help
+          users better understand themselves, recognize patterns, improve emotional awareness, and
+          actively work toward measurable personal growth.
+        </p>
+        <p>The platform combines:</p>
+        <p>
+          Unlike passive wellness applications focused only on mood tracking, Crown Psychology is
+          designed to function as an interactive self improvement ecosystem that actively helps
+          users move toward healthier behavioral patterns and stronger self awareness.
+        </p>
+      </section>
 
-    <section class="panel-grid">
-      <div class="panel-card">
-        <h2>Product signals</h2>
-        <ul><li>behavioral assessments</li><li>AI assisted interpretation</li><li>guided self reflection</li><li>emotional pattern tracking</li></ul>
-      </div>
-      <div class="panel-card">
-        <h2>Core capabilities</h2>
-        <ul><li>behavioral tendencies</li><li>emotional patterns</li><li>communication styles</li><li>growth opportunities</li><li>recurring challenges</li><li>personalized insight</li><li>pattern recognition</li><li>emotionally intelligent feedback</li></ul>
-      </div>
-      <div class="panel-card">
-        <h2>Metadata checks</h2>
-        <ul><li><strong>Canonical source:</strong> docs/crownlabsbible/04-product-dossiers/crown-psychology/overview.md</li><li><strong>Classification:</strong> Behavioral intelligence and self improvement platform</li><li><strong>Status:</strong> Advanced active platform architecture with production deployment infrastructure</li></ul>
-      </div>
-    </section>
-  </main>
+      <section class="panel-grid">
+        <div class="panel-card">
+          <h2>Product signals</h2>
+          <ul>
+            <li>behavioral assessments</li>
+            <li>AI assisted interpretation</li>
+            <li>guided self reflection</li>
+            <li>emotional pattern tracking</li>
+          </ul>
+        </div>
+        <div class="panel-card">
+          <h2>Core capabilities</h2>
+          <ul>
+            <li>behavioral tendencies</li>
+            <li>emotional patterns</li>
+            <li>communication styles</li>
+            <li>growth opportunities</li>
+            <li>recurring challenges</li>
+            <li>personalized insight</li>
+            <li>pattern recognition</li>
+            <li>emotionally intelligent feedback</li>
+          </ul>
+        </div>
+        <div class="panel-card">
+          <h2>Metadata checks</h2>
+          <ul>
+            <li>
+              <strong>Canonical route:</strong>
+              <a
+                href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crown-psychology/overview.md#Overview"
+                >Crown Labs Bible documentation app</a
+              >
+            </li>
+            <li>
+              <strong>Classification:</strong> Behavioral intelligence and self improvement platform
+            </li>
+            <li>
+              <strong>Status:</strong> Advanced active platform architecture with production
+              deployment infrastructure
+            </li>
+          </ul>
+        </div>
+      </section>
+    </main>
 
-  <footer class="product-footer">
-    <p>© Crown Labs • Generated from canonical Crown Labs Bible metadata.</p>
-  </footer>
+    <footer class="product-footer">
+      <p>© Crown Labs • Generated from canonical Crown Labs Bible metadata.</p>
+    </footer>
 
-  <script src="../../assets/labs-product.js" defer></script>
-</body>
+    <script>
+      ;(() => {
+        const header = document.querySelector('.top-nav')
+        const toggle = document.querySelector('.product-menu-toggle')
+        const menu = document.getElementById('product-site-menu')
+        if (!header || !toggle || !menu) return
+        const close = () => {
+          header.classList.remove('nav-open')
+          toggle.setAttribute('aria-expanded', 'false')
+        }
+        toggle.addEventListener('click', () => {
+          const open = !header.classList.contains('nav-open')
+          header.classList.toggle('nav-open', open)
+          toggle.setAttribute('aria-expanded', String(open))
+        })
+        menu.addEventListener('click', (event) => {
+          if (event.target.closest('a')) close()
+        })
+        document.addEventListener('keydown', (event) => {
+          if (event.key === 'Escape') close()
+        })
+        document.addEventListener('click', (event) => {
+          if (!header.contains(event.target)) close()
+        })
+      })()
+    </script>
+    <script src="../../assets/labs-product.js" defer></script>
+  </body>
 </html>

--- a/labs/products/crown-sos.html
+++ b/labs/products/crown-sos.html
@@ -1,102 +1,300 @@
 <!doctype html>
 <html lang="en" data-theme="dark">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-  <title>Crown SOS | Crown Labs</title>
-  <meta name="description" content="Crown SOS is a real time crisis response and emergency coordination platform designed to help users maintain operational continuity, communicate during unstable situations, preserve critical evidence, and coordinate survivability workflows." />
-  <meta name="theme-color" content="#0b0f17" />
-  <link rel="canonical" href="https://www.darenprince.com/labs/products/crown-sos.html" />
-  <meta property="og:type" content="article" />
-  <meta property="og:title" content="Crown SOS | Crown Labs" />
-  <meta property="og:description" content="Crown SOS is a real time crisis response and emergency coordination platform designed to help users maintain operational continuity, communicate during unstable situations, preserve critical evidence, and coordinate survivability workflows." />
-  <meta property="og:url" content="https://www.darenprince.com/labs/products/crown-sos.html" />
-  <meta property="og:image" content="https://www.darenprince.com/labs/assets/labs-opengraph.svg" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Crown SOS | Crown Labs" />
-  <meta name="twitter:description" content="Crown SOS is a real time crisis response and emergency coordination platform designed to help users maintain operational continuity, communicate during unstable situations, preserve critical evidence, and coordinate survivability workflows." />
-  <meta name="twitter:image" content="https://www.darenprince.com/labs/assets/labs-opengraph.svg" />
-  <link rel="icon" type="image/svg+xml" href="../assets/labs-favicon.svg" />
-  <link rel="stylesheet" href="../../assets/labs-product.css" />
-</head>
-<body class="theme-dark product-page">
-  <header class="top-nav">
-    <div class="nav-brand">
-      <img src="../assets/crown-labs-logo.png" alt="Crown Labs" />
-      <div>
-        <strong>Crown SOS</strong>
-        <div class="footer-note">Sourced from docs/crownlabsbible/04-product-dossiers/crown-sos/overview.md</div>
-      </div>
-    </div>
-    <div class="nav-actions">
-      <a class="back-link" href="../#products">Back to Labs</a>
-      <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
-      <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
-    </div>
-  </header>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Crown SOS | Crown Labs</title>
+    <meta
+      name="description"
+      content="Crown SOS is a real time crisis response and emergency coordination platform designed to help users maintain operational continuity, communicate during unstable situations, preserve critical evidence, and coordinate survivability workflows."
+    />
+    <meta name="theme-color" content="#0b0f17" />
+    <link rel="canonical" href="https://www.darenprince.com/labs/products/crown-sos.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="Crown SOS | Crown Labs" />
+    <meta
+      property="og:description"
+      content="Crown SOS is a real time crisis response and emergency coordination platform designed to help users maintain operational continuity, communicate during unstable situations, preserve critical evidence, and coordinate survivability workflows."
+    />
+    <meta property="og:url" content="https://www.darenprince.com/labs/products/crown-sos.html" />
+    <meta
+      property="og:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Crown SOS | Crown Labs" />
+    <meta
+      name="twitter:description"
+      content="Crown SOS is a real time crisis response and emergency coordination platform designed to help users maintain operational continuity, communicate during unstable situations, preserve critical evidence, and coordinate survivability workflows."
+    />
+    <meta
+      name="twitter:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <link rel="icon" type="image/svg+xml" href="../assets/labs-favicon.svg" />
+    <script src="https://code.iconify.design/iconify-icon/2.1.0/iconify-icon.min.js"></script>
+    <link rel="stylesheet" href="../../assets/labs-product.css" />
 
-  <main>
-    <section class="product-hero">
-      <div>
-        <div class="hero-tags">
-          <span class="tag">Prototype and beta testing phase</span>
-          <span class="tag">Emergency coordination and crisis response platform</span>
+    <style>
+      .top-nav {
+        gap: 1rem;
+      }
+      .nav-actions {
+        align-items: center;
+      }
+      .product-menu-toggle {
+        display: none;
+        align-items: center;
+        justify-content: center;
+        width: 42px;
+        height: 42px;
+        border: 1px solid rgba(231, 237, 246, 0.16);
+        background: rgba(18, 26, 39, 0.84);
+        color: currentColor;
+        font-size: 1.35rem;
+      }
+      .modern-product-nav {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 0.5rem;
+      }
+      .modern-product-nav a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.42rem;
+      }
+      .modern-product-nav iconify-icon {
+        color: #8ea2ff;
+        font-size: 1.02rem;
+      }
+      @media (max-width: 860px) {
+        .top-nav {
+          position: sticky;
+          top: 0;
+          z-index: 50;
+        }
+        .product-menu-toggle {
+          display: inline-flex;
+        }
+        .nav-actions {
+          position: relative;
+          margin-left: auto;
+        }
+        .modern-product-nav {
+          position: absolute;
+          top: calc(100% + 10px);
+          right: 0;
+          min-width: min(82vw, 320px);
+          display: none;
+          flex-direction: column;
+          padding: 12px;
+          border: 1px solid rgba(231, 237, 246, 0.16);
+          background: rgba(8, 12, 19, 0.98);
+          box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+        }
+        .top-nav.nav-open .modern-product-nav {
+          display: flex;
+        }
+        .modern-product-nav a {
+          justify-content: flex-start;
+          padding: 12px 14px;
+        }
+      }
+    </style>
+  </head>
+  <body class="theme-dark product-page">
+    <header class="top-nav">
+      <div class="nav-brand">
+        <img src="../assets/crown-labs-logo.png" alt="Crown Labs" />
+        <div>
+          <strong>Crown SOS</strong>
+          <div class="footer-note">Sourced from Crown Labs Bible documentation application.</div>
         </div>
-        <h1>Crown SOS</h1>
-        <p class="subtitle">Crown SOS is a real time crisis response and emergency coordination platform designed to help users maintain operational continuity, communicate during unstable situations, preserve critical evidence, and coordinate survivability workflows.</p>
-        <p>Crown SOS is a real time crisis response and emergency coordination platform designed to help users maintain operational continuity, communicate during unstable situations, preserve critical evidence, and coordinate survivability workflows.</p>
-        <div class="access-actions">
-          <a class="primary-btn" href="../../docs/crownlabsbible/04-product-dossiers/crown-sos/overview.md">Open canonical dossier</a>
-          <a class="ghost-btn" href="../#products">Explore Labs</a>
+      </div>
+      <div class="nav-actions">
+        <button
+          class="product-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="product-site-menu"
+          aria-label="Open Crown Labs navigation"
+        >
+          <iconify-icon icon="tabler:menu-2" aria-hidden="true"></iconify-icon>
+        </button>
+        <nav class="modern-product-nav" id="product-site-menu" aria-label="Crown Labs navigation">
+          <a class="back-link" href="../"
+            ><iconify-icon icon="tabler:home-2" aria-hidden="true"></iconify-icon
+            ><span>Home</span></a
+          >
+          <a class="back-link" href="../#products"
+            ><iconify-icon icon="tabler:box" aria-hidden="true"></iconify-icon
+            ><span>Products</span></a
+          >
+          <a class="back-link" href="../#crowncode"
+            ><iconify-icon icon="tabler:cpu-2" aria-hidden="true"></iconify-icon
+            ><span>Technology</span></a
+          >
+          <a class="back-link" href="../#founder"
+            ><iconify-icon icon="tabler:crown" aria-hidden="true"></iconify-icon
+            ><span>Founder</span></a
+          >
+          <a class="back-link" href="../../docs/crownlabsbible/docs/index.html"
+            ><iconify-icon icon="tabler:file-text" aria-hidden="true"></iconify-icon
+            ><span>Documentation</span></a
+          >
+          <a class="back-link" href="mailto:apps@crownlabs.tech"
+            ><iconify-icon icon="tabler:mail" aria-hidden="true"></iconify-icon
+            ><span>Contact</span></a
+          >
+          <button
+            class="theme-toggle"
+            id="theme-toggle"
+            type="button"
+            aria-pressed="false"
+            aria-label="Toggle light and dark mode"
+          >
+            Theme
+          </button>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="product-hero">
+        <div>
+          <div class="hero-tags">
+            <span class="tag">Prototype and beta testing phase</span>
+            <span class="tag">Emergency coordination and crisis response platform</span>
+          </div>
+          <h1>Crown SOS</h1>
+          <p class="subtitle">
+            Crown SOS is a real time crisis response and emergency coordination platform designed to
+            help users maintain operational continuity, communicate during unstable situations,
+            preserve critical evidence, and coordinate survivability workflows.
+          </p>
+          <p>
+            Crown SOS is a real time crisis response and emergency coordination platform designed to
+            help users maintain operational continuity, communicate during unstable situations,
+            preserve critical evidence, and coordinate survivability workflows.
+          </p>
+          <div class="access-actions">
+            <a
+              class="primary-btn"
+              href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crown-sos/overview.md#Overview"
+              >Open documentation app</a
+            >
+            <a class="ghost-btn" href="../#products">Explore Labs</a>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <section class="panel-grid">
-      <div class="panel-card">
-        <h2>Canonical status</h2>
-        <p><strong>Status:</strong> Prototype and beta testing phase</p>
-        <p><strong>Classification:</strong> Real time emergency communication, survivability coordination, and continuity response ecosystem</p>
-        <p><strong>Readiness signal:</strong> 68% documentation readiness signal</p>
-      </div>
-      <div class="panel-card">
-        <h2>Source governance</h2>
-        <p><strong>Authority:</strong> docs/crownlabsbible/</p>
-        <p><strong>Source file:</strong> docs/crownlabsbible/04-product-dossiers/crown-sos/overview.md</p>
-        <p><strong>Update rule:</strong> edit the dossier first, then regenerate metadata.</p>
-      </div>
-      <div class="panel-card">
-        <h2>Valuation reference</h2>
-        <p>$2,500,000 to $7,000,000</p>
-        <p class="footer-note">Financial language remains directional and must be verified against canonical valuation dossiers.</p>
-      </div>
-    </section>
+      <section class="panel-grid">
+        <div class="panel-card">
+          <h2>Canonical status</h2>
+          <p><strong>Status:</strong> Prototype and beta testing phase</p>
+          <p>
+            <strong>Classification:</strong> Real time emergency communication, survivability
+            coordination, and continuity response ecosystem
+          </p>
+          <p><strong>Readiness signal:</strong> 68% documentation readiness signal</p>
+        </div>
+        <div class="panel-card">
+          <h2>Source governance</h2>
+          <p><strong>Authority:</strong> Crown Labs Bible documentation application</p>
+          <p>
+            <strong>Documentation route:</strong>
+            <a
+              href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crown-sos/overview.md#Overview"
+              >Crown Labs Bible viewer</a
+            >
+          </p>
+          <p><strong>Update rule:</strong> edit the dossier first, then regenerate metadata.</p>
+        </div>
+        <div class="panel-card">
+          <h2>Valuation reference</h2>
+          <p>$2,500,000 to $7,000,000</p>
+          <p class="footer-note">
+            Financial language remains directional and must be verified against canonical valuation
+            dossiers.
+          </p>
+        </div>
+      </section>
 
-    <section class="section-block">
-      <h2>What it is</h2>
-      <p>Crown SOS is a real time crisis response and emergency coordination platform designed to help users maintain operational continuity, communicate during unstable situations, preserve critical evidence, and coordinate survivability workflows.</p><p>The platform combines:</p><p>into a unified emergency coordination ecosystem.</p>
-    </section>
+      <section class="section-block">
+        <h2>What it is</h2>
+        <p>
+          Crown SOS is a real time crisis response and emergency coordination platform designed to
+          help users maintain operational continuity, communicate during unstable situations,
+          preserve critical evidence, and coordinate survivability workflows.
+        </p>
+        <p>The platform combines:</p>
+        <p>into a unified emergency coordination ecosystem.</p>
+      </section>
 
-    <section class="panel-grid">
-      <div class="panel-card">
-        <h2>Product signals</h2>
-        <ul><li>emergency communication systems</li><li>live video infrastructure</li><li>live audio routing</li><li>proof of life workflows</li></ul>
-      </div>
-      <div class="panel-card">
-        <h2>Core capabilities</h2>
-        <ul></ul>
-      </div>
-      <div class="panel-card">
-        <h2>Metadata checks</h2>
-        <ul><li><strong>Canonical source:</strong> docs/crownlabsbible/04-product-dossiers/crown-sos/overview.md</li><li><strong>Classification:</strong> Emergency coordination and crisis response platform</li><li><strong>Status:</strong> Prototype and beta testing phase</li></ul>
-      </div>
-    </section>
-  </main>
+      <section class="panel-grid">
+        <div class="panel-card">
+          <h2>Product signals</h2>
+          <ul>
+            <li>emergency communication systems</li>
+            <li>live video infrastructure</li>
+            <li>live audio routing</li>
+            <li>proof of life workflows</li>
+          </ul>
+        </div>
+        <div class="panel-card">
+          <h2>Core capabilities</h2>
+          <ul></ul>
+        </div>
+        <div class="panel-card">
+          <h2>Metadata checks</h2>
+          <ul>
+            <li>
+              <strong>Canonical route:</strong>
+              <a
+                href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crown-sos/overview.md#Overview"
+                >Crown Labs Bible documentation app</a
+              >
+            </li>
+            <li>
+              <strong>Classification:</strong> Emergency coordination and crisis response platform
+            </li>
+            <li><strong>Status:</strong> Prototype and beta testing phase</li>
+          </ul>
+        </div>
+      </section>
+    </main>
 
-  <footer class="product-footer">
-    <p>© Crown Labs • Generated from canonical Crown Labs Bible metadata.</p>
-  </footer>
+    <footer class="product-footer">
+      <p>© Crown Labs • Generated from canonical Crown Labs Bible metadata.</p>
+    </footer>
 
-  <script src="../../assets/labs-product.js" defer></script>
-</body>
+    <script>
+      ;(() => {
+        const header = document.querySelector('.top-nav')
+        const toggle = document.querySelector('.product-menu-toggle')
+        const menu = document.getElementById('product-site-menu')
+        if (!header || !toggle || !menu) return
+        const close = () => {
+          header.classList.remove('nav-open')
+          toggle.setAttribute('aria-expanded', 'false')
+        }
+        toggle.addEventListener('click', () => {
+          const open = !header.classList.contains('nav-open')
+          header.classList.toggle('nav-open', open)
+          toggle.setAttribute('aria-expanded', String(open))
+        })
+        menu.addEventListener('click', (event) => {
+          if (event.target.closest('a')) close()
+        })
+        document.addEventListener('keydown', (event) => {
+          if (event.key === 'Escape') close()
+        })
+        document.addEventListener('click', (event) => {
+          if (!header.contains(event.target)) close()
+        })
+      })()
+    </script>
+    <script src="../../assets/labs-product.js" defer></script>
+  </body>
 </html>

--- a/labs/products/crown-watchtower.html
+++ b/labs/products/crown-watchtower.html
@@ -1,102 +1,306 @@
 <!doctype html>
 <html lang="en" data-theme="dark">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-  <title>Crown WatchTower | Crown Labs</title>
-  <meta name="description" content="Crown WatchTower is a forensic grade environmental signal intelligence and operational visibility platform designed to support threat awareness, monitoring coordination, ecosystem observability, and continuity focused intelligence workflows." />
-  <meta name="theme-color" content="#0b0f17" />
-  <link rel="canonical" href="https://www.darenprince.com/labs/products/crown-watchtower.html" />
-  <meta property="og:type" content="article" />
-  <meta property="og:title" content="Crown WatchTower | Crown Labs" />
-  <meta property="og:description" content="Crown WatchTower is a forensic grade environmental signal intelligence and operational visibility platform designed to support threat awareness, monitoring coordination, ecosystem observability, and continuity focused intelligence workflows." />
-  <meta property="og:url" content="https://www.darenprince.com/labs/products/crown-watchtower.html" />
-  <meta property="og:image" content="https://www.darenprince.com/labs/assets/labs-opengraph.svg" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Crown WatchTower | Crown Labs" />
-  <meta name="twitter:description" content="Crown WatchTower is a forensic grade environmental signal intelligence and operational visibility platform designed to support threat awareness, monitoring coordination, ecosystem observability, and continuity focused intelligence workflows." />
-  <meta name="twitter:image" content="https://www.darenprince.com/labs/assets/labs-opengraph.svg" />
-  <link rel="icon" type="image/svg+xml" href="../assets/labs-favicon.svg" />
-  <link rel="stylesheet" href="../../assets/labs-product.css" />
-</head>
-<body class="theme-dark product-page">
-  <header class="top-nav">
-    <div class="nav-brand">
-      <img src="../assets/crown-labs-logo.png" alt="Crown Labs" />
-      <div>
-        <strong>Crown WatchTower</strong>
-        <div class="footer-note">Sourced from docs/crownlabsbible/04-product-dossiers/crown-watchtower/overview.md</div>
-      </div>
-    </div>
-    <div class="nav-actions">
-      <a class="back-link" href="../#products">Back to Labs</a>
-      <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
-      <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
-    </div>
-  </header>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Crown WatchTower | Crown Labs</title>
+    <meta
+      name="description"
+      content="Crown WatchTower is a forensic grade environmental signal intelligence and operational visibility platform designed to support threat awareness, monitoring coordination, ecosystem observability, and continuity focused intelligence workflows."
+    />
+    <meta name="theme-color" content="#0b0f17" />
+    <link rel="canonical" href="https://www.darenprince.com/labs/products/crown-watchtower.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="Crown WatchTower | Crown Labs" />
+    <meta
+      property="og:description"
+      content="Crown WatchTower is a forensic grade environmental signal intelligence and operational visibility platform designed to support threat awareness, monitoring coordination, ecosystem observability, and continuity focused intelligence workflows."
+    />
+    <meta
+      property="og:url"
+      content="https://www.darenprince.com/labs/products/crown-watchtower.html"
+    />
+    <meta
+      property="og:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Crown WatchTower | Crown Labs" />
+    <meta
+      name="twitter:description"
+      content="Crown WatchTower is a forensic grade environmental signal intelligence and operational visibility platform designed to support threat awareness, monitoring coordination, ecosystem observability, and continuity focused intelligence workflows."
+    />
+    <meta
+      name="twitter:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <link rel="icon" type="image/svg+xml" href="../assets/labs-favicon.svg" />
+    <script src="https://code.iconify.design/iconify-icon/2.1.0/iconify-icon.min.js"></script>
+    <link rel="stylesheet" href="../../assets/labs-product.css" />
 
-  <main>
-    <section class="product-hero">
-      <div>
-        <div class="hero-tags">
-          <span class="tag">Active development and strategic infrastructure phase</span>
-          <span class="tag">Environmental signal intelligence and operational visibility platform</span>
+    <style>
+      .top-nav {
+        gap: 1rem;
+      }
+      .nav-actions {
+        align-items: center;
+      }
+      .product-menu-toggle {
+        display: none;
+        align-items: center;
+        justify-content: center;
+        width: 42px;
+        height: 42px;
+        border: 1px solid rgba(231, 237, 246, 0.16);
+        background: rgba(18, 26, 39, 0.84);
+        color: currentColor;
+        font-size: 1.35rem;
+      }
+      .modern-product-nav {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 0.5rem;
+      }
+      .modern-product-nav a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.42rem;
+      }
+      .modern-product-nav iconify-icon {
+        color: #8ea2ff;
+        font-size: 1.02rem;
+      }
+      @media (max-width: 860px) {
+        .top-nav {
+          position: sticky;
+          top: 0;
+          z-index: 50;
+        }
+        .product-menu-toggle {
+          display: inline-flex;
+        }
+        .nav-actions {
+          position: relative;
+          margin-left: auto;
+        }
+        .modern-product-nav {
+          position: absolute;
+          top: calc(100% + 10px);
+          right: 0;
+          min-width: min(82vw, 320px);
+          display: none;
+          flex-direction: column;
+          padding: 12px;
+          border: 1px solid rgba(231, 237, 246, 0.16);
+          background: rgba(8, 12, 19, 0.98);
+          box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+        }
+        .top-nav.nav-open .modern-product-nav {
+          display: flex;
+        }
+        .modern-product-nav a {
+          justify-content: flex-start;
+          padding: 12px 14px;
+        }
+      }
+    </style>
+  </head>
+  <body class="theme-dark product-page">
+    <header class="top-nav">
+      <div class="nav-brand">
+        <img src="../assets/crown-labs-logo.png" alt="Crown Labs" />
+        <div>
+          <strong>Crown WatchTower</strong>
+          <div class="footer-note">Sourced from Crown Labs Bible documentation application.</div>
         </div>
-        <h1>Crown WatchTower</h1>
-        <p class="subtitle">Crown WatchTower is a forensic grade environmental signal intelligence and operational visibility platform designed to support threat awareness, monitoring coordination, ecosystem observability, and continuity focused intelligence workflows.</p>
-        <p>Crown WatchTower is a forensic grade environmental signal intelligence and operational visibility platform designed to support threat awareness, monitoring coordination, ecosystem observability, and continuity focused intelligence workflows.</p>
-        <div class="access-actions">
-          <a class="primary-btn" href="../../docs/crownlabsbible/04-product-dossiers/crown-watchtower/overview.md">Open canonical dossier</a>
-          <a class="ghost-btn" href="../#products">Explore Labs</a>
+      </div>
+      <div class="nav-actions">
+        <button
+          class="product-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="product-site-menu"
+          aria-label="Open Crown Labs navigation"
+        >
+          <iconify-icon icon="tabler:menu-2" aria-hidden="true"></iconify-icon>
+        </button>
+        <nav class="modern-product-nav" id="product-site-menu" aria-label="Crown Labs navigation">
+          <a class="back-link" href="../"
+            ><iconify-icon icon="tabler:home-2" aria-hidden="true"></iconify-icon
+            ><span>Home</span></a
+          >
+          <a class="back-link" href="../#products"
+            ><iconify-icon icon="tabler:box" aria-hidden="true"></iconify-icon
+            ><span>Products</span></a
+          >
+          <a class="back-link" href="../#crowncode"
+            ><iconify-icon icon="tabler:cpu-2" aria-hidden="true"></iconify-icon
+            ><span>Technology</span></a
+          >
+          <a class="back-link" href="../#founder"
+            ><iconify-icon icon="tabler:crown" aria-hidden="true"></iconify-icon
+            ><span>Founder</span></a
+          >
+          <a class="back-link" href="../../docs/crownlabsbible/docs/index.html"
+            ><iconify-icon icon="tabler:file-text" aria-hidden="true"></iconify-icon
+            ><span>Documentation</span></a
+          >
+          <a class="back-link" href="mailto:apps@crownlabs.tech"
+            ><iconify-icon icon="tabler:mail" aria-hidden="true"></iconify-icon
+            ><span>Contact</span></a
+          >
+          <button
+            class="theme-toggle"
+            id="theme-toggle"
+            type="button"
+            aria-pressed="false"
+            aria-label="Toggle light and dark mode"
+          >
+            Theme
+          </button>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="product-hero">
+        <div>
+          <div class="hero-tags">
+            <span class="tag">Active development and strategic infrastructure phase</span>
+            <span class="tag"
+              >Environmental signal intelligence and operational visibility platform</span
+            >
+          </div>
+          <h1>Crown WatchTower</h1>
+          <p class="subtitle">
+            Crown WatchTower is a forensic grade environmental signal intelligence and operational
+            visibility platform designed to support threat awareness, monitoring coordination,
+            ecosystem observability, and continuity focused intelligence workflows.
+          </p>
+          <p>
+            Crown WatchTower is a forensic grade environmental signal intelligence and operational
+            visibility platform designed to support threat awareness, monitoring coordination,
+            ecosystem observability, and continuity focused intelligence workflows.
+          </p>
+          <div class="access-actions">
+            <a
+              class="primary-btn"
+              href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crown-watchtower/overview.md#Overview"
+              >Open documentation app</a
+            >
+            <a class="ghost-btn" href="../#products">Explore Labs</a>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <section class="panel-grid">
-      <div class="panel-card">
-        <h2>Canonical status</h2>
-        <p><strong>Status:</strong> Active development and strategic infrastructure phase</p>
-        <p><strong>Classification:</strong> Forensic grade monitoring, environmental intelligence, and operational awareness ecosystem</p>
-        <p><strong>Readiness signal:</strong> 74% documentation readiness signal</p>
-      </div>
-      <div class="panel-card">
-        <h2>Source governance</h2>
-        <p><strong>Authority:</strong> docs/crownlabsbible/</p>
-        <p><strong>Source file:</strong> docs/crownlabsbible/04-product-dossiers/crown-watchtower/overview.md</p>
-        <p><strong>Update rule:</strong> edit the dossier first, then regenerate metadata.</p>
-      </div>
-      <div class="panel-card">
-        <h2>Valuation reference</h2>
-        <p>$3,000,000 to $8,500,000</p>
-        <p class="footer-note">Financial language remains directional and must be verified against canonical valuation dossiers.</p>
-      </div>
-    </section>
+      <section class="panel-grid">
+        <div class="panel-card">
+          <h2>Canonical status</h2>
+          <p><strong>Status:</strong> Active development and strategic infrastructure phase</p>
+          <p>
+            <strong>Classification:</strong> Forensic grade monitoring, environmental intelligence,
+            and operational awareness ecosystem
+          </p>
+          <p><strong>Readiness signal:</strong> 74% documentation readiness signal</p>
+        </div>
+        <div class="panel-card">
+          <h2>Source governance</h2>
+          <p><strong>Authority:</strong> Crown Labs Bible documentation application</p>
+          <p>
+            <strong>Documentation route:</strong>
+            <a
+              href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crown-watchtower/overview.md#Overview"
+              >Crown Labs Bible viewer</a
+            >
+          </p>
+          <p><strong>Update rule:</strong> edit the dossier first, then regenerate metadata.</p>
+        </div>
+        <div class="panel-card">
+          <h2>Valuation reference</h2>
+          <p>$3,000,000 to $8,500,000</p>
+          <p class="footer-note">
+            Financial language remains directional and must be verified against canonical valuation
+            dossiers.
+          </p>
+        </div>
+      </section>
 
-    <section class="section-block">
-      <h2>What it is</h2>
-      <p>Crown WatchTower is a forensic grade environmental signal intelligence and operational visibility platform designed to support threat awareness, monitoring coordination, ecosystem observability, and continuity focused intelligence workflows.</p><p>The platform combines:</p><p>into a unified environmental intelligence ecosystem.</p>
-    </section>
+      <section class="section-block">
+        <h2>What it is</h2>
+        <p>
+          Crown WatchTower is a forensic grade environmental signal intelligence and operational
+          visibility platform designed to support threat awareness, monitoring coordination,
+          ecosystem observability, and continuity focused intelligence workflows.
+        </p>
+        <p>The platform combines:</p>
+        <p>into a unified environmental intelligence ecosystem.</p>
+      </section>
 
-    <section class="panel-grid">
-      <div class="panel-card">
-        <h2>Product signals</h2>
-        <ul><li>operational visibility systems</li><li>environmental signal monitoring</li><li>threat awareness infrastructure</li><li>continuity focused intelligence workflows</li></ul>
-      </div>
-      <div class="panel-card">
-        <h2>Core capabilities</h2>
-        <ul></ul>
-      </div>
-      <div class="panel-card">
-        <h2>Metadata checks</h2>
-        <ul><li><strong>Canonical source:</strong> docs/crownlabsbible/04-product-dossiers/crown-watchtower/overview.md</li><li><strong>Classification:</strong> Environmental signal intelligence and operational visibility platform</li><li><strong>Status:</strong> Active development and strategic infrastructure phase</li></ul>
-      </div>
-    </section>
-  </main>
+      <section class="panel-grid">
+        <div class="panel-card">
+          <h2>Product signals</h2>
+          <ul>
+            <li>operational visibility systems</li>
+            <li>environmental signal monitoring</li>
+            <li>threat awareness infrastructure</li>
+            <li>continuity focused intelligence workflows</li>
+          </ul>
+        </div>
+        <div class="panel-card">
+          <h2>Core capabilities</h2>
+          <ul></ul>
+        </div>
+        <div class="panel-card">
+          <h2>Metadata checks</h2>
+          <ul>
+            <li>
+              <strong>Canonical route:</strong>
+              <a
+                href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crown-watchtower/overview.md#Overview"
+                >Crown Labs Bible documentation app</a
+              >
+            </li>
+            <li>
+              <strong>Classification:</strong> Environmental signal intelligence and operational
+              visibility platform
+            </li>
+            <li><strong>Status:</strong> Active development and strategic infrastructure phase</li>
+          </ul>
+        </div>
+      </section>
+    </main>
 
-  <footer class="product-footer">
-    <p>© Crown Labs • Generated from canonical Crown Labs Bible metadata.</p>
-  </footer>
+    <footer class="product-footer">
+      <p>© Crown Labs • Generated from canonical Crown Labs Bible metadata.</p>
+    </footer>
 
-  <script src="../../assets/labs-product.js" defer></script>
-</body>
+    <script>
+      ;(() => {
+        const header = document.querySelector('.top-nav')
+        const toggle = document.querySelector('.product-menu-toggle')
+        const menu = document.getElementById('product-site-menu')
+        if (!header || !toggle || !menu) return
+        const close = () => {
+          header.classList.remove('nav-open')
+          toggle.setAttribute('aria-expanded', 'false')
+        }
+        toggle.addEventListener('click', () => {
+          const open = !header.classList.contains('nav-open')
+          header.classList.toggle('nav-open', open)
+          toggle.setAttribute('aria-expanded', String(open))
+        })
+        menu.addEventListener('click', (event) => {
+          if (event.target.closest('a')) close()
+        })
+        document.addEventListener('keydown', (event) => {
+          if (event.key === 'Escape') close()
+        })
+        document.addEventListener('click', (event) => {
+          if (!header.contains(event.target)) close()
+        })
+      })()
+    </script>
+    <script src="../../assets/labs-product.js" defer></script>
+  </body>
 </html>

--- a/labs/products/crowncam.html
+++ b/labs/products/crowncam.html
@@ -1,102 +1,310 @@
 <!doctype html>
 <html lang="en" data-theme="dark">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-  <title>CrownCam | Crown Labs</title>
-  <meta name="description" content="CrownCam is a real time monitoring and remote camera infrastructure platform designed to transform everyday devices into scalable live monitoring systems." />
-  <meta name="theme-color" content="#0b0f17" />
-  <link rel="canonical" href="https://www.darenprince.com/labs/products/crowncam.html" />
-  <meta property="og:type" content="article" />
-  <meta property="og:title" content="CrownCam | Crown Labs" />
-  <meta property="og:description" content="CrownCam is a real time monitoring and remote camera infrastructure platform designed to transform everyday devices into scalable live monitoring systems." />
-  <meta property="og:url" content="https://www.darenprince.com/labs/products/crowncam.html" />
-  <meta property="og:image" content="https://www.darenprince.com/labs/assets/labs-opengraph.svg" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="CrownCam | Crown Labs" />
-  <meta name="twitter:description" content="CrownCam is a real time monitoring and remote camera infrastructure platform designed to transform everyday devices into scalable live monitoring systems." />
-  <meta name="twitter:image" content="https://www.darenprince.com/labs/assets/labs-opengraph.svg" />
-  <link rel="icon" type="image/svg+xml" href="../assets/labs-favicon.svg" />
-  <link rel="stylesheet" href="../../assets/labs-product.css" />
-</head>
-<body class="theme-dark product-page">
-  <header class="top-nav">
-    <div class="nav-brand">
-      <img src="../assets/crown-labs-logo.png" alt="Crown Labs" />
-      <div>
-        <strong>CrownCam</strong>
-        <div class="footer-note">Sourced from docs/crownlabsbible/04-product-dossiers/crowncam/overview.md</div>
-      </div>
-    </div>
-    <div class="nav-actions">
-      <a class="back-link" href="../#products">Back to Labs</a>
-      <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
-      <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
-    </div>
-  </header>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>CrownCam | Crown Labs</title>
+    <meta
+      name="description"
+      content="CrownCam is a real time monitoring and remote camera infrastructure platform designed to transform everyday devices into scalable live monitoring systems."
+    />
+    <meta name="theme-color" content="#0b0f17" />
+    <link rel="canonical" href="https://www.darenprince.com/labs/products/crowncam.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="CrownCam | Crown Labs" />
+    <meta
+      property="og:description"
+      content="CrownCam is a real time monitoring and remote camera infrastructure platform designed to transform everyday devices into scalable live monitoring systems."
+    />
+    <meta property="og:url" content="https://www.darenprince.com/labs/products/crowncam.html" />
+    <meta
+      property="og:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="CrownCam | Crown Labs" />
+    <meta
+      name="twitter:description"
+      content="CrownCam is a real time monitoring and remote camera infrastructure platform designed to transform everyday devices into scalable live monitoring systems."
+    />
+    <meta
+      name="twitter:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <link rel="icon" type="image/svg+xml" href="../assets/labs-favicon.svg" />
+    <script src="https://code.iconify.design/iconify-icon/2.1.0/iconify-icon.min.js"></script>
+    <link rel="stylesheet" href="../../assets/labs-product.css" />
 
-  <main>
-    <section class="product-hero">
-      <div>
-        <div class="hero-tags">
-          <span class="tag">Advanced prototype and tested deployment architecture</span>
-          <span class="tag">Live monitoring, security, and remote continuity platform</span>
+    <style>
+      .top-nav {
+        gap: 1rem;
+      }
+      .nav-actions {
+        align-items: center;
+      }
+      .product-menu-toggle {
+        display: none;
+        align-items: center;
+        justify-content: center;
+        width: 42px;
+        height: 42px;
+        border: 1px solid rgba(231, 237, 246, 0.16);
+        background: rgba(18, 26, 39, 0.84);
+        color: currentColor;
+        font-size: 1.35rem;
+      }
+      .modern-product-nav {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 0.5rem;
+      }
+      .modern-product-nav a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.42rem;
+      }
+      .modern-product-nav iconify-icon {
+        color: #8ea2ff;
+        font-size: 1.02rem;
+      }
+      @media (max-width: 860px) {
+        .top-nav {
+          position: sticky;
+          top: 0;
+          z-index: 50;
+        }
+        .product-menu-toggle {
+          display: inline-flex;
+        }
+        .nav-actions {
+          position: relative;
+          margin-left: auto;
+        }
+        .modern-product-nav {
+          position: absolute;
+          top: calc(100% + 10px);
+          right: 0;
+          min-width: min(82vw, 320px);
+          display: none;
+          flex-direction: column;
+          padding: 12px;
+          border: 1px solid rgba(231, 237, 246, 0.16);
+          background: rgba(8, 12, 19, 0.98);
+          box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+        }
+        .top-nav.nav-open .modern-product-nav {
+          display: flex;
+        }
+        .modern-product-nav a {
+          justify-content: flex-start;
+          padding: 12px 14px;
+        }
+      }
+    </style>
+  </head>
+  <body class="theme-dark product-page">
+    <header class="top-nav">
+      <div class="nav-brand">
+        <img src="../assets/crown-labs-logo.png" alt="Crown Labs" />
+        <div>
+          <strong>CrownCam</strong>
+          <div class="footer-note">Sourced from Crown Labs Bible documentation application.</div>
         </div>
-        <h1>CrownCam</h1>
-        <p class="subtitle">CrownCam is a real time monitoring and remote camera infrastructure platform designed to transform everyday devices into scalable live monitoring systems.</p>
-        <p>CrownCam is a real time monitoring and remote camera infrastructure platform designed to transform everyday devices into scalable live monitoring systems.</p>
-        <div class="access-actions">
-          <a class="primary-btn" href="../../docs/crownlabsbible/04-product-dossiers/crowncam/overview.md">Open canonical dossier</a>
-          <a class="ghost-btn" href="../#products">Explore Labs</a>
+      </div>
+      <div class="nav-actions">
+        <button
+          class="product-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="product-site-menu"
+          aria-label="Open Crown Labs navigation"
+        >
+          <iconify-icon icon="tabler:menu-2" aria-hidden="true"></iconify-icon>
+        </button>
+        <nav class="modern-product-nav" id="product-site-menu" aria-label="Crown Labs navigation">
+          <a class="back-link" href="../"
+            ><iconify-icon icon="tabler:home-2" aria-hidden="true"></iconify-icon
+            ><span>Home</span></a
+          >
+          <a class="back-link" href="../#products"
+            ><iconify-icon icon="tabler:box" aria-hidden="true"></iconify-icon
+            ><span>Products</span></a
+          >
+          <a class="back-link" href="../#crowncode"
+            ><iconify-icon icon="tabler:cpu-2" aria-hidden="true"></iconify-icon
+            ><span>Technology</span></a
+          >
+          <a class="back-link" href="../#founder"
+            ><iconify-icon icon="tabler:crown" aria-hidden="true"></iconify-icon
+            ><span>Founder</span></a
+          >
+          <a class="back-link" href="../../docs/crownlabsbible/docs/index.html"
+            ><iconify-icon icon="tabler:file-text" aria-hidden="true"></iconify-icon
+            ><span>Documentation</span></a
+          >
+          <a class="back-link" href="mailto:apps@crownlabs.tech"
+            ><iconify-icon icon="tabler:mail" aria-hidden="true"></iconify-icon
+            ><span>Contact</span></a
+          >
+          <button
+            class="theme-toggle"
+            id="theme-toggle"
+            type="button"
+            aria-pressed="false"
+            aria-label="Toggle light and dark mode"
+          >
+            Theme
+          </button>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="product-hero">
+        <div>
+          <div class="hero-tags">
+            <span class="tag">Advanced prototype and tested deployment architecture</span>
+            <span class="tag">Live monitoring, security, and remote continuity platform</span>
+          </div>
+          <h1>CrownCam</h1>
+          <p class="subtitle">
+            CrownCam is a real time monitoring and remote camera infrastructure platform designed to
+            transform everyday devices into scalable live monitoring systems.
+          </p>
+          <p>
+            CrownCam is a real time monitoring and remote camera infrastructure platform designed to
+            transform everyday devices into scalable live monitoring systems.
+          </p>
+          <div class="access-actions">
+            <a
+              class="primary-btn"
+              href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crowncam/overview.md#Overview"
+              >Open documentation app</a
+            >
+            <a class="ghost-btn" href="../#products">Explore Labs</a>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <section class="panel-grid">
-      <div class="panel-card">
-        <h2>Canonical status</h2>
-        <p><strong>Status:</strong> Advanced prototype and tested deployment architecture</p>
-        <p><strong>Classification:</strong> Real time camera monitoring, survivability streaming, and operational continuity ecosystem</p>
-        <p><strong>Readiness signal:</strong> 55% documentation readiness signal</p>
-      </div>
-      <div class="panel-card">
-        <h2>Source governance</h2>
-        <p><strong>Authority:</strong> docs/crownlabsbible/</p>
-        <p><strong>Source file:</strong> docs/crownlabsbible/04-product-dossiers/crowncam/overview.md</p>
-        <p><strong>Update rule:</strong> edit the dossier first, then regenerate metadata.</p>
-      </div>
-      <div class="panel-card">
-        <h2>Valuation reference</h2>
-        <p>$2,000,000 to $6,000,000</p>
-        <p class="footer-note">Financial language remains directional and must be verified against canonical valuation dossiers.</p>
-      </div>
-    </section>
+      <section class="panel-grid">
+        <div class="panel-card">
+          <h2>Canonical status</h2>
+          <p><strong>Status:</strong> Advanced prototype and tested deployment architecture</p>
+          <p>
+            <strong>Classification:</strong> Real time camera monitoring, survivability streaming,
+            and operational continuity ecosystem
+          </p>
+          <p><strong>Readiness signal:</strong> 55% documentation readiness signal</p>
+        </div>
+        <div class="panel-card">
+          <h2>Source governance</h2>
+          <p><strong>Authority:</strong> Crown Labs Bible documentation application</p>
+          <p>
+            <strong>Documentation route:</strong>
+            <a
+              href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crowncam/overview.md#Overview"
+              >Crown Labs Bible viewer</a
+            >
+          </p>
+          <p><strong>Update rule:</strong> edit the dossier first, then regenerate metadata.</p>
+        </div>
+        <div class="panel-card">
+          <h2>Valuation reference</h2>
+          <p>$2,000,000 to $6,000,000</p>
+          <p class="footer-note">
+            Financial language remains directional and must be verified against canonical valuation
+            dossiers.
+          </p>
+        </div>
+      </section>
 
-    <section class="section-block">
-      <h2>What it is</h2>
-      <p>CrownCam is a real time monitoring and remote camera infrastructure platform designed to transform everyday devices into scalable live monitoring systems.</p><p>Built on modern live streaming architecture and designed around operational simplicity, CrownCam combines:</p><p>into a unified live monitoring ecosystem.</p>
-    </section>
+      <section class="section-block">
+        <h2>What it is</h2>
+        <p>
+          CrownCam is a real time monitoring and remote camera infrastructure platform designed to
+          transform everyday devices into scalable live monitoring systems.
+        </p>
+        <p>
+          Built on modern live streaming architecture and designed around operational simplicity,
+          CrownCam combines:
+        </p>
+        <p>into a unified live monitoring ecosystem.</p>
+      </section>
 
-    <section class="panel-grid">
-      <div class="panel-card">
-        <h2>Product signals</h2>
-        <ul><li>real time camera feeds</li><li>remote viewing infrastructure</li><li>survivability focused monitoring</li><li>live communication systems</li></ul>
-      </div>
-      <div class="panel-card">
-        <h2>Core capabilities</h2>
-        <ul><li>phones</li><li>tablets</li><li>laptops</li><li>desktops</li><li>webcams</li><li>live viewing rooms</li><li>secure stream routing</li><li>remote monitoring sessions</li></ul>
-      </div>
-      <div class="panel-card">
-        <h2>Metadata checks</h2>
-        <ul><li><strong>Canonical source:</strong> docs/crownlabsbible/04-product-dossiers/crowncam/overview.md</li><li><strong>Classification:</strong> Live monitoring, security, and remote continuity platform</li><li><strong>Status:</strong> Advanced prototype and tested deployment architecture</li></ul>
-      </div>
-    </section>
-  </main>
+      <section class="panel-grid">
+        <div class="panel-card">
+          <h2>Product signals</h2>
+          <ul>
+            <li>real time camera feeds</li>
+            <li>remote viewing infrastructure</li>
+            <li>survivability focused monitoring</li>
+            <li>live communication systems</li>
+          </ul>
+        </div>
+        <div class="panel-card">
+          <h2>Core capabilities</h2>
+          <ul>
+            <li>phones</li>
+            <li>tablets</li>
+            <li>laptops</li>
+            <li>desktops</li>
+            <li>webcams</li>
+            <li>live viewing rooms</li>
+            <li>secure stream routing</li>
+            <li>remote monitoring sessions</li>
+          </ul>
+        </div>
+        <div class="panel-card">
+          <h2>Metadata checks</h2>
+          <ul>
+            <li>
+              <strong>Canonical route:</strong>
+              <a
+                href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crowncam/overview.md#Overview"
+                >Crown Labs Bible documentation app</a
+              >
+            </li>
+            <li>
+              <strong>Classification:</strong> Live monitoring, security, and remote continuity
+              platform
+            </li>
+            <li><strong>Status:</strong> Advanced prototype and tested deployment architecture</li>
+          </ul>
+        </div>
+      </section>
+    </main>
 
-  <footer class="product-footer">
-    <p>© Crown Labs • Generated from canonical Crown Labs Bible metadata.</p>
-  </footer>
+    <footer class="product-footer">
+      <p>© Crown Labs • Generated from canonical Crown Labs Bible metadata.</p>
+    </footer>
 
-  <script src="../../assets/labs-product.js" defer></script>
-</body>
+    <script>
+      ;(() => {
+        const header = document.querySelector('.top-nav')
+        const toggle = document.querySelector('.product-menu-toggle')
+        const menu = document.getElementById('product-site-menu')
+        if (!header || !toggle || !menu) return
+        const close = () => {
+          header.classList.remove('nav-open')
+          toggle.setAttribute('aria-expanded', 'false')
+        }
+        toggle.addEventListener('click', () => {
+          const open = !header.classList.contains('nav-open')
+          header.classList.toggle('nav-open', open)
+          toggle.setAttribute('aria-expanded', String(open))
+        })
+        menu.addEventListener('click', (event) => {
+          if (event.target.closest('a')) close()
+        })
+        document.addEventListener('keydown', (event) => {
+          if (event.key === 'Escape') close()
+        })
+        document.addEventListener('click', (event) => {
+          if (!header.contains(event.target)) close()
+        })
+      })()
+    </script>
+    <script src="../../assets/labs-product.js" defer></script>
+  </body>
 </html>

--- a/labs/products/crowncast.html
+++ b/labs/products/crowncast.html
@@ -1,102 +1,292 @@
 <!doctype html>
 <html lang="en" data-theme="dark">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-  <title>CrownCast | Crown Labs</title>
-  <meta name="description" content="CrownCast is a daily alignment and motivational platform designed to help users improve self awareness, emotional clarity, reflection, and personal alignment." />
-  <meta name="theme-color" content="#0b0f17" />
-  <link rel="canonical" href="https://www.darenprince.com/labs/products/crowncast.html" />
-  <meta property="og:type" content="article" />
-  <meta property="og:title" content="CrownCast | Crown Labs" />
-  <meta property="og:description" content="CrownCast is a daily alignment and motivational platform designed to help users improve self awareness, emotional clarity, reflection, and personal alignment." />
-  <meta property="og:url" content="https://www.darenprince.com/labs/products/crowncast.html" />
-  <meta property="og:image" content="https://www.darenprince.com/labs/assets/labs-opengraph.svg" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="CrownCast | Crown Labs" />
-  <meta name="twitter:description" content="CrownCast is a daily alignment and motivational platform designed to help users improve self awareness, emotional clarity, reflection, and personal alignment." />
-  <meta name="twitter:image" content="https://www.darenprince.com/labs/assets/labs-opengraph.svg" />
-  <link rel="icon" type="image/svg+xml" href="../assets/labs-favicon.svg" />
-  <link rel="stylesheet" href="../../assets/labs-product.css" />
-</head>
-<body class="theme-dark product-page">
-  <header class="top-nav">
-    <div class="nav-brand">
-      <img src="../assets/crown-labs-logo.png" alt="Crown Labs" />
-      <div>
-        <strong>CrownCast</strong>
-        <div class="footer-note">Sourced from docs/crownlabsbible/04-product-dossiers/crowncast/overview.md</div>
-      </div>
-    </div>
-    <div class="nav-actions">
-      <a class="back-link" href="../#products">Back to Labs</a>
-      <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
-      <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
-    </div>
-  </header>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>CrownCast | Crown Labs</title>
+    <meta
+      name="description"
+      content="CrownCast is a daily alignment and motivational platform designed to help users improve self awareness, emotional clarity, reflection, and personal alignment."
+    />
+    <meta name="theme-color" content="#0b0f17" />
+    <link rel="canonical" href="https://www.darenprince.com/labs/products/crowncast.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="CrownCast | Crown Labs" />
+    <meta
+      property="og:description"
+      content="CrownCast is a daily alignment and motivational platform designed to help users improve self awareness, emotional clarity, reflection, and personal alignment."
+    />
+    <meta property="og:url" content="https://www.darenprince.com/labs/products/crowncast.html" />
+    <meta
+      property="og:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="CrownCast | Crown Labs" />
+    <meta
+      name="twitter:description"
+      content="CrownCast is a daily alignment and motivational platform designed to help users improve self awareness, emotional clarity, reflection, and personal alignment."
+    />
+    <meta
+      name="twitter:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <link rel="icon" type="image/svg+xml" href="../assets/labs-favicon.svg" />
+    <script src="https://code.iconify.design/iconify-icon/2.1.0/iconify-icon.min.js"></script>
+    <link rel="stylesheet" href="../../assets/labs-product.css" />
 
-  <main>
-    <section class="product-hero">
-      <div>
-        <div class="hero-tags">
-          <span class="tag">Active conceptual development</span>
-          <span class="tag">Daily alignment and motivational platform</span>
+    <style>
+      .top-nav {
+        gap: 1rem;
+      }
+      .nav-actions {
+        align-items: center;
+      }
+      .product-menu-toggle {
+        display: none;
+        align-items: center;
+        justify-content: center;
+        width: 42px;
+        height: 42px;
+        border: 1px solid rgba(231, 237, 246, 0.16);
+        background: rgba(18, 26, 39, 0.84);
+        color: currentColor;
+        font-size: 1.35rem;
+      }
+      .modern-product-nav {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 0.5rem;
+      }
+      .modern-product-nav a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.42rem;
+      }
+      .modern-product-nav iconify-icon {
+        color: #8ea2ff;
+        font-size: 1.02rem;
+      }
+      @media (max-width: 860px) {
+        .top-nav {
+          position: sticky;
+          top: 0;
+          z-index: 50;
+        }
+        .product-menu-toggle {
+          display: inline-flex;
+        }
+        .nav-actions {
+          position: relative;
+          margin-left: auto;
+        }
+        .modern-product-nav {
+          position: absolute;
+          top: calc(100% + 10px);
+          right: 0;
+          min-width: min(82vw, 320px);
+          display: none;
+          flex-direction: column;
+          padding: 12px;
+          border: 1px solid rgba(231, 237, 246, 0.16);
+          background: rgba(8, 12, 19, 0.98);
+          box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+        }
+        .top-nav.nav-open .modern-product-nav {
+          display: flex;
+        }
+        .modern-product-nav a {
+          justify-content: flex-start;
+          padding: 12px 14px;
+        }
+      }
+    </style>
+  </head>
+  <body class="theme-dark product-page">
+    <header class="top-nav">
+      <div class="nav-brand">
+        <img src="../assets/crown-labs-logo.png" alt="Crown Labs" />
+        <div>
+          <strong>CrownCast</strong>
+          <div class="footer-note">Sourced from Crown Labs Bible documentation application.</div>
         </div>
-        <h1>CrownCast</h1>
-        <p class="subtitle">CrownCast is a daily alignment and motivational platform designed to help users improve self awareness, emotional clarity, reflection, and personal alignment.</p>
-        <p>CrownCast is a daily alignment and motivational platform designed to help users improve self awareness, emotional clarity, reflection, and personal alignment.</p>
-        <div class="access-actions">
-          <a class="primary-btn" href="../../docs/crownlabsbible/04-product-dossiers/crowncast/overview.md">Open canonical dossier</a>
-          <a class="ghost-btn" href="../#products">Explore Labs</a>
+      </div>
+      <div class="nav-actions">
+        <button
+          class="product-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="product-site-menu"
+          aria-label="Open Crown Labs navigation"
+        >
+          <iconify-icon icon="tabler:menu-2" aria-hidden="true"></iconify-icon>
+        </button>
+        <nav class="modern-product-nav" id="product-site-menu" aria-label="Crown Labs navigation">
+          <a class="back-link" href="../"
+            ><iconify-icon icon="tabler:home-2" aria-hidden="true"></iconify-icon
+            ><span>Home</span></a
+          >
+          <a class="back-link" href="../#products"
+            ><iconify-icon icon="tabler:box" aria-hidden="true"></iconify-icon
+            ><span>Products</span></a
+          >
+          <a class="back-link" href="../#crowncode"
+            ><iconify-icon icon="tabler:cpu-2" aria-hidden="true"></iconify-icon
+            ><span>Technology</span></a
+          >
+          <a class="back-link" href="../#founder"
+            ><iconify-icon icon="tabler:crown" aria-hidden="true"></iconify-icon
+            ><span>Founder</span></a
+          >
+          <a class="back-link" href="../../docs/crownlabsbible/docs/index.html"
+            ><iconify-icon icon="tabler:file-text" aria-hidden="true"></iconify-icon
+            ><span>Documentation</span></a
+          >
+          <a class="back-link" href="mailto:apps@crownlabs.tech"
+            ><iconify-icon icon="tabler:mail" aria-hidden="true"></iconify-icon
+            ><span>Contact</span></a
+          >
+          <button
+            class="theme-toggle"
+            id="theme-toggle"
+            type="button"
+            aria-pressed="false"
+            aria-label="Toggle light and dark mode"
+          >
+            Theme
+          </button>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="product-hero">
+        <div>
+          <div class="hero-tags">
+            <span class="tag">Active conceptual development</span>
+            <span class="tag">Daily alignment and motivational platform</span>
+          </div>
+          <h1>CrownCast</h1>
+          <p class="subtitle">
+            CrownCast is a daily alignment and motivational platform designed to help users improve
+            self awareness, emotional clarity, reflection, and personal alignment.
+          </p>
+          <p>
+            CrownCast is a daily alignment and motivational platform designed to help users improve
+            self awareness, emotional clarity, reflection, and personal alignment.
+          </p>
+          <div class="access-actions">
+            <a
+              class="primary-btn"
+              href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crowncast/overview.md#Overview"
+              >Open documentation app</a
+            >
+            <a class="ghost-btn" href="../#products">Explore Labs</a>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <section class="panel-grid">
-      <div class="panel-card">
-        <h2>Canonical status</h2>
-        <p><strong>Status:</strong> Active conceptual development</p>
-        <p><strong>Classification:</strong> Reflection and insight ecosystem</p>
-        <p><strong>Readiness signal:</strong> 50% documentation readiness signal</p>
-      </div>
-      <div class="panel-card">
-        <h2>Source governance</h2>
-        <p><strong>Authority:</strong> docs/crownlabsbible/</p>
-        <p><strong>Source file:</strong> docs/crownlabsbible/04-product-dossiers/crowncast/overview.md</p>
-        <p><strong>Update rule:</strong> edit the dossier first, then regenerate metadata.</p>
-      </div>
-      <div class="panel-card">
-        <h2>Valuation reference</h2>
-        <p>$2,000,000 to $6,500,000</p>
-        <p class="footer-note">Financial language remains directional and must be verified against canonical valuation dossiers.</p>
-      </div>
-    </section>
+      <section class="panel-grid">
+        <div class="panel-card">
+          <h2>Canonical status</h2>
+          <p><strong>Status:</strong> Active conceptual development</p>
+          <p><strong>Classification:</strong> Reflection and insight ecosystem</p>
+          <p><strong>Readiness signal:</strong> 50% documentation readiness signal</p>
+        </div>
+        <div class="panel-card">
+          <h2>Source governance</h2>
+          <p><strong>Authority:</strong> Crown Labs Bible documentation application</p>
+          <p>
+            <strong>Documentation route:</strong>
+            <a
+              href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crowncast/overview.md#Overview"
+              >Crown Labs Bible viewer</a
+            >
+          </p>
+          <p><strong>Update rule:</strong> edit the dossier first, then regenerate metadata.</p>
+        </div>
+        <div class="panel-card">
+          <h2>Valuation reference</h2>
+          <p>$2,000,000 to $6,500,000</p>
+          <p class="footer-note">
+            Financial language remains directional and must be verified against canonical valuation
+            dossiers.
+          </p>
+        </div>
+      </section>
 
-    <section class="section-block">
-      <h2>What it is</h2>
-      <p>CrownCast is a daily alignment and motivational platform designed to help users improve self awareness, emotional clarity, reflection, and personal alignment.</p><p>The platform combines:</p><p>into a unified reflection ecosystem.</p>
-    </section>
+      <section class="section-block">
+        <h2>What it is</h2>
+        <p>
+          CrownCast is a daily alignment and motivational platform designed to help users improve
+          self awareness, emotional clarity, reflection, and personal alignment.
+        </p>
+        <p>The platform combines:</p>
+        <p>into a unified reflection ecosystem.</p>
+      </section>
 
-    <section class="panel-grid">
-      <div class="panel-card">
-        <h2>Product signals</h2>
-        <ul><li>reflection systems</li><li>alignment focused insight delivery</li><li>motivational guidance</li><li>daily awareness workflows</li></ul>
-      </div>
-      <div class="panel-card">
-        <h2>Core capabilities</h2>
-        <ul></ul>
-      </div>
-      <div class="panel-card">
-        <h2>Metadata checks</h2>
-        <ul><li><strong>Canonical source:</strong> docs/crownlabsbible/04-product-dossiers/crowncast/overview.md</li><li><strong>Classification:</strong> Daily alignment and motivational platform</li><li><strong>Status:</strong> Active conceptual development</li></ul>
-      </div>
-    </section>
-  </main>
+      <section class="panel-grid">
+        <div class="panel-card">
+          <h2>Product signals</h2>
+          <ul>
+            <li>reflection systems</li>
+            <li>alignment focused insight delivery</li>
+            <li>motivational guidance</li>
+            <li>daily awareness workflows</li>
+          </ul>
+        </div>
+        <div class="panel-card">
+          <h2>Core capabilities</h2>
+          <ul></ul>
+        </div>
+        <div class="panel-card">
+          <h2>Metadata checks</h2>
+          <ul>
+            <li>
+              <strong>Canonical route:</strong>
+              <a
+                href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/crowncast/overview.md#Overview"
+                >Crown Labs Bible documentation app</a
+              >
+            </li>
+            <li><strong>Classification:</strong> Daily alignment and motivational platform</li>
+            <li><strong>Status:</strong> Active conceptual development</li>
+          </ul>
+        </div>
+      </section>
+    </main>
 
-  <footer class="product-footer">
-    <p>© Crown Labs • Generated from canonical Crown Labs Bible metadata.</p>
-  </footer>
+    <footer class="product-footer">
+      <p>© Crown Labs • Generated from canonical Crown Labs Bible metadata.</p>
+    </footer>
 
-  <script src="../../assets/labs-product.js" defer></script>
-</body>
+    <script>
+      ;(() => {
+        const header = document.querySelector('.top-nav')
+        const toggle = document.querySelector('.product-menu-toggle')
+        const menu = document.getElementById('product-site-menu')
+        if (!header || !toggle || !menu) return
+        const close = () => {
+          header.classList.remove('nav-open')
+          toggle.setAttribute('aria-expanded', 'false')
+        }
+        toggle.addEventListener('click', () => {
+          const open = !header.classList.contains('nav-open')
+          header.classList.toggle('nav-open', open)
+          toggle.setAttribute('aria-expanded', String(open))
+        })
+        menu.addEventListener('click', (event) => {
+          if (event.target.closest('a')) close()
+        })
+        document.addEventListener('keydown', (event) => {
+          if (event.key === 'Escape') close()
+        })
+        document.addEventListener('click', (event) => {
+          if (!header.contains(event.target)) close()
+        })
+      })()
+    </script>
+    <script src="../../assets/labs-product.js" defer></script>
+  </body>
 </html>

--- a/labs/products/crowncode-ai.html
+++ b/labs/products/crowncode-ai.html
@@ -1,102 +1,292 @@
 <!doctype html>
 <html lang="en" data-theme="dark">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-  <title>CrownCode.ai | Crown Labs</title>
-  <meta name="description" content="CrownCode.ai is not positioned as a single standalone application." />
-  <meta name="theme-color" content="#0b0f17" />
-  <link rel="canonical" href="https://www.darenprince.com/labs/products/crowncode-ai.html" />
-  <meta property="og:type" content="article" />
-  <meta property="og:title" content="CrownCode.ai | Crown Labs" />
-  <meta property="og:description" content="CrownCode.ai is not positioned as a single standalone application." />
-  <meta property="og:url" content="https://www.darenprince.com/labs/products/crowncode-ai.html" />
-  <meta property="og:image" content="https://www.darenprince.com/labs/assets/labs-opengraph.svg" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="CrownCode.ai | Crown Labs" />
-  <meta name="twitter:description" content="CrownCode.ai is not positioned as a single standalone application." />
-  <meta name="twitter:image" content="https://www.darenprince.com/labs/assets/labs-opengraph.svg" />
-  <link rel="icon" type="image/svg+xml" href="../assets/labs-favicon.svg" />
-  <link rel="stylesheet" href="../../assets/labs-product.css" />
-</head>
-<body class="theme-dark product-page">
-  <header class="top-nav">
-    <div class="nav-brand">
-      <img src="../assets/crown-labs-logo.png" alt="Crown Labs" />
-      <div>
-        <strong>CrownCode.ai</strong>
-        <div class="footer-note">Sourced from docs/crownlabsbible/02-products/crowncode-ai.md</div>
-      </div>
-    </div>
-    <div class="nav-actions">
-      <a class="back-link" href="../#products">Back to Labs</a>
-      <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
-      <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
-    </div>
-  </header>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>CrownCode.ai | Crown Labs</title>
+    <meta
+      name="description"
+      content="CrownCode.ai is not positioned as a single standalone application."
+    />
+    <meta name="theme-color" content="#0b0f17" />
+    <link rel="canonical" href="https://www.darenprince.com/labs/products/crowncode-ai.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="CrownCode.ai | Crown Labs" />
+    <meta
+      property="og:description"
+      content="CrownCode.ai is not positioned as a single standalone application."
+    />
+    <meta property="og:url" content="https://www.darenprince.com/labs/products/crowncode-ai.html" />
+    <meta
+      property="og:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="CrownCode.ai | Crown Labs" />
+    <meta
+      name="twitter:description"
+      content="CrownCode.ai is not positioned as a single standalone application."
+    />
+    <meta
+      name="twitter:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <link rel="icon" type="image/svg+xml" href="../assets/labs-favicon.svg" />
+    <script src="https://code.iconify.design/iconify-icon/2.1.0/iconify-icon.min.js"></script>
+    <link rel="stylesheet" href="../../assets/labs-product.css" />
 
-  <main>
-    <section class="product-hero">
-      <div>
-        <div class="hero-tags">
-          <span class="tag">Active Development</span>
-          <span class="tag">Platform Infrastructure / Applied Intelligence Systems / Shared Crown Labs AI Layer</span>
+    <style>
+      .top-nav {
+        gap: 1rem;
+      }
+      .nav-actions {
+        align-items: center;
+      }
+      .product-menu-toggle {
+        display: none;
+        align-items: center;
+        justify-content: center;
+        width: 42px;
+        height: 42px;
+        border: 1px solid rgba(231, 237, 246, 0.16);
+        background: rgba(18, 26, 39, 0.84);
+        color: currentColor;
+        font-size: 1.35rem;
+      }
+      .modern-product-nav {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 0.5rem;
+      }
+      .modern-product-nav a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.42rem;
+      }
+      .modern-product-nav iconify-icon {
+        color: #8ea2ff;
+        font-size: 1.02rem;
+      }
+      @media (max-width: 860px) {
+        .top-nav {
+          position: sticky;
+          top: 0;
+          z-index: 50;
+        }
+        .product-menu-toggle {
+          display: inline-flex;
+        }
+        .nav-actions {
+          position: relative;
+          margin-left: auto;
+        }
+        .modern-product-nav {
+          position: absolute;
+          top: calc(100% + 10px);
+          right: 0;
+          min-width: min(82vw, 320px);
+          display: none;
+          flex-direction: column;
+          padding: 12px;
+          border: 1px solid rgba(231, 237, 246, 0.16);
+          background: rgba(8, 12, 19, 0.98);
+          box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+        }
+        .top-nav.nav-open .modern-product-nav {
+          display: flex;
+        }
+        .modern-product-nav a {
+          justify-content: flex-start;
+          padding: 12px 14px;
+        }
+      }
+    </style>
+  </head>
+  <body class="theme-dark product-page">
+    <header class="top-nav">
+      <div class="nav-brand">
+        <img src="../assets/crown-labs-logo.png" alt="Crown Labs" />
+        <div>
+          <strong>CrownCode.ai</strong>
+          <div class="footer-note">Sourced from Crown Labs Bible documentation application.</div>
         </div>
-        <h1>CrownCode.ai</h1>
-        <p class="subtitle">CrownCode.ai is not positioned as a single standalone application.</p>
-        <p>CrownCode.ai is not positioned as a single standalone application.</p>
-        <div class="access-actions">
-          <a class="primary-btn" href="../../docs/crownlabsbible/02-products/crowncode-ai.md">Open canonical dossier</a>
-          <a class="ghost-btn" href="../#products">Explore Labs</a>
+      </div>
+      <div class="nav-actions">
+        <button
+          class="product-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="product-site-menu"
+          aria-label="Open Crown Labs navigation"
+        >
+          <iconify-icon icon="tabler:menu-2" aria-hidden="true"></iconify-icon>
+        </button>
+        <nav class="modern-product-nav" id="product-site-menu" aria-label="Crown Labs navigation">
+          <a class="back-link" href="../"
+            ><iconify-icon icon="tabler:home-2" aria-hidden="true"></iconify-icon
+            ><span>Home</span></a
+          >
+          <a class="back-link" href="../#products"
+            ><iconify-icon icon="tabler:box" aria-hidden="true"></iconify-icon
+            ><span>Products</span></a
+          >
+          <a class="back-link" href="../#crowncode"
+            ><iconify-icon icon="tabler:cpu-2" aria-hidden="true"></iconify-icon
+            ><span>Technology</span></a
+          >
+          <a class="back-link" href="../#founder"
+            ><iconify-icon icon="tabler:crown" aria-hidden="true"></iconify-icon
+            ><span>Founder</span></a
+          >
+          <a class="back-link" href="../../docs/crownlabsbible/docs/index.html"
+            ><iconify-icon icon="tabler:file-text" aria-hidden="true"></iconify-icon
+            ><span>Documentation</span></a
+          >
+          <a class="back-link" href="mailto:apps@crownlabs.tech"
+            ><iconify-icon icon="tabler:mail" aria-hidden="true"></iconify-icon
+            ><span>Contact</span></a
+          >
+          <button
+            class="theme-toggle"
+            id="theme-toggle"
+            type="button"
+            aria-pressed="false"
+            aria-label="Toggle light and dark mode"
+          >
+            Theme
+          </button>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="product-hero">
+        <div>
+          <div class="hero-tags">
+            <span class="tag">Active Development</span>
+            <span class="tag"
+              >Platform Infrastructure / Applied Intelligence Systems / Shared Crown Labs AI
+              Layer</span
+            >
+          </div>
+          <h1>CrownCode.ai</h1>
+          <p class="subtitle">CrownCode.ai is not positioned as a single standalone application.</p>
+          <p>CrownCode.ai is not positioned as a single standalone application.</p>
+          <div class="access-actions">
+            <a class="primary-btn" href="../../docs/crownlabsbible/docs/crowncode-ai.html"
+              >Open documentation app</a
+            >
+            <a class="ghost-btn" href="../#products">Explore Labs</a>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <section class="panel-grid">
-      <div class="panel-card">
-        <h2>Canonical status</h2>
-        <p><strong>Status:</strong> Active Development</p>
-        <p><strong>Classification:</strong> Platform Infrastructure / Applied Intelligence Systems / Shared Crown Labs AI Layer</p>
-        <p><strong>Readiness signal:</strong> 74% documentation readiness signal</p>
-      </div>
-      <div class="panel-card">
-        <h2>Source governance</h2>
-        <p><strong>Authority:</strong> docs/crownlabsbible/</p>
-        <p><strong>Source file:</strong> docs/crownlabsbible/02-products/crowncode-ai.md</p>
-        <p><strong>Update rule:</strong> edit the dossier first, then regenerate metadata.</p>
-      </div>
-      <div class="panel-card">
-        <h2>Valuation reference</h2>
-        <p>See canonical valuation dossier</p>
-        <p class="footer-note">Financial language remains directional and must be verified against canonical valuation dossiers.</p>
-      </div>
-    </section>
+      <section class="panel-grid">
+        <div class="panel-card">
+          <h2>Canonical status</h2>
+          <p><strong>Status:</strong> Active Development</p>
+          <p>
+            <strong>Classification:</strong> Platform Infrastructure / Applied Intelligence Systems
+            / Shared Crown Labs AI Layer
+          </p>
+          <p><strong>Readiness signal:</strong> 74% documentation readiness signal</p>
+        </div>
+        <div class="panel-card">
+          <h2>Source governance</h2>
+          <p><strong>Authority:</strong> Crown Labs Bible documentation application</p>
+          <p>
+            <strong>Documentation route:</strong>
+            <a href="../../docs/crownlabsbible/docs/crowncode-ai.html">Crown Labs Bible viewer</a>
+          </p>
+          <p><strong>Update rule:</strong> edit the dossier first, then regenerate metadata.</p>
+        </div>
+        <div class="panel-card">
+          <h2>Valuation reference</h2>
+          <p>See canonical valuation dossier</p>
+          <p class="footer-note">
+            Financial language remains directional and must be verified against canonical valuation
+            dossiers.
+          </p>
+        </div>
+      </section>
 
-    <section class="section-block">
-      <h2>What it is</h2>
-      <p>CrownCode.ai is not positioned as a single standalone application. It is the operational and technical substrate behind multiple Crown Labs products and initiatives.</p><p>The platform exists to:</p><p>CrownCode.ai acts as the connective framework between behavioral systems, documentation systems, AI tooling, reporting engines, monitoring systems, and future modular services.</p>
-    </section>
+      <section class="section-block">
+        <h2>What it is</h2>
+        <p>
+          CrownCode.ai is not positioned as a single standalone application. It is the operational
+          and technical substrate behind multiple Crown Labs products and initiatives.
+        </p>
+        <p>The platform exists to:</p>
+        <p>
+          CrownCode.ai acts as the connective framework between behavioral systems, documentation
+          systems, AI tooling, reporting engines, monitoring systems, and future modular services.
+        </p>
+      </section>
 
-    <section class="panel-grid">
-      <div class="panel-card">
-        <h2>Product signals</h2>
-        <ul><li>reduce duplicated development effort</li><li>centralize reusable intelligence systems</li><li>standardize architecture across products</li><li>accelerate launch velocity</li></ul>
-      </div>
-      <div class="panel-card">
-        <h2>Core capabilities</h2>
-        <ul></ul>
-      </div>
-      <div class="panel-card">
-        <h2>Metadata checks</h2>
-        <ul><li><strong>Canonical source:</strong> docs/crownlabsbible/02-products/crowncode-ai.md</li><li><strong>Classification:</strong> Platform Infrastructure / Applied Intelligence Systems / Shared Crown Labs AI Layer</li><li><strong>Status:</strong> Active Development</li></ul>
-      </div>
-    </section>
-  </main>
+      <section class="panel-grid">
+        <div class="panel-card">
+          <h2>Product signals</h2>
+          <ul>
+            <li>reduce duplicated development effort</li>
+            <li>centralize reusable intelligence systems</li>
+            <li>standardize architecture across products</li>
+            <li>accelerate launch velocity</li>
+          </ul>
+        </div>
+        <div class="panel-card">
+          <h2>Core capabilities</h2>
+          <ul></ul>
+        </div>
+        <div class="panel-card">
+          <h2>Metadata checks</h2>
+          <ul>
+            <li>
+              <strong>Canonical route:</strong>
+              <a href="../../docs/crownlabsbible/docs/crowncode-ai.html"
+                >Crown Labs Bible documentation app</a
+              >
+            </li>
+            <li>
+              <strong>Classification:</strong> Platform Infrastructure / Applied Intelligence
+              Systems / Shared Crown Labs AI Layer
+            </li>
+            <li><strong>Status:</strong> Active Development</li>
+          </ul>
+        </div>
+      </section>
+    </main>
 
-  <footer class="product-footer">
-    <p>© Crown Labs • Generated from canonical Crown Labs Bible metadata.</p>
-  </footer>
+    <footer class="product-footer">
+      <p>© Crown Labs • Generated from canonical Crown Labs Bible metadata.</p>
+    </footer>
 
-  <script src="../../assets/labs-product.js" defer></script>
-</body>
+    <script>
+      ;(() => {
+        const header = document.querySelector('.top-nav')
+        const toggle = document.querySelector('.product-menu-toggle')
+        const menu = document.getElementById('product-site-menu')
+        if (!header || !toggle || !menu) return
+        const close = () => {
+          header.classList.remove('nav-open')
+          toggle.setAttribute('aria-expanded', 'false')
+        }
+        toggle.addEventListener('click', () => {
+          const open = !header.classList.contains('nav-open')
+          header.classList.toggle('nav-open', open)
+          toggle.setAttribute('aria-expanded', String(open))
+        })
+        menu.addEventListener('click', (event) => {
+          if (event.target.closest('a')) close()
+        })
+        document.addEventListener('keydown', (event) => {
+          if (event.key === 'Escape') close()
+        })
+        document.addEventListener('click', (event) => {
+          if (!header.contains(event.target)) close()
+        })
+      })()
+    </script>
+    <script src="../../assets/labs-product.js" defer></script>
+  </body>
 </html>

--- a/labs/products/sentinel-vault.html
+++ b/labs/products/sentinel-vault.html
@@ -1,102 +1,318 @@
 <!doctype html>
 <html lang="en" data-theme="dark">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-  <title>Sentinel Vault | Crown Labs</title>
-  <meta name="description" content="Sentinel Vault is a privacy centered survivability and evidence continuity platform designed to help users preserve critical information, maintain emergency communication capability, and protect sensitive personal evidence during high stress, dangerous, or unstable situations." />
-  <meta name="theme-color" content="#0b0f17" />
-  <link rel="canonical" href="https://www.darenprince.com/labs/products/sentinel-vault.html" />
-  <meta property="og:type" content="article" />
-  <meta property="og:title" content="Sentinel Vault | Crown Labs" />
-  <meta property="og:description" content="Sentinel Vault is a privacy centered survivability and evidence continuity platform designed to help users preserve critical information, maintain emergency communication capability, and protect sensitive personal evidence during high stress, dangerous, or unstable situations." />
-  <meta property="og:url" content="https://www.darenprince.com/labs/products/sentinel-vault.html" />
-  <meta property="og:image" content="https://www.darenprince.com/labs/assets/labs-opengraph.svg" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Sentinel Vault | Crown Labs" />
-  <meta name="twitter:description" content="Sentinel Vault is a privacy centered survivability and evidence continuity platform designed to help users preserve critical information, maintain emergency communication capability, and protect sensitive personal evidence during high stress, dangerous, or unstable situations." />
-  <meta name="twitter:image" content="https://www.darenprince.com/labs/assets/labs-opengraph.svg" />
-  <link rel="icon" type="image/svg+xml" href="../assets/labs-favicon.svg" />
-  <link rel="stylesheet" href="../../assets/labs-product.css" />
-</head>
-<body class="theme-dark product-page">
-  <header class="top-nav">
-    <div class="nav-brand">
-      <img src="../assets/crown-labs-logo.png" alt="Crown Labs" />
-      <div>
-        <strong>Sentinel Vault</strong>
-        <div class="footer-note">Sourced from docs/crownlabsbible/04-product-dossiers/sentinel-vault/overview.md</div>
-      </div>
-    </div>
-    <div class="nav-actions">
-      <a class="back-link" href="../#products">Back to Labs</a>
-      <a class="back-link" href="../../docs/crownlabsbible/docs/index.html">Crown Labs Bible</a>
-      <button class="theme-toggle" id="theme-toggle" type="button" aria-pressed="false" aria-label="Toggle light and dark mode">Theme</button>
-    </div>
-  </header>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Sentinel Vault | Crown Labs</title>
+    <meta
+      name="description"
+      content="Sentinel Vault is a privacy centered survivability and evidence continuity platform designed to help users preserve critical information, maintain emergency communication capability, and protect sensitive personal evidence during high stress, dangerous, or unstable situations."
+    />
+    <meta name="theme-color" content="#0b0f17" />
+    <link rel="canonical" href="https://www.darenprince.com/labs/products/sentinel-vault.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="Sentinel Vault | Crown Labs" />
+    <meta
+      property="og:description"
+      content="Sentinel Vault is a privacy centered survivability and evidence continuity platform designed to help users preserve critical information, maintain emergency communication capability, and protect sensitive personal evidence during high stress, dangerous, or unstable situations."
+    />
+    <meta
+      property="og:url"
+      content="https://www.darenprince.com/labs/products/sentinel-vault.html"
+    />
+    <meta
+      property="og:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Sentinel Vault | Crown Labs" />
+    <meta
+      name="twitter:description"
+      content="Sentinel Vault is a privacy centered survivability and evidence continuity platform designed to help users preserve critical information, maintain emergency communication capability, and protect sensitive personal evidence during high stress, dangerous, or unstable situations."
+    />
+    <meta
+      name="twitter:image"
+      content="https://www.darenprince.com/labs/assets/labs-opengraph.svg"
+    />
+    <link rel="icon" type="image/svg+xml" href="../assets/labs-favicon.svg" />
+    <script src="https://code.iconify.design/iconify-icon/2.1.0/iconify-icon.min.js"></script>
+    <link rel="stylesheet" href="../../assets/labs-product.css" />
 
-  <main>
-    <section class="product-hero">
-      <div>
-        <div class="hero-tags">
-          <span class="tag">Advanced prototype and strategic infrastructure concept</span>
-          <span class="tag">Security, survivability, and evidence continuity platform</span>
+    <style>
+      .top-nav {
+        gap: 1rem;
+      }
+      .nav-actions {
+        align-items: center;
+      }
+      .product-menu-toggle {
+        display: none;
+        align-items: center;
+        justify-content: center;
+        width: 42px;
+        height: 42px;
+        border: 1px solid rgba(231, 237, 246, 0.16);
+        background: rgba(18, 26, 39, 0.84);
+        color: currentColor;
+        font-size: 1.35rem;
+      }
+      .modern-product-nav {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 0.5rem;
+      }
+      .modern-product-nav a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.42rem;
+      }
+      .modern-product-nav iconify-icon {
+        color: #8ea2ff;
+        font-size: 1.02rem;
+      }
+      @media (max-width: 860px) {
+        .top-nav {
+          position: sticky;
+          top: 0;
+          z-index: 50;
+        }
+        .product-menu-toggle {
+          display: inline-flex;
+        }
+        .nav-actions {
+          position: relative;
+          margin-left: auto;
+        }
+        .modern-product-nav {
+          position: absolute;
+          top: calc(100% + 10px);
+          right: 0;
+          min-width: min(82vw, 320px);
+          display: none;
+          flex-direction: column;
+          padding: 12px;
+          border: 1px solid rgba(231, 237, 246, 0.16);
+          background: rgba(8, 12, 19, 0.98);
+          box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+        }
+        .top-nav.nav-open .modern-product-nav {
+          display: flex;
+        }
+        .modern-product-nav a {
+          justify-content: flex-start;
+          padding: 12px 14px;
+        }
+      }
+    </style>
+  </head>
+  <body class="theme-dark product-page">
+    <header class="top-nav">
+      <div class="nav-brand">
+        <img src="../assets/crown-labs-logo.png" alt="Crown Labs" />
+        <div>
+          <strong>Sentinel Vault</strong>
+          <div class="footer-note">Sourced from Crown Labs Bible documentation application.</div>
         </div>
-        <h1>Sentinel Vault</h1>
-        <p class="subtitle">Sentinel Vault is a privacy centered survivability and evidence continuity platform designed to help users preserve critical information, maintain emergency communication capability, and protect sensitive personal evidence during high stress, dangerous, or unstable situations.</p>
-        <p>Sentinel Vault is a privacy centered survivability and evidence continuity platform designed to help users preserve critical information, maintain emergency communication capability, and protect sensitive personal evidence during high stress, dangerous, or unstable situations.</p>
-        <div class="access-actions">
-          <a class="primary-btn" href="../../docs/crownlabsbible/04-product-dossiers/sentinel-vault/overview.md">Open canonical dossier</a>
-          <a class="ghost-btn" href="../#products">Explore Labs</a>
+      </div>
+      <div class="nav-actions">
+        <button
+          class="product-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="product-site-menu"
+          aria-label="Open Crown Labs navigation"
+        >
+          <iconify-icon icon="tabler:menu-2" aria-hidden="true"></iconify-icon>
+        </button>
+        <nav class="modern-product-nav" id="product-site-menu" aria-label="Crown Labs navigation">
+          <a class="back-link" href="../"
+            ><iconify-icon icon="tabler:home-2" aria-hidden="true"></iconify-icon
+            ><span>Home</span></a
+          >
+          <a class="back-link" href="../#products"
+            ><iconify-icon icon="tabler:box" aria-hidden="true"></iconify-icon
+            ><span>Products</span></a
+          >
+          <a class="back-link" href="../#crowncode"
+            ><iconify-icon icon="tabler:cpu-2" aria-hidden="true"></iconify-icon
+            ><span>Technology</span></a
+          >
+          <a class="back-link" href="../#founder"
+            ><iconify-icon icon="tabler:crown" aria-hidden="true"></iconify-icon
+            ><span>Founder</span></a
+          >
+          <a class="back-link" href="../../docs/crownlabsbible/docs/index.html"
+            ><iconify-icon icon="tabler:file-text" aria-hidden="true"></iconify-icon
+            ><span>Documentation</span></a
+          >
+          <a class="back-link" href="mailto:apps@crownlabs.tech"
+            ><iconify-icon icon="tabler:mail" aria-hidden="true"></iconify-icon
+            ><span>Contact</span></a
+          >
+          <button
+            class="theme-toggle"
+            id="theme-toggle"
+            type="button"
+            aria-pressed="false"
+            aria-label="Toggle light and dark mode"
+          >
+            Theme
+          </button>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="product-hero">
+        <div>
+          <div class="hero-tags">
+            <span class="tag">Advanced prototype and strategic infrastructure concept</span>
+            <span class="tag">Security, survivability, and evidence continuity platform</span>
+          </div>
+          <h1>Sentinel Vault</h1>
+          <p class="subtitle">
+            Sentinel Vault is a privacy centered survivability and evidence continuity platform
+            designed to help users preserve critical information, maintain emergency communication
+            capability, and protect sensitive personal evidence during high stress, dangerous, or
+            unstable situations.
+          </p>
+          <p>
+            Sentinel Vault is a privacy centered survivability and evidence continuity platform
+            designed to help users preserve critical information, maintain emergency communication
+            capability, and protect sensitive personal evidence during high stress, dangerous, or
+            unstable situations.
+          </p>
+          <div class="access-actions">
+            <a
+              class="primary-btn"
+              href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/sentinel-vault/overview.md#Overview"
+              >Open documentation app</a
+            >
+            <a class="ghost-btn" href="../#products">Explore Labs</a>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <section class="panel-grid">
-      <div class="panel-card">
-        <h2>Canonical status</h2>
-        <p><strong>Status:</strong> Advanced prototype and strategic infrastructure concept</p>
-        <p><strong>Classification:</strong> Emergency intelligence, secure evidence preservation, and crisis continuity ecosystem</p>
-        <p><strong>Readiness signal:</strong> 55% documentation readiness signal</p>
-      </div>
-      <div class="panel-card">
-        <h2>Source governance</h2>
-        <p><strong>Authority:</strong> docs/crownlabsbible/</p>
-        <p><strong>Source file:</strong> docs/crownlabsbible/04-product-dossiers/sentinel-vault/overview.md</p>
-        <p><strong>Update rule:</strong> edit the dossier first, then regenerate metadata.</p>
-      </div>
-      <div class="panel-card">
-        <h2>Valuation reference</h2>
-        <p>$1,500,000 to $5,000,000</p>
-        <p class="footer-note">Financial language remains directional and must be verified against canonical valuation dossiers.</p>
-      </div>
-    </section>
+      <section class="panel-grid">
+        <div class="panel-card">
+          <h2>Canonical status</h2>
+          <p><strong>Status:</strong> Advanced prototype and strategic infrastructure concept</p>
+          <p>
+            <strong>Classification:</strong> Emergency intelligence, secure evidence preservation,
+            and crisis continuity ecosystem
+          </p>
+          <p><strong>Readiness signal:</strong> 55% documentation readiness signal</p>
+        </div>
+        <div class="panel-card">
+          <h2>Source governance</h2>
+          <p><strong>Authority:</strong> Crown Labs Bible documentation application</p>
+          <p>
+            <strong>Documentation route:</strong>
+            <a
+              href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/sentinel-vault/overview.md#Overview"
+              >Crown Labs Bible viewer</a
+            >
+          </p>
+          <p><strong>Update rule:</strong> edit the dossier first, then regenerate metadata.</p>
+        </div>
+        <div class="panel-card">
+          <h2>Valuation reference</h2>
+          <p>$1,500,000 to $5,000,000</p>
+          <p class="footer-note">
+            Financial language remains directional and must be verified against canonical valuation
+            dossiers.
+          </p>
+        </div>
+      </section>
 
-    <section class="section-block">
-      <h2>What it is</h2>
-      <p>Sentinel Vault is a privacy centered survivability and evidence continuity platform designed to help users preserve critical information, maintain emergency communication capability, and protect sensitive personal evidence during high stress, dangerous, or unstable situations.</p><p>The platform combines:</p><p>into a unified security focused ecosystem.</p>
-    </section>
+      <section class="section-block">
+        <h2>What it is</h2>
+        <p>
+          Sentinel Vault is a privacy centered survivability and evidence continuity platform
+          designed to help users preserve critical information, maintain emergency communication
+          capability, and protect sensitive personal evidence during high stress, dangerous, or
+          unstable situations.
+        </p>
+        <p>The platform combines:</p>
+        <p>into a unified security focused ecosystem.</p>
+      </section>
 
-    <section class="panel-grid">
-      <div class="panel-card">
-        <h2>Product signals</h2>
-        <ul><li>secure storage infrastructure</li><li>emergency communication systems</li><li>evidence continuity workflows</li><li>conditional disclosure systems</li></ul>
-      </div>
-      <div class="panel-card">
-        <h2>Core capabilities</h2>
-        <ul><li>documents</li><li>media</li><li>recordings</li><li>photographs</li><li>emergency notes</li><li>critical personal information</li><li>emergency alert systems</li><li>crisis response workflows</li></ul>
-      </div>
-      <div class="panel-card">
-        <h2>Metadata checks</h2>
-        <ul><li><strong>Canonical source:</strong> docs/crownlabsbible/04-product-dossiers/sentinel-vault/overview.md</li><li><strong>Classification:</strong> Security, survivability, and evidence continuity platform</li><li><strong>Status:</strong> Advanced prototype and strategic infrastructure concept</li></ul>
-      </div>
-    </section>
-  </main>
+      <section class="panel-grid">
+        <div class="panel-card">
+          <h2>Product signals</h2>
+          <ul>
+            <li>secure storage infrastructure</li>
+            <li>emergency communication systems</li>
+            <li>evidence continuity workflows</li>
+            <li>conditional disclosure systems</li>
+          </ul>
+        </div>
+        <div class="panel-card">
+          <h2>Core capabilities</h2>
+          <ul>
+            <li>documents</li>
+            <li>media</li>
+            <li>recordings</li>
+            <li>photographs</li>
+            <li>emergency notes</li>
+            <li>critical personal information</li>
+            <li>emergency alert systems</li>
+            <li>crisis response workflows</li>
+          </ul>
+        </div>
+        <div class="panel-card">
+          <h2>Metadata checks</h2>
+          <ul>
+            <li>
+              <strong>Canonical route:</strong>
+              <a
+                href="../../docs/crownlabsbible/docs/viewer.html?doc=../04-product-dossiers/sentinel-vault/overview.md#Overview"
+                >Crown Labs Bible documentation app</a
+              >
+            </li>
+            <li>
+              <strong>Classification:</strong> Security, survivability, and evidence continuity
+              platform
+            </li>
+            <li>
+              <strong>Status:</strong> Advanced prototype and strategic infrastructure concept
+            </li>
+          </ul>
+        </div>
+      </section>
+    </main>
 
-  <footer class="product-footer">
-    <p>© Crown Labs • Generated from canonical Crown Labs Bible metadata.</p>
-  </footer>
+    <footer class="product-footer">
+      <p>© Crown Labs • Generated from canonical Crown Labs Bible metadata.</p>
+    </footer>
 
-  <script src="../../assets/labs-product.js" defer></script>
-</body>
+    <script>
+      ;(() => {
+        const header = document.querySelector('.top-nav')
+        const toggle = document.querySelector('.product-menu-toggle')
+        const menu = document.getElementById('product-site-menu')
+        if (!header || !toggle || !menu) return
+        const close = () => {
+          header.classList.remove('nav-open')
+          toggle.setAttribute('aria-expanded', 'false')
+        }
+        toggle.addEventListener('click', () => {
+          const open = !header.classList.contains('nav-open')
+          header.classList.toggle('nav-open', open)
+          toggle.setAttribute('aria-expanded', String(open))
+        })
+        menu.addEventListener('click', (event) => {
+          if (event.target.closest('a')) close()
+        })
+        document.addEventListener('keydown', (event) => {
+          if (event.key === 'Escape') close()
+        })
+        document.addEventListener('click', (event) => {
+          if (!header.contains(event.target)) close()
+        })
+      })()
+    </script>
+    <script src="../../assets/labs-product.js" defer></script>
+  </body>
 </html>


### PR DESCRIPTION
### Motivation

- Provide a single, modern public navigation contract (Home, Products, Technology, Founder, Documentation, Contact) across the Labs landing and product pages. 
- Ensure public-facing pages link into the generated Crown Labs Bible documentation application instead of pointing at repository indexes or raw Markdown files. 
- Preserve and surface the existing documentation application experience while enabling deep-links into specific dossiers.

### Description

- Added audit artifacts `audit/navigation-map-before.md` and `audit/navigation-map-after.md` and updated `docs/LABS_PAGE_SYSTEM.md` to document the new navigation contract and documentation routing rules. 
- Updated the documentation viewer `docs/crownlabsbible/docs/viewer.html` to support the `doc` query parameter, update the URL via `history.replaceState`, and preserve the sidebar/viewer UX while enabling deep-linking into specific Markdown dossiers. 
- Modernized the public Labs pages (`labs/index.html`, `labs/crowncode/index.html`) and all `labs/products/*.html` product briefs to a consistent navigation pattern: Iconify `iconify-icon` icons, accessible hamburger toggles on mobile, rebuilt link targets to point at the docs app (for example `../docs/crownlabsbible/docs/index.html` or `viewer.html?doc=...#...`), and small markup/formatting improvements. 
- Added small client scripts to normalize documentation links and manage the mobile nav disclosure behavior, plus minor cleanups and accessibility/HTML normalization across multiple files.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e0dd8755c83259d9217c53e24c3da)