### PR TITLE
Add VoxVector standalone microsite

### DIFF
--- a/voxvector.html
+++ b/voxvector.html
@@ -1,0 +1,1048 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>VoxVector — AI Vocal Credibility Intelligence</title>
+  <meta name="description" content="VoxVector is Crown Labs' evidence-first AI audio analysis platform for vocal credibility, temporal cognitive dynamics, narrative consistency, and calibrated uncertainty." />
+  <meta name="theme-color" content="#050812" />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://www.darenprince.com/voxvector.html" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="VoxVector — AI Vocal Credibility Intelligence" />
+  <meta property="og:description" content="A multi-layer evidence engine for audio credibility analysis. Built to measure first, infer second, and abstain when the evidence is not strong enough." />
+  <meta property="og:url" content="https://www.darenprince.com/voxvector.html" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="VoxVector — AI Vocal Credibility Intelligence" />
+  <meta name="twitter:description" content="Evidence-first AI audio analysis from Crown Labs." />
+
+  <style>
+    :root {
+      --bg: #050812;
+      --bg-2: #0a1020;
+      --panel: rgba(13, 20, 38, 0.74);
+      --panel-2: rgba(8, 14, 27, 0.92);
+      --line: rgba(148, 163, 184, 0.18);
+      --line-strong: rgba(96, 225, 255, 0.3);
+      --text: #f7fbff;
+      --muted: #9fb0c6;
+      --muted-2: #718096;
+      --cyan: #62e5ff;
+      --cyan-2: #0db9e8;
+      --violet: #8b7cff;
+      --amber: #f4b85a;
+      --green: #62e6b3;
+      --danger: #ff7f8c;
+      --shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
+      --radius: 22px;
+      --max: 1180px;
+    }
+
+    * { box-sizing: border-box; }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      color: var(--text);
+      background:
+        radial-gradient(circle at 15% 8%, rgba(98, 229, 255, 0.12), transparent 30rem),
+        radial-gradient(circle at 88% 18%, rgba(139, 124, 255, 0.14), transparent 34rem),
+        linear-gradient(180deg, #050812 0%, #07101d 52%, #04070d 100%);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      overflow-x: hidden;
+    }
+
+    a { color: inherit; }
+
+    .ambient {
+      position: fixed;
+      inset: 0;
+      z-index: -3;
+      pointer-events: none;
+      opacity: 0.38;
+      background-image:
+        linear-gradient(rgba(96, 225, 255, 0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(96, 225, 255, 0.04) 1px, transparent 1px);
+      background-size: 44px 44px;
+      mask-image: linear-gradient(to bottom, black 0%, transparent 78%);
+    }
+
+    .noise {
+      position: fixed;
+      inset: 0;
+      z-index: -2;
+      pointer-events: none;
+      opacity: 0.045;
+      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 180 180' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.78' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.9'/%3E%3C/svg%3E");
+    }
+
+    .container {
+      width: min(calc(100% - 40px), var(--max));
+      margin: 0 auto;
+    }
+
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+      background: rgba(5, 8, 18, 0.72);
+      backdrop-filter: blur(18px);
+    }
+
+    .nav-inner {
+      min-height: 74px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 24px;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      text-decoration: none;
+      font-weight: 780;
+      letter-spacing: -0.025em;
+      font-size: 1.08rem;
+    }
+
+    .brand-mark {
+      width: 38px;
+      height: 38px;
+      filter: drop-shadow(0 8px 24px rgba(98, 229, 255, 0.22));
+    }
+
+    .brand small {
+      display: block;
+      margin-top: 1px;
+      color: var(--muted-2);
+      font-size: 0.66rem;
+      font-weight: 680;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+    }
+
+    .nav-links {
+      display: flex;
+      align-items: center;
+      gap: 22px;
+      color: #c5d0df;
+      font-size: 0.9rem;
+    }
+
+    .nav-links a {
+      text-decoration: none;
+      transition: color 160ms ease;
+    }
+
+    .nav-links a:hover { color: var(--cyan); }
+
+    .nav-pill {
+      border: 1px solid rgba(98, 229, 255, 0.28);
+      padding: 10px 14px;
+      border-radius: 999px;
+      background: rgba(98, 229, 255, 0.055);
+      color: #dffaff !important;
+    }
+
+    .hero {
+      position: relative;
+      padding: 96px 0 72px;
+    }
+
+    .hero-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.05fr) minmax(360px, 0.95fr);
+      gap: 58px;
+      align-items: center;
+    }
+
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 9px;
+      margin-bottom: 24px;
+      color: #c8f7ff;
+      border: 1px solid rgba(98, 229, 255, 0.22);
+      background: rgba(98, 229, 255, 0.055);
+      border-radius: 999px;
+      padding: 8px 12px;
+      font-size: 0.75rem;
+      font-weight: 760;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    .eyebrow-dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: var(--green);
+      box-shadow: 0 0 14px rgba(98, 230, 179, 0.85);
+    }
+
+    h1, h2, h3, p { margin-top: 0; }
+
+    h1 {
+      margin-bottom: 24px;
+      max-width: 820px;
+      font-size: clamp(3.5rem, 8.2vw, 7.4rem);
+      line-height: 0.88;
+      letter-spacing: -0.075em;
+      font-weight: 860;
+    }
+
+    .gradient-word {
+      color: transparent;
+      background: linear-gradient(100deg, #f8fdff 5%, #84ecff 42%, #9a8cff 82%, #efb85c 112%);
+      background-clip: text;
+      -webkit-background-clip: text;
+    }
+
+    .hero-copy {
+      max-width: 680px;
+      margin-bottom: 30px;
+      color: #b8c6d7;
+      font-size: clamp(1.05rem, 1.8vw, 1.28rem);
+      line-height: 1.65;
+    }
+
+    .hero-copy strong { color: #edf9ff; }
+
+    .hero-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-bottom: 34px;
+    }
+
+    .button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 50px;
+      padding: 0 19px;
+      border-radius: 13px;
+      border: 1px solid transparent;
+      font-size: 0.92rem;
+      font-weight: 770;
+      text-decoration: none;
+      transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+    }
+
+    .button:hover { transform: translateY(-2px); }
+
+    .button-primary {
+      color: #041018;
+      background: linear-gradient(120deg, #76ebff, #42cfe8);
+      box-shadow: 0 14px 42px rgba(13, 185, 232, 0.25);
+    }
+
+    .button-secondary {
+      color: #dfe8f4;
+      border-color: rgba(148, 163, 184, 0.2);
+      background: rgba(255, 255, 255, 0.035);
+    }
+
+    .hero-proof {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px 26px;
+      color: #8394a9;
+      font-size: 0.8rem;
+    }
+
+    .hero-proof span {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+    }
+
+    .hero-proof b {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: #4f637a;
+    }
+
+    .signal-shell {
+      position: relative;
+      min-height: 520px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .signal-glow {
+      position: absolute;
+      width: 78%;
+      aspect-ratio: 1;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(98, 229, 255, 0.14), rgba(139, 124, 255, 0.045) 48%, transparent 70%);
+      filter: blur(12px);
+    }
+
+    .signal-card {
+      position: relative;
+      width: min(100%, 470px);
+      overflow: hidden;
+      border: 1px solid rgba(111, 224, 249, 0.22);
+      border-radius: 28px;
+      background: linear-gradient(160deg, rgba(13, 24, 43, 0.92), rgba(7, 12, 24, 0.86));
+      box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.035);
+    }
+
+    .signal-card::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 70% 12%, rgba(98, 229, 255, 0.12), transparent 38%);
+      pointer-events: none;
+    }
+
+    .signal-top {
+      padding: 18px 20px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+      color: #8da2bb;
+      font-size: 0.73rem;
+      letter-spacing: 0.09em;
+      text-transform: uppercase;
+    }
+
+    .live-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      color: #bff8e1;
+    }
+
+    .live-label i {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: var(--green);
+      box-shadow: 0 0 13px rgba(98, 230, 179, 0.75);
+    }
+
+    .visualizer {
+      position: relative;
+      height: 176px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 30px 22px;
+      overflow: hidden;
+      background:
+        linear-gradient(rgba(98, 229, 255, 0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(98, 229, 255, 0.04) 1px, transparent 1px);
+      background-size: 28px 28px;
+    }
+
+    .wave {
+      width: 100%;
+      height: 112px;
+    }
+
+    .wave path {
+      fill: none;
+      stroke: url(#waveGradient);
+      stroke-width: 3;
+      stroke-linecap: round;
+      filter: drop-shadow(0 0 7px rgba(98, 229, 255, 0.34));
+      stroke-dasharray: 660;
+      stroke-dashoffset: 660;
+      animation: draw 2.7s ease-out forwards, pulse 6s ease-in-out 2.7s infinite;
+    }
+
+    @keyframes draw { to { stroke-dashoffset: 0; } }
+    @keyframes pulse { 0%, 100% { opacity: .72; } 50% { opacity: 1; } }
+
+    .signal-metrics {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1px;
+      background: rgba(148, 163, 184, 0.12);
+      border-top: 1px solid rgba(148, 163, 184, 0.08);
+    }
+
+    .metric {
+      min-height: 96px;
+      padding: 17px;
+      background: rgba(5, 10, 21, 0.95);
+    }
+
+    .metric-label {
+      color: #778ba4;
+      font-size: 0.66rem;
+      font-weight: 710;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .metric-value {
+      margin: 7px 0 5px;
+      font-size: 1.18rem;
+      font-weight: 800;
+      letter-spacing: -0.03em;
+    }
+
+    .metric-sub {
+      color: #6f8198;
+      font-size: 0.67rem;
+    }
+
+    .signal-foot {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 18px 20px 20px;
+      color: #8c9cb0;
+      font-size: 0.72rem;
+    }
+
+    .cx-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      padding: 7px 10px;
+      border: 1px solid rgba(244, 184, 90, 0.24);
+      border-radius: 999px;
+      background: rgba(244, 184, 90, 0.065);
+      color: #ffd69a;
+      font-weight: 760;
+      letter-spacing: 0.05em;
+    }
+
+    section { padding: 76px 0; }
+
+    .section-kicker {
+      margin-bottom: 12px;
+      color: var(--cyan);
+      font-size: 0.72rem;
+      font-weight: 820;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+    }
+
+    .section-title {
+      max-width: 800px;
+      margin-bottom: 17px;
+      font-size: clamp(2rem, 4.5vw, 4.05rem);
+      line-height: 1;
+      letter-spacing: -0.055em;
+    }
+
+    .section-lead {
+      max-width: 720px;
+      color: var(--muted);
+      font-size: 1.04rem;
+      line-height: 1.72;
+    }
+
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 15px;
+      margin-top: 42px;
+    }
+
+    .feature {
+      min-height: 230px;
+      padding: 25px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: linear-gradient(150deg, rgba(16, 24, 43, 0.72), rgba(8, 13, 24, 0.7));
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.024);
+      transition: transform 180ms ease, border-color 180ms ease;
+    }
+
+    .feature:hover {
+      transform: translateY(-4px);
+      border-color: rgba(98, 229, 255, 0.25);
+    }
+
+    .feature-icon {
+      width: 38px;
+      height: 38px;
+      display: grid;
+      place-items: center;
+      margin-bottom: 27px;
+      border-radius: 11px;
+      border: 1px solid rgba(98, 229, 255, 0.18);
+      background: rgba(98, 229, 255, 0.06);
+      color: var(--cyan);
+      font-weight: 860;
+      font-size: 0.78rem;
+      letter-spacing: -0.03em;
+    }
+
+    .feature h3 {
+      margin-bottom: 10px;
+      font-size: 1.05rem;
+      letter-spacing: -0.025em;
+    }
+
+    .feature p {
+      margin-bottom: 0;
+      color: #8fa1b7;
+      line-height: 1.6;
+      font-size: 0.88rem;
+    }
+
+    .process-wrap {
+      display: grid;
+      grid-template-columns: 0.85fr 1.15fr;
+      gap: 52px;
+      align-items: start;
+    }
+
+    .process-list {
+      position: relative;
+      border-left: 1px solid rgba(98, 229, 255, 0.17);
+      padding-left: 31px;
+    }
+
+    .process-step {
+      position: relative;
+      padding: 4px 0 33px;
+    }
+
+    .process-step:last-child { padding-bottom: 0; }
+
+    .process-step::before {
+      content: "";
+      position: absolute;
+      left: -36px;
+      top: 8px;
+      width: 9px;
+      height: 9px;
+      border-radius: 50%;
+      background: var(--bg);
+      border: 2px solid var(--cyan);
+      box-shadow: 0 0 0 5px rgba(98, 229, 255, 0.045);
+    }
+
+    .process-step span {
+      display: block;
+      margin-bottom: 7px;
+      color: #6d8097;
+      font-size: 0.69rem;
+      font-weight: 790;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    .process-step h3 {
+      margin-bottom: 8px;
+      font-size: 1.03rem;
+    }
+
+    .process-step p {
+      margin-bottom: 0;
+      color: #8a9db4;
+      font-size: 0.87rem;
+      line-height: 1.62;
+    }
+
+    .guardrail {
+      position: relative;
+      overflow: hidden;
+      margin-top: 72px;
+      padding: 35px;
+      border: 1px solid rgba(244, 184, 90, 0.22);
+      border-radius: 26px;
+      background:
+        radial-gradient(circle at 90% 10%, rgba(244, 184, 90, 0.1), transparent 38%),
+        rgba(12, 15, 23, 0.8);
+    }
+
+    .guardrail-grid {
+      display: grid;
+      grid-template-columns: 0.9fr 1.1fr;
+      gap: 46px;
+      align-items: center;
+    }
+
+    .guardrail-tag {
+      display: inline-block;
+      margin-bottom: 14px;
+      color: #ffd49a;
+      font-size: 0.69rem;
+      font-weight: 820;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    .guardrail h3 {
+      max-width: 520px;
+      margin-bottom: 12px;
+      font-size: clamp(1.75rem, 3vw, 2.7rem);
+      line-height: 1.04;
+      letter-spacing: -0.045em;
+    }
+
+    .guardrail p {
+      color: #9ba9bb;
+      line-height: 1.68;
+    }
+
+    .guardrail-list {
+      display: grid;
+      gap: 10px;
+    }
+
+    .guardrail-item {
+      display: flex;
+      gap: 12px;
+      align-items: flex-start;
+      padding: 13px 15px;
+      border: 1px solid rgba(148, 163, 184, 0.12);
+      border-radius: 12px;
+      background: rgba(5, 8, 15, 0.46);
+      color: #abb9ca;
+      font-size: 0.82rem;
+      line-height: 1.45;
+    }
+
+    .guardrail-item b {
+      color: var(--amber);
+      font-size: 0.8rem;
+    }
+
+    .status-grid {
+      display: grid;
+      grid-template-columns: 1.2fr 0.8fr;
+      gap: 18px;
+      margin-top: 40px;
+    }
+
+    .status-panel {
+      padding: 28px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--panel-2);
+    }
+
+    .status-panel h3 {
+      margin-bottom: 18px;
+      font-size: 1rem;
+    }
+
+    .status-row {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 18px;
+      align-items: center;
+      padding: 12px 0;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.09);
+      color: #91a3b9;
+      font-size: 0.8rem;
+    }
+
+    .status-row:last-child { border-bottom: 0; }
+
+    .state {
+      padding: 5px 8px;
+      border-radius: 999px;
+      font-size: 0.63rem;
+      font-weight: 820;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .state-run { color: #baf4df; background: rgba(98, 230, 179, 0.08); border: 1px solid rgba(98, 230, 179, 0.18); }
+    .state-build { color: #d7e9ff; background: rgba(98, 229, 255, 0.065); border: 1px solid rgba(98, 229, 255, 0.18); }
+
+    .lab-panel {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      min-height: 100%;
+      background:
+        radial-gradient(circle at 100% 0%, rgba(139, 124, 255, 0.16), transparent 46%),
+        var(--panel-2);
+    }
+
+    .lab-panel p {
+      color: #8fa0b5;
+      line-height: 1.65;
+      font-size: 0.89rem;
+    }
+
+    .lab-wordmark {
+      margin-top: 40px;
+      color: #627389;
+      font-size: 0.7rem;
+      font-weight: 800;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+    }
+
+    .cta {
+      padding-top: 46px;
+      padding-bottom: 94px;
+    }
+
+    .cta-card {
+      position: relative;
+      overflow: hidden;
+      padding: 54px;
+      border: 1px solid rgba(98, 229, 255, 0.21);
+      border-radius: 30px;
+      background:
+        radial-gradient(circle at 80% 20%, rgba(98, 229, 255, 0.13), transparent 38%),
+        radial-gradient(circle at 20% 90%, rgba(139, 124, 255, 0.11), transparent 42%),
+        linear-gradient(145deg, #0b1525, #080d18);
+      box-shadow: var(--shadow);
+    }
+
+    .cta-card h2 {
+      max-width: 720px;
+      margin-bottom: 15px;
+      font-size: clamp(2rem, 5vw, 4.2rem);
+      line-height: 0.98;
+      letter-spacing: -0.055em;
+    }
+
+    .cta-card p {
+      max-width: 650px;
+      margin-bottom: 25px;
+      color: #9eafc3;
+      line-height: 1.7;
+    }
+
+    footer {
+      border-top: 1px solid rgba(148, 163, 184, 0.09);
+      padding: 28px 0 38px;
+      color: #687b92;
+      font-size: 0.72rem;
+    }
+
+    .footer-inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 20px;
+      flex-wrap: wrap;
+    }
+
+    .footer-links {
+      display: flex;
+      gap: 18px;
+    }
+
+    .footer-links a { text-decoration: none; }
+    .footer-links a:hover { color: #a8bbd0; }
+
+    @media (max-width: 920px) {
+      .hero { padding-top: 66px; }
+      .hero-grid,
+      .process-wrap,
+      .guardrail-grid,
+      .status-grid {
+        grid-template-columns: 1fr;
+      }
+      .signal-shell { min-height: 440px; }
+      .feature-grid { grid-template-columns: repeat(2, 1fr); }
+      .process-wrap { gap: 36px; }
+      .nav-links a:not(.nav-pill) { display: none; }
+    }
+
+    @media (max-width: 620px) {
+      .container { width: min(calc(100% - 24px), var(--max)); }
+      .nav-inner { min-height: 66px; }
+      .brand small { display: none; }
+      .nav-pill { padding: 8px 11px; font-size: 0.76rem; }
+      .hero { padding: 52px 0 50px; }
+      h1 { font-size: clamp(3.05rem, 18vw, 4.6rem); }
+      .hero-copy { font-size: 1rem; }
+      .signal-shell { min-height: auto; padding-top: 20px; }
+      .signal-metrics { grid-template-columns: 1fr; }
+      .metric { min-height: 78px; }
+      section { padding: 58px 0; }
+      .feature-grid { grid-template-columns: 1fr; }
+      .feature { min-height: 0; }
+      .guardrail, .cta-card { padding: 27px 22px; }
+      .cta { padding-bottom: 66px; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+      *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; }
+    }
+  </style>
+</head>
+<body>
+  <div class="ambient" aria-hidden="true"></div>
+  <div class="noise" aria-hidden="true"></div>
+
+  <nav aria-label="Primary navigation">
+    <div class="container nav-inner">
+      <a class="brand" href="#top" aria-label="VoxVector home">
+        <svg class="brand-mark" viewBox="0 0 48 48" aria-hidden="true">
+          <defs>
+            <linearGradient id="logoGradient" x1="7" y1="5" x2="42" y2="43" gradientUnits="userSpaceOnUse">
+              <stop stop-color="#84ECFF"/>
+              <stop offset="0.56" stop-color="#62E5FF"/>
+              <stop offset="1" stop-color="#8B7CFF"/>
+            </linearGradient>
+          </defs>
+          <path d="M6 8.5L20.1 39.5c1.4 3.1 5.8 3.1 7.2 0L42 8.5h-8.8L23.7 30 14.5 8.5H6Z" fill="url(#logoGradient)"/>
+          <path d="M20.4 17.4 31.8 24l-11.4 6.6V17.4Z" fill="#050812" opacity=".9"/>
+        </svg>
+        <span>VoxVector<small>Crown Labs Audio Intelligence</small></span>
+      </a>
+
+      <div class="nav-links">
+        <a href="#engine">Engine</a>
+        <a href="#method">Method</a>
+        <a href="#beta">Beta</a>
+        <a class="nav-pill" href="/labs.html">Crown Labs</a>
+      </div>
+    </div>
+  </nav>
+
+  <main id="top">
+    <header class="hero">
+      <div class="container hero-grid">
+        <div>
+          <div class="eyebrow"><span class="eyebrow-dot"></span> Evidence-first vocal intelligence</div>
+          <h1>Voice leaves a <span class="gradient-word">vector.</span></h1>
+          <p class="hero-copy">
+            VoxVector is an AI-powered audio credibility analysis system built to measure <strong>how speech changes under cognitive demand</strong> without pretending that stress, pitch, silence, or any single vocal cue proves deception.
+          </p>
+          <div class="hero-actions">
+            <a class="button button-primary" href="#engine">Explore the engine</a>
+            <a class="button button-secondary" href="#principle">See the scientific guardrail</a>
+          </div>
+          <div class="hero-proof" aria-label="Core principles">
+            <span><b></b> Speaker-specific baselines</span>
+            <span><b></b> Independent evidence lanes</span>
+            <span><b></b> Mandatory abstention</span>
+          </div>
+        </div>
+
+        <div class="signal-shell" aria-label="Illustrative VoxVector analysis panel">
+          <div class="signal-glow" aria-hidden="true"></div>
+          <div class="signal-card">
+            <div class="signal-top">
+              <span>Temporal Cognitive Dynamics</span>
+              <span class="live-label"><i></i> analysis lane</span>
+            </div>
+            <div class="visualizer">
+              <svg class="wave" viewBox="0 0 660 130" role="img" aria-label="Abstract waveform illustration">
+                <defs>
+                  <linearGradient id="waveGradient" x1="0" y1="0" x2="660" y2="0" gradientUnits="userSpaceOnUse">
+                    <stop stop-color="#62E5FF"/>
+                    <stop offset="0.55" stop-color="#8B7CFF"/>
+                    <stop offset="1" stop-color="#F4B85A"/>
+                  </linearGradient>
+                </defs>
+                <path d="M0 67 C22 67 22 42 42 42 S64 91 84 91 106 53 126 53 148 69 168 69 190 20 210 20 232 108 252 108 274 49 294 49 316 76 336 76 358 33 378 33 400 94 420 94 442 58 462 58 484 68 504 68 526 45 546 45 568 82 588 82 610 61 630 61 646 67 660 67"/>
+              </svg>
+            </div>
+            <div class="signal-metrics">
+              <div class="metric">
+                <div class="metric-label">Response latency</div>
+                <div class="metric-value">Δ matched</div>
+                <div class="metric-sub">question-conditioned</div>
+              </div>
+              <div class="metric">
+                <div class="metric-label">Narrative state</div>
+                <div class="metric-value">tracked</div>
+                <div class="metric-sub">claim consistency</div>
+              </div>
+              <div class="metric">
+                <div class="metric-label">Reliability gate</div>
+                <div class="metric-value">active</div>
+                <div class="metric-sub">quality + OOD</div>
+              </div>
+            </div>
+            <div class="signal-foot">
+              <span>Measurement before inference.</span>
+              <span class="cx-badge">CX · ABSTAIN capable</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <section id="engine">
+      <div class="container">
+        <div class="section-kicker">The engine</div>
+        <h2 class="section-title">Not one lie detector. A synchronized evidence stack.</h2>
+        <p class="section-lead">
+          VoxVector is designed as a multi-engine forensic pipeline. Deterministic signal measurements, timing, phonetics, speech representations, narrative structure, contradiction analysis, and confound modeling remain separate long enough to challenge one another before any conclusion is considered.
+        </p>
+
+        <div class="feature-grid">
+          <article class="feature">
+            <div class="feature-icon">D10</div>
+            <h3>Signal integrity</h3>
+            <p>Quality, clipping, codec, channel, noise, discontinuity, and processing checks determine what the recording can actually support.</p>
+          </article>
+          <article class="feature">
+            <div class="feature-icon">D14</div>
+            <h3>Temporal cognitive dynamics</h3>
+            <p>Question offset, breath, filler, lexical onset, pauses, repairs, and re-answer timing are evaluated against matched conditions.</p>
+          </article>
+          <article class="feature">
+            <div class="feature-icon">D15</div>
+            <h3>Phoneme microcontrast</h3>
+            <p>Matched words and phonetic contexts help separate ordinary anatomy and articulation from question-specific voice change.</p>
+          </article>
+          <article class="feature">
+            <div class="feature-icon">D18</div>
+            <h3>Claim graph intelligence</h3>
+            <p>Statements become propositions that can be tracked across chronology, repetition, supporting detail, and independent evidence.</p>
+          </article>
+          <article class="feature">
+            <div class="feature-icon">D20</div>
+            <h3>Counterfactual speaker model</h3>
+            <p>The system estimates expected behavior for the speaker, sentence, phonetics, channel, and question difficulty before scoring residual change.</p>
+          </article>
+          <article class="feature">
+            <div class="feature-icon">D24</div>
+            <h3>Calibration + abstention</h3>
+            <p>When quality, domain fit, baseline sufficiency, or independent convergence is inadequate, VoxVector is designed to say so.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="method">
+      <div class="container process-wrap">
+        <div>
+          <div class="section-kicker">Method</div>
+          <h2 class="section-title">Follow the waveform. Keep the uncertainty.</h2>
+          <p class="section-lead">
+            The original recording remains the source of truth. Every downstream measurement is timestamped, attributable, reproducible, and allowed to disagree with every other lane.
+          </p>
+        </div>
+
+        <div class="process-list">
+          <div class="process-step">
+            <span>01 · Preserve</span>
+            <h3>Immutable source audio</h3>
+            <p>Hash the original bytes, preserve channels, and never replace evidence with an AI-enhanced derivative.</p>
+          </div>
+          <div class="process-step">
+            <span>02 · Align</span>
+            <h3>Transcript, speakers, words, phonemes</h3>
+            <p>Independent transcription and diarization paths feed consensus alignment back to the waveform clock.</p>
+          </div>
+          <div class="process-step">
+            <span>03 · Measure</span>
+            <h3>Timing, acoustics, voice quality, representation</h3>
+            <p>Handcrafted and learned features are retained as distinct evidence classes instead of being collapsed into one opaque score.</p>
+          </div>
+          <div class="process-step">
+            <span>04 · Compare</span>
+            <h3>Matched baselines and cognitive challenges</h3>
+            <p>Relevant answers are compared with speaker-specific truth, memory, emotional, task, and phonetic controls whenever available.</p>
+          </div>
+          <div class="process-step">
+            <span>05 · Challenge</span>
+            <h3>Alternative explanation engine</h3>
+            <p>Anxiety, fatigue, retrieval difficulty, dialect, embarrassment, channel effects, medication, substance effects, and question complexity remain live competing hypotheses.</p>
+          </div>
+          <div class="process-step">
+            <span>06 · Converge</span>
+            <h3>Independent-domain fusion</h3>
+            <p>Only multiple sufficiently independent domains may elevate an investigative concern. Missing prerequisites force uncertainty instead of fake precision.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="container" id="principle">
+        <div class="guardrail">
+          <div class="guardrail-grid">
+            <div>
+              <div class="guardrail-tag">Scientific prime directive</div>
+              <h3>Stress is not deception.</h3>
+              <p>
+                Pitch, silence, hesitation, breathing, tension, rate, disfluency, whispering, and latency can reflect many states. VoxVector treats them as measurements of change first. Intentional deception remains a hypothesis that requires convergence, context, and uncertainty controls.
+              </p>
+            </div>
+            <div class="guardrail-list">
+              <div class="guardrail-item"><b>01</b><span>No single vocal feature is allowed to prove a lie.</span></div>
+              <div class="guardrail-item"><b>02</b><span>Factual error, honest memory failure, and intentional deception are separate targets.</span></div>
+              <div class="guardrail-item"><b>03</b><span>Model confidence is not the probability that a person lied.</span></div>
+              <div class="guardrail-item"><b>04</b><span>Out-of-domain or insufficient evidence must be allowed to end in abstention.</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="beta">
+      <div class="container">
+        <div class="section-kicker">Current build</div>
+        <h2 class="section-title">Beta means capability truth, not capability theater.</h2>
+        <p class="section-lead">
+          VoxVector is being built in layers. Connected modules are identified as connected. Unavailable modules remain unavailable until real services produce real, auditable measurements.
+        </p>
+
+        <div class="status-grid">
+          <div class="status-panel">
+            <h3>v1 Beta foundation</h3>
+            <div class="status-row"><span>Evidence-first runtime contract</span><span class="state state-run">Active</span></div>
+            <div class="status-row"><span>Transcript narrative + claim review</span><span class="state state-run">Active</span></div>
+            <div class="status-row"><span>Source provenance + SHA-256 contract</span><span class="state state-run">Active</span></div>
+            <div class="status-row"><span>CX / abstention safeguard</span><span class="state state-run">Active</span></div>
+            <div class="status-row"><span>Full waveform D1–D24 gateway</span><span class="state state-build">In build</span></div>
+            <div class="status-row"><span>Cross-domain validation corpus</span><span class="state state-build">In build</span></div>
+          </div>
+
+          <div class="status-panel lab-panel">
+            <div>
+              <h3>Built by Crown Labs</h3>
+              <p>
+                VoxVector is part of the CrownCode intelligence portfolio, combining signal analysis, forensic architecture, AI reasoning, behavioral research, and evidence design into one auditable system.
+              </p>
+              <a class="button button-secondary" href="/labs.html">Explore Crown Labs</a>
+            </div>
+            <div class="lab-wordmark">Crown Labs · Intelligence Systems</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="cta">
+      <div class="container">
+        <div class="cta-card">
+          <div class="section-kicker">VoxVector</div>
+          <h2>Measure more. Assume less.</h2>
+          <p>
+            The goal is not a prettier lie detector. It is a more defensible audio intelligence system that knows the difference between evidence, inference, and uncertainty.
+          </p>
+          <a class="button button-primary" href="#top">Return to signal</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <div>© <span id="year"></span> Crown Labs. VoxVector Beta.</div>
+      <div class="footer-links">
+        <a href="/">Daren Prince</a>
+        <a href="/labs.html">Crown Labs</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## What changed

Adds a new standalone `voxvector.html` microsite to the author website without changing the existing homepage or shared author-site application code.

## VoxVector page

- new V/playmark identity built as inline SVG
- responsive dark audio-intelligence design
- evidence-first vocal credibility positioning
- CrownCode D10, D14, D15, D18, D20 and D24 architecture highlights
- scientific guardrail explaining that stress or a single vocal cue does not establish deception
- Beta capability-truth section and CX/abstention positioning
- links back to Crown Labs and the main Daren Prince site
- canonical URL targeting `https://www.darenprince.com/voxvector.html`

## Deployment behavior

The repo already deploys the root directory through GitHub Pages. Once merged to `main`, the page should publish at:

`https://www.darenprince.com/voxvector.html`

The page is self-contained and intentionally does not depend on the main site stylesheet or JavaScript bundle, so VoxVector can evolve independently without destabilizing the author site.