### PR TITLE
Add Game On Second Edition publishing structure

### DIFF
--- a/publishing/game-on-second-edition/CHANGELOG.md
+++ b/publishing/game-on-second-edition/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- Publishing project structure
+- Project Bible
+- Editorial workflow
+- Roadmap
+- Decision log
+- Chapter tracker
+- Manuscript assembly file
+- Research source index
+- Story vault
+- Marketing content engine

--- a/publishing/game-on-second-edition/DECISIONS.md
+++ b/publishing/game-on-second-edition/DECISIONS.md
@@ -1,0 +1,8 @@
+# Decision Log
+
+Record decisions that affect positioning, structure, tone, frameworks, chapter order, production, or marketing.
+
+| Date | Decision | Rationale | Files affected | Status |
+|---|---|---|---|---|
+| 2026-08-05 | Use GitHub as canonical version-controlled source and Google Drive as collaboration/export layer | Prevent lost drafts and preserve revision history | Entire project | Approved |
+| 2026-08-05 | Store project under `publishing/game-on-second-edition` in the author repository | Keeps the book connected to the author platform without changing live site code | Entire project | Approved |

--- a/publishing/game-on-second-edition/PROJECT_BIBLE.md
+++ b/publishing/game-on-second-edition/PROJECT_BIBLE.md
@@ -1,0 +1,53 @@
+# Project Bible
+
+## Working title
+
+*Game On! Master the Conversation & Win Her Heart — Second Edition*
+
+## Author
+
+Daren Prince
+
+## Core objective
+
+Transform the existing book into a stronger, more memorable, more useful, and more marketable communication and relationship guide without drifting into manipulation, unsupported psychology, or generic self-help filler.
+
+## Central promise
+
+Help men become more confident, emotionally intelligent, socially effective, and capable of building healthier romantic relationships through authentic communication.
+
+## Primary reader
+
+Men who want practical help with confidence, conversation, attraction, dating, emotional connection, conflict, and long-term relationship skills.
+
+## Editorial principles
+
+1. Transformation over information
+2. Authenticity over tactics
+3. Evidence over unsupported claims
+4. Stories and examples over abstract lectures
+5. Practical exercises over passive reading
+6. Healthy masculinity over performance or manipulation
+7. Clear language over jargon
+8. Every chapter must advance the central promise
+
+## Required chapter components
+
+1. Hook
+2. Reader problem
+3. Core insight
+4. Story or realistic example
+5. Research-supported explanation where appropriate
+6. Practical framework
+7. Common mistakes
+8. Exercise or challenge
+9. Memorable takeaway
+10. Transition to the next chapter
+
+## Canonical records
+
+Structural decisions belong in `DECISIONS.md`.
+Project progress belongs in `ROADMAP.md`.
+Release-level changes belong in `CHANGELOG.md`.
+Research claims belong in `research/SOURCE_INDEX.md`.
+Chapter status belongs in `manuscript/CHAPTER_TRACKER.md`.

--- a/publishing/game-on-second-edition/README.md
+++ b/publishing/game-on-second-edition/README.md
@@ -1,0 +1,19 @@
+# Game On! Second Edition
+
+This directory is the version-controlled publishing headquarters for the revised edition of *Game On! Master the Conversation & Win Her Heart* by Daren Prince.
+
+## Source of truth
+
+GitHub stores canonical manuscript text, research indexes, editorial decisions, revision history, and automation configuration. Google Drive is used for visual review, collaboration, exports, and marketing assets.
+
+## Workflow
+
+1. Audit original manuscript
+2. Approve revised architecture
+3. Research and source claims
+4. Draft chapter revisions
+5. Run developmental, evidence, continuity, and copy passes
+6. Assemble publication candidate
+7. Generate marketing and companion assets
+
+See `PROJECT_BIBLE.md`, `ROADMAP.md`, and `WORKFLOW.md` before making structural changes.

--- a/publishing/game-on-second-edition/ROADMAP.md
+++ b/publishing/game-on-second-edition/ROADMAP.md
@@ -1,0 +1,63 @@
+# Roadmap
+
+## Phase 0 — Foundation
+
+- [x] Create repository structure
+- [ ] Import original manuscript
+- [ ] Confirm rights and source files
+- [ ] Record current edition metadata
+
+## Phase 1 — Manuscript Audit
+
+- [ ] Inventory every chapter and section
+- [ ] Identify strengths, repetition, gaps, weak claims, outdated material, and market opportunities
+- [ ] Produce chapter-by-chapter audit
+- [ ] Approve revised positioning
+
+## Phase 2 — Structural Redesign
+
+- [ ] Approve book promise and target reader
+- [ ] Finalize signature framework
+- [ ] Finalize revised table of contents
+- [ ] Define chapter objectives and dependencies
+
+## Phase 3 — Research and Story Development
+
+- [ ] Build source index
+- [ ] Verify claims
+- [ ] Build story vault
+- [ ] Map stories and research to chapters
+
+## Phase 4 — Rewrite
+
+- [ ] Rewrite front matter
+- [ ] Rewrite each chapter
+- [ ] Add exercises, examples, frameworks, and transitions
+- [ ] Maintain complete-manuscript assembly
+
+## Phase 5 — Editorial Passes
+
+- [ ] Developmental edit
+- [ ] Evidence and accuracy edit
+- [ ] Continuity and repetition edit
+- [ ] Sensitivity and ethics review
+- [ ] Line edit
+- [ ] Copy edit
+- [ ] Proofread
+
+## Phase 6 — Production
+
+- [ ] Interior formatting
+- [ ] Cover and metadata
+- [ ] Kindle, paperback, and hardcover files
+- [ ] Audiobook script
+- [ ] Companion workbook
+
+## Phase 7 — Launch
+
+- [ ] Amazon listing optimization
+- [ ] Advance reader campaign
+- [ ] Email sequence
+- [ ] Social content bank
+- [ ] Podcast and media kit
+- [ ] Launch calendar

