### PR TITLE
Restore GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,61 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+      - work
+  workflow_dispatch:
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build GitHub Pages artifact
+        run: npm run deploy:github-pages
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Stage GitHub Pages artifact
+        run: |
+          mkdir -p _site
+          rsync -a ./ _site/ --exclude _site --exclude .git --exclude node_modules
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+          retention-days: 7
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/BUILD_PIPELINE.md
+++ b/docs/BUILD_PIPELINE.md
@@ -1,6 +1,6 @@
 # 🏗 Build & Deployment Pipeline
 
-_Last updated: 2026-04-17_
+_Last updated: 2026-06-22_
 
 This doc captures how assets are generated locally and served via GitHub Pages. Follow it before adjusting npm scripts or automation.
 
@@ -43,12 +43,13 @@ This doc captures how assets are generated locally and served via GitHub Pages. 
 
 ## GitHub Pages configuration
 
-- Configure **Settings → Pages** to publish from `main` (root) or your preferred Pages branch.
+- Configure **Settings → Pages** to use **GitHub Actions** as the Pages source. `.github/workflows/deploy-pages.yml` builds the site, uploads the root artifact, and deploys it through the official Pages artifact flow on pushes to `main`/`work` or manual `workflow_dispatch` runs.
 - `CNAME` maps the custom domain. Keep it updated if the domain changes.
 - Add `DOMAIN` (e.g. `https://www.darenprince.com`) so `seo-enrich.js` can generate canonical URLs, sitemap entries, and structured data.
 - Keep the `data-site-root` attribute + asset-prefix patcher script in HTML files for GitHub Pages subdirectory deployments (`<user>.github.io/<repo>/`). This ensures `/assets` references resolve during local previews and production.
 - When search or image manifests change, commit the generated JSON so GitHub Pages serves updated data.
-- Netlify is no longer used. All deploys are committed artifacts published by GitHub Pages.
+- Netlify is no longer used. GitHub Pages deploys from the Actions-built artifact; generated static files still remain committed so local previews, PR previews, and rollback diffs stay inspectable.
+- Keep `.nojekyll` committed so GitHub Pages serves generated asset directories and modern static files without Jekyll filtering.
 - Pull requests with visual changes must include both desktop and mobile screenshots.
 - Keep browser chrome customizations aligned to brand green (favicons, manifest theme colors, and tile colors) and ensure OG/Twitter sharing images are committed and deployable.
 - Keep `/nexuswho/` redirect (`nexuswho/index.html`) pointing to `nexuswho.html` so clean URLs keep working.
@@ -119,5 +120,5 @@ If a visual change appears to be ignored, verify you edited the stylesheet owned
 - [ ] Verify `nexuswho.html` loads and that the latest `nexuswho-assets/*` chunks (vendor, scanner, charts, etc.) are committed for GitHub Pages.
 - [ ] Confirm `/nexuswho/` redirects to `nexuswho.html` and the fallback copy is visible if the bundle fails to load.
 - [ ] Commit generated artifacts (`assets/styles.css`, `assets/image-manifest.json`, `public/search/*.json`).
-- [ ] Push to `main` (GitHub Pages auto-publish).
+- [ ] Push to `main` or run the **Deploy GitHub Pages** workflow manually; GitHub Pages publishes the Actions artifact after the build job succeeds.
 - [ ] After deploy, confirm migration messaging is visible on auth surfaces.


### PR DESCRIPTION
### Motivation
- The public site was returning a GitHub Pages 404 because the repository lacked a Pages Actions workflow and some Pages-serving requirements, so the deployment path needed to be restored and documented. 
- Ensure GitHub Pages serves the generated static artifact (not Jekyll-filtered source) and provide a robust, repeatable Actions-driven publish flow.

### Description
- Add an official Pages pipeline at `.github/workflows/deploy-pages.yml` that runs `npm ci`, builds the site with `npm run deploy:github-pages`, stages a clean `_site` artifact via `rsync` (excluding `.git` and `node_modules`), uploads it with `actions/upload-pages-artifact`, and deploys with `actions/deploy-pages`.
- Add a committed `.nojekyll` file so generated asset directories and modern static files are served without Jekyll filtering.
- Update `docs/BUILD_PIPELINE.md` to make GitHub Actions the canonical Pages source, document the artifact-based publish and manual `workflow_dispatch` redeploy option, and add notes about keeping `.nojekyll` and committing generated artifacts.

### Testing
- `npm run lint:metadata` completed successfully and reported deploy metadata checks passed.
- `npm run deploy:github-pages` was executed locally and completed the build pipeline (site generation, icon/image manifests, Sass build, Vite bundle); the build completed despite Vite warnings about `outDir`/publicDir configuration.
- `npm test` (Vitest) was run; suite failed one smoke-test in `tests/public-site.spec.ts` because the live production homepage returned HTTP `404`, which confirms the outage this change aims to remediate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38908f0ce083259db0760cf84049be)