--- a/publishing/game-on-second-edition/WORKFLOW.md
+++ b/publishing/game-on-second-edition/WORKFLOW.md
@@ -1,0 +1,32 @@
+# Editorial Workflow
+
+Each chapter moves through these statuses:
+
+`BACKLOG → AUDIT → OUTLINE → RESEARCH → DRAFT → DEVELOPMENTAL_EDIT → FACT_CHECK → LINE_EDIT → COPY_EDIT → APPROVED`
+
+## Rules
+
+1. The approved outline is updated before major structural drafting.
+2. New factual claims must be entered in the source index.
+3. Structural decisions must be recorded in the decision log.
+4. Drafts are never silently overwritten without a commit.
+5. Marketing copy is derived from approved manuscript content, not treated as manuscript text.
+6. The complete manuscript is assembled from approved chapter files.
+7. Publication candidates receive version tags.
+
+## Branch model
+
+- `main`: approved production state
+- `agent/*`: automation or assistant-created changes
+- `chapter/*`: chapter-focused revisions
+- `release/*`: publication candidate preparation
+
+## Commit style
+
+Use concise action-oriented commits, for example:
+
+- `Audit chapter 03`
+- `Approve revised table of contents`
+- `Add attachment research sources`
+- `Rewrite chapter 07 opening`
+- `Assemble v2.0 release candidate`

--- a/publishing/game-on-second-edition/manuscript/CHAPTER_TRACKER.md
+++ b/publishing/game-on-second-edition/manuscript/CHAPTER_TRACKER.md
@@ -1,0 +1,10 @@
+# Chapter Tracker
+
+| ID | Working title | Status | Audit | Outline | Research | Draft | Fact check | Final |
+|---|---|---|---|---|---|---|---|---|
+| FM | Front Matter | BACKLOG |  |  |  |  |  |  |
+| 01 | TBD after manuscript audit | BACKLOG |  |  |  |  |  |  |
+| 02 | TBD after manuscript audit | BACKLOG |  |  |  |  |  |  |
+| BM | Back Matter | BACKLOG |  |  |  |  |  |  |
+
+Add rows only after the original manuscript inventory is complete. Do not treat the previously discussed chapter list as verified until checked against the author manuscript.

--- a/publishing/game-on-second-edition/manuscript/complete-manuscript.md
+++ b/publishing/game-on-second-edition/manuscript/complete-manuscript.md
@@ -1,0 +1,11 @@
+# Game On! Master the Conversation & Win Her Heart
+
+## Second Edition Working Manuscript
+
+> This assembly file is updated only from approved chapter files. It is not the primary drafting surface.
+
+<!-- Front matter -->
+
+<!-- Chapters -->
+
+<!-- Back matter -->

--- a/publishing/game-on-second-edition/marketing/CONTENT_ENGINE.md
+++ b/publishing/game-on-second-edition/marketing/CONTENT_ENGINE.md
@@ -1,0 +1,21 @@
+# Marketing Content Engine
+
+Approved manuscript content may be repurposed into:
+
+- Quote graphics
+- Short-form video scripts
+- Email newsletters
+- Blog posts
+- Podcast topics
+- Interview talking points
+- Reader challenges
+- Workbook exercises
+- Landing-page copy
+
+## Guardrails
+
+1. Marketing claims must match the manuscript.
+2. Do not exaggerate research findings.
+3. Do not publish draft frameworks before approval.
+4. Track the originating chapter for every asset.
+5. Keep platform-specific copy outside manuscript files.

--- a/publishing/game-on-second-edition/research/SOURCE_INDEX.md
+++ b/publishing/game-on-second-edition/research/SOURCE_INDEX.md
@@ -1,0 +1,12 @@
+# Research Source Index
+
+| Source ID | Citation | Source type | Credibility notes | Claim supported | Chapter | Verification status |
+|---|---|---|---|---|---|---|
+
+## Rules
+
+1. Give every factual or scientific source a stable Source ID.
+2. Record the exact claim the source supports.
+3. Do not use a source merely because it is popular or agrees with the manuscript.
+4. Distinguish evidence, expert interpretation, author experience, and illustrative examples.
+5. Recheck time-sensitive statistics before publication.

--- a/publishing/game-on-second-edition/stories/STORY_VAULT.md
+++ b/publishing/game-on-second-edition/stories/STORY_VAULT.md
@@ -1,0 +1,8 @@
+# Story Vault
+
+| Story ID | Summary | Source or owner | Permission | Themes | Candidate chapters | Status |
+|---|---|---|---|---|---|---|
+
+## Story standards
+
+Use stories to illuminate an idea, not manufacture authority. Change identifying details when appropriate, document permission for contributed stories, and label composites or hypothetical examples clearly during editorial review.


### PR DESCRIPTION
## What changed

Created a version-controlled publishing workspace under `publishing/game-on-second-edition` with:

- Project Bible
- Roadmap
- Editorial workflow
- Decision log
- Changelog
- Chapter tracker
- Complete-manuscript assembly file
- Research source index
- Story vault
- Marketing content engine

## Why

This gives the manuscript a permanent source of truth, separates editorial work from marketing and research, and preserves revision history without affecting the live author website.

## Next step

Import and audit the original manuscript, then replace the placeholder chapter tracker with the verified table of contents.