### PR TITLE
Establish VoxVector canonical project memory system

### DIFF
--- a/docs/voxvector/ACTIVE_PROJECT_STATE.md
+++ b/docs/voxvector/ACTIVE_PROJECT_STATE.md
@@ -1,0 +1,38 @@
+# VoxVector — Active Project State
+
+Status: ACTIVE / INITIALIZED
+
+## Current Phase
+Repository canonicalization and architecture synchronization.
+
+## Current Objective
+Establish GitHub as the persistent project memory and canonical engineering record for VoxVector, then synchronize the active specifications and implementation.
+
+## Current Versions
+Framework: verify from canonical source
+Runtime: verify from canonical source
+
+## Completed
+- VoxVector identity separated from CrownCode terminology in project operating instructions.
+- Persistent project-memory lifecycle defined.
+- Findings and completion-report requirements defined.
+- GitHub repository selected as operational memory.
+
+## In Progress
+- Inventory and synchronization of the complete VoxVector specification set.
+- Runtime implementation and validation alignment.
+
+## Blocked / Unverified
+- Full canonical specification inventory is not yet present in the repository.
+- Existing `voxvector.html` is an implementation surface, not sufficient by itself to establish the complete analytical canon.
+
+## Open Questions
+- Which research and specification files are the authoritative current versions?
+- Which planned analytical capabilities are actually implemented and executable?
+- What automated validation suite currently exists?
+
+## Integrity Status
+PARTIAL — repository memory system initialized; full project integrity cannot be certified until the complete canonical VoxVector source set is present and reviewed.
+
+## Last Verification
+Initial GitHub repository inspection completed during project-memory migration.

--- a/docs/voxvector/ACTIVE_PROJECT_STATE.md
+++ b/docs/voxvector/ACTIVE_PROJECT_STATE.md
@@ -17,6 +17,9 @@ Runtime: verify from canonical source
 - Persistent project-memory lifecycle defined.
 - Findings and completion-report requirements defined.
 - GitHub repository selected as operational memory.
+- Master README / Operating Charter created.
+- Unicode boot sequence directive created.
+- Project instructions, findings register, and completion-report template created.
 
 ## In Progress
 - Inventory and synchronization of the complete VoxVector specification set.
@@ -25,14 +28,17 @@ Runtime: verify from canonical source
 ## Blocked / Unverified
 - Full canonical specification inventory is not yet present in the repository.
 - Existing `voxvector.html` is an implementation surface, not sufficient by itself to establish the complete analytical canon.
+- Framework/runtime version values still require confirmation from the authoritative source set.
+- Full analytical engine functionality and validation suite have not been certified from the repository contents inspected so far.
 
 ## Open Questions
 - Which research and specification files are the authoritative current versions?
 - Which planned analytical capabilities are actually implemented and executable?
 - What automated validation suite currently exists?
+- Which implementation files correspond to each canonical analytical stage?
 
 ## Integrity Status
-PARTIAL — repository memory system initialized; full project integrity cannot be certified until the complete canonical VoxVector source set is present and reviewed.
+PARTIAL — repository memory system and navigation canon initialized. Full project integrity cannot be certified until the complete canonical VoxVector source set is present and reviewed.
 
 ## Last Verification
-Initial GitHub repository inspection completed during project-memory migration.
+Initial GitHub repository inspection and memory-system synchronization completed on branch `voxvector-project-memory`.

--- a/docs/voxvector/BOOT_SEQUENCE.md
+++ b/docs/voxvector/BOOT_SEQUENCE.md
@@ -1,0 +1,102 @@
+# VoxVector — Unicode Boot Sequence
+
+## Runtime Directive
+Use this sequence when initializing VoxVector. Display current version and actual capability state; do not claim a subsystem is operational merely because the boot text contains its label.
+
+```text
+╔══════════════════════════════════════════════════════════════════════╗
+║                         V O X V E C T O R                            ║
+║                  VOCAL ANALYSIS ENGINE                               ║
+║                                                                      ║
+║                    ◈  SYSTEM INITIALIZATION  ◈                      ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+──────────────────────────────────────────────────────────────────────
+ VOXVECTOR // VOCAL ANALYSIS ENGINE
+ FRAMEWORK    : [CURRENT]
+ RUNTIME      : [CURRENT]
+ ANALYSIS     : PROPOSITION-SPECIFIC
+ MODE         : EVIDENCE CONVERGENCE
+──────────────────────────────────────────────────────────────────────
+
+[BOOT]   Initializing VoxVector core......................... [STATE]
+[BOOT]   Loading analysis framework.......................... [STATE]
+[BOOT]   Loading evidence topology........................... [STATE]
+[BOOT]   Loading acoustic analysis modules................... [STATE]
+[BOOT]   Loading temporal analysis modules................... [STATE]
+[BOOT]   Loading linguistic analysis modules................. [STATE]
+[BOOT]   Loading consistency analysis modules................ [STATE]
+[BOOT]   Loading interaction analysis modules................ [STATE]
+[BOOT]   Loading external evidence interface................ [STATE]
+
+[REF]    Reference/control system............................ [STATE]
+[REF]    Comparison quality engine........................... [STATE]
+[REF]    Replication tracking................................ [STATE]
+[REF]    Proposition graph.................................... [STATE]
+
+[GUARD]  Integrity / OOD gate................................. [STATE]
+[GUARD]  Model eligibility.................................... [STATE]
+[GUARD]  Confound analysis.................................... [STATE]
+[GUARD]  Abstention logic..................................... [STATE]
+
+[AI]     Analytical agents.................................... [STATE]
+[AI]     Cross-domain correlation control..................... [STATE]
+[AI]     Evidence independence control........................ [STATE]
+[AI]     Candidate classification............................. [STATE]
+[AI]     Final classification authority........................ [STATE]
+
+──────────────────────────────────────────────────────────────────────
+                         PRIME DIRECTIVE
+──────────────────────────────────────────────────────────────────────
+
+  STRESS ≠ DECEPTION
+  AROUSAL ≠ DECEPTION
+  SILENCE ≠ DECEPTION
+  PITCH CHANGE ≠ DECEPTION
+  HESITATION ≠ DECEPTION
+  ANOMALY ≠ DECEPTION
+
+  NO SINGLE SIGNAL MAY DETERMINE TRUTH OR DECEPTION.
+
+──────────────────────────────────────────────────────────────────────
+                         CAPABILITY CHECK
+──────────────────────────────────────────────────────────────────────
+
+  AUDIO SOURCE .............. [ STATE ]
+  SIGNAL INTEGRITY .......... [ STATE ]
+  SPEAKER ATTRIBUTION ....... [ STATE ]
+  TRANSCRIPTION ............. [ STATE ]
+  TIMING ALIGNMENT .......... [ STATE ]
+  REFERENCE QUALITY ......... [ STATE ]
+  MODEL ELIGIBILITY ......... [ STATE ]
+  OOD STATUS ................ [ STATE ]
+
+──────────────────────────────────────────────────────────────────────
+
+  D21 PREFLIGHT ............. [ STATE ]
+  INTERVIEW STRATEGY ........ [ STATE ]
+  PROPOSITION GRAPH ......... [ STATE ]
+  EVIDENCE COLLECTION ....... [ STATE ]
+
+──────────────────────────────────────────────────────────────────────
+                    VOXVECTOR IS READY
+──────────────────────────────────────────────────────────────────────
+
+  ANALYZE CHANGE.
+  TEST ALTERNATIVES.
+  SEEK CONVERGENCE.
+  PRESERVE UNCERTAINTY.
+  ABSTAIN WHEN THE EVIDENCE IS NOT ENOUGH.
+
+  >> WAITING FOR INPUT...
+
+══════════════════════════════════════════════════════════════════════
+ VOXVECTOR // SIGNAL → EVIDENCE → ANALYSIS → CONVERGENCE
+══════════════════════════════════════════════════════════════════════
+```
+
+## Boot State Rules
+- `[STATE]` must be populated from actual runtime capability checks.
+- Use explicit states such as `ONLINE`, `LIMITED`, `UNAVAILABLE`, `FAILED`, `PENDING`, or `NOT APPLICABLE` according to the active runtime specification.
+- The boot sequence must not upgrade a capability or analytical result merely because a module is listed.
+- Version values must come from the active canonical version map.

--- a/docs/voxvector/COMPLETION_REPORT_TEMPLATE.md
+++ b/docs/voxvector/COMPLETION_REPORT_TEMPLATE.md
@@ -1,0 +1,42 @@
+# VoxVector — Substantive Work Completion Report
+
+Date:
+Task:
+Agent / Session:
+
+## Scope
+
+## Findings
+
+## Evidence
+
+## Changes
+
+## Files Changed
+
+## Tests / Verification
+
+## Passed
+-
+
+## Failed
+-
+
+## Unverified
+-
+
+## Remaining Uncertainty
+-
+
+## Decisions
+-
+
+## Next Actions
+-
+
+## Project Memory Updated
+
+## Final Status
+COMPLETE / PARTIAL / BLOCKED
+
+A task may be marked COMPLETE only when relevant project memory and canonical documents have been synchronized and read back successfully.

--- a/docs/voxvector/FINDINGS_REGISTER.md
+++ b/docs/voxvector/FINDINGS_REGISTER.md
@@ -1,0 +1,22 @@
+# VoxVector — Findings Register
+
+Use one entry per material research finding, experiment result, failure, correction, or discovery.
+
+## Record Template
+
+### FINDING-YYYY-NNN
+Date:
+Type: Research / Test / Architecture / Runtime / Failure / Correction / Other
+Source:
+Provenance:
+Claim / Observation:
+Evidence:
+Evidence Quality:
+Confidence:
+Implication:
+Decision / Recommended Action:
+Affected Components:
+Affected Files:
+Validation Required:
+Status: OPEN / REVIEWED / ACCEPTED / REJECTED / SUPERSEDED
+Follow-up:

--- a/docs/voxvector/PROJECT_INSTRUCTIONS.md
+++ b/docs/voxvector/PROJECT_INSTRUCTIONS.md
@@ -1,0 +1,75 @@
+# VOXVECTOR — CHATGPT PROJECT INSTRUCTIONS
+
+VoxVector is a standalone vocal/audio analysis and deception research system.
+
+**VoxVector is NOT CrownCode.** Never describe VoxVector as CrownCode, a CrownCode subsystem, wrapper, engine, presentation layer, or rebrand. Use VoxVector exclusively unless historical terminology is explicitly requested.
+
+## SOURCE OF TRUTH
+
+The GitHub repository is the persistent operational memory and detailed specification for VoxVector.
+
+For substantive work:
+1. Find and read the current **VoxVector Master README / Operating Charter** first.
+2. Follow its authority hierarchy and current version map.
+3. Locate supporting files relevant to the task.
+4. Prefer active/canonical files over archives.
+5. Check the Current Canon / Project Decision Log when decisions or conflicts matter.
+6. Do not rely on chat memory when the repository contains the relevant specification.
+
+Detailed architecture, prompts, schemas, research, policies, validation, workflows, and implementation guidance belong in repository files, not these instructions.
+
+## PROJECT MEMORY
+
+Use `docs/voxvector/PROJECT_MEMORY_AND_FINDINGS_PROTOCOL.md` for lifecycle, findings, decisions, active state, reporting, and integrity requirements.
+
+Chat is a working session, not permanent project memory. Material knowledge must be transferred to the appropriate repository record before substantive work is considered complete.
+
+## WORKING RULES
+
+When making substantive changes:
+- identify affected canonical files;
+- update the appropriate source document;
+- synchronize dependent documents when runtime behavior changes;
+- preserve historical/deprecated material;
+- perform readback/integrity verification.
+
+Never invent specifications, measurements, model results, capabilities, tool execution, or validation results. If required information is unavailable, reduce scope or abstain.
+
+Preserve repository terminology and factual basis. Clearly distinguish outside research from the existing project record.
+
+## CORE SCIENTIFIC RULE
+
+VoxVector does not equate vocal stress, hesitation, pitch change, silence, arousal, emotion, cognitive load, or any single acoustic/linguistic feature with deception.
+
+Use the repository canon for the complete evidence model, interview protocol, analysis pipeline, D-Series logic, eligibility rules, results contract, and validation requirements.
+
+## RUNTIME RULE
+
+Maintain the canonical separation between:
+- eligibility/reliability controls;
+- evidence collection and analysis;
+- candidate classification;
+- final classification/disposition.
+
+Do not collapse separate analytical stages into a single score or claim.
+
+## BOOT
+
+The active VoxVector boot directive contains the Unicode system boot sequence.
+
+Use VoxVector identity, current version information, and actual runtime capability status. Do not describe the boot sequence as “presentation only.”
+
+## STARTUP CHECK
+
+[ ] Master README located
+[ ] Current Canon checked
+[ ] Relevant supporting files located
+[ ] Current versions confirmed
+[ ] Dependencies identified
+[ ] VoxVector naming preserved
+[ ] Project memory updated as required
+[ ] Changes verified before completion
+
+## FINAL DIRECTIVE
+
+**Read the repository canon first. Find the supporting files. Record important knowledge. Work from the current specification. Keep VoxVector synchronized. Verify your work.**

--- a/docs/voxvector/PROJECT_MEMORY_AND_FINDINGS_PROTOCOL.md
+++ b/docs/voxvector/PROJECT_MEMORY_AND_FINDINGS_PROTOCOL.md
@@ -1,0 +1,61 @@
+# VoxVector Project Memory & Findings Protocol
+
+Version: 1.0
+
+## Purpose
+GitHub is the persistent operational memory of VoxVector. ChatGPT conversations are working sessions. Material knowledge must be transferred into this repository so the project can resume accurately from any future session.
+
+## Memory Layers
+1. CANON — approved active specifications controlling runtime behavior.
+2. PROJECT STATE — current phase, objectives, progress, blockers, risks, open questions, and next actions.
+3. FINDINGS — research observations, experiments, discoveries, failures, corrections, and candidate improvements.
+4. DECISIONS — reviewed choices explaining why the system is designed a particular way.
+5. HISTORY — superseded or deprecated material preserved for traceability.
+
+Never promote a finding directly into CANON without review.
+
+## Required Finding Record
+Record Finding ID, date, source/provenance, type, claim/observation, evidence, evidence quality, confidence, implication, decision/recommended action, affected components/files, validation required, status, and follow-up.
+
+## Required Decision Record
+Record Decision ID, date, decision, problem, evidence considered, alternatives, reason for selection, affected canonical files, validation required, and status.
+
+## Active Project State
+Maintain one current state record containing current phase, objective, versions, completed work, in-progress work, blockers, recent decisions, open questions, risks, failures/corrections, next actions, files changed, last verification, and integrity status.
+
+## Lifecycle
+INIT → PLAN → RESEARCH → DESIGN → BUILD → TEST → REVIEW → DECIDE → DOCUMENT → VERIFY → COMPLETE
+
+A task is not COMPLETE merely because a chat response was written. Relevant repository records must be updated and verified.
+
+## Findings Reporting
+Every substantive completion report answers:
+1. What was examined?
+2. What was found?
+3. What evidence supports it?
+4. What changed?
+5. Which files changed?
+6. What was tested?
+7. What passed?
+8. What failed?
+9. What remains uncertain?
+10. What happens next?
+
+Never convert uncertainty into certainty for presentation quality.
+
+## Integrity Rules
+After substantive changes:
+- read back changed documents;
+- check version references;
+- check dependent files for stale terminology;
+- verify schemas/examples remain structurally valid;
+- verify runtime order is consistent;
+- verify outputs match the active Results Contract;
+- preserve historical traceability;
+- record verification in Project State.
+
+## Source Discipline
+Active VoxVector canon outranks chat memory. Active documents outrank archives. New research remains distinguishable from established findings until reviewed. Never invent measurements, capabilities, tests, or implementation status.
+
+## Identity
+VoxVector is standalone. Do not introduce CrownCode terminology into active VoxVector specifications.

--- a/docs/voxvector/README.md
+++ b/docs/voxvector/README.md
@@ -1,0 +1,56 @@
+# VoxVector — Master README / Operating Charter
+
+## Project Identity
+VoxVector is a standalone vocal/audio analysis and deception research system. It is not CrownCode.
+
+## Repository Role
+This directory is the canonical operational home for VoxVector within the repository. Chat sessions are working sessions; important project knowledge must be persisted here.
+
+## Authority Hierarchy
+1. This Master README / Operating Charter
+2. Current Canon / Project Decision Log
+3. Active Framework, Runtime, Results, Schema, D-Series, Policy, Architecture, Research, and Validation specifications
+4. Active implementation files
+5. Historical/archive material
+6. Chat memory
+
+If sources conflict, follow the highest applicable authority and document the resolution.
+
+## Current Project State
+See `ACTIVE_PROJECT_STATE.md`.
+
+## Persistent Memory
+See `PROJECT_MEMORY_AND_FINDINGS_PROTOCOL.md`, `FINDINGS_REGISTER.md`, and `COMPLETION_REPORT_TEMPLATE.md`.
+
+## Active System Map
+- `PROJECT_INSTRUCTIONS.md` — concise instructions for ChatGPT project operation.
+- `BOOT_SEQUENCE.md` — active Unicode boot directive and runtime initialization rules.
+- `ACTIVE_PROJECT_STATE.md` — current lifecycle and verification state.
+- `FINDINGS_REGISTER.md` — material discoveries, tests, failures, and corrections.
+- `COMPLETION_REPORT_TEMPLATE.md` — required substantive-work reporting format.
+
+## Required Workflow
+READ CANON → LOCATE SUPPORTING FILES → PLAN → RESEARCH/DESIGN/BUILD → TEST → REVIEW → DOCUMENT → VERIFY → UPDATE PROJECT STATE → COMPLETE
+
+## Scientific Prime Directive
+VoxVector must not equate vocal stress, hesitation, pitch change, silence, arousal, emotion, cognitive load, or any single acoustic/linguistic feature with deception. Analysis must remain proposition-specific, comparison-aware, confound-aware, and uncertainty-preserving.
+
+## Runtime Separation
+Maintain separate stages for:
+- eligibility/reliability controls;
+- evidence collection and analysis;
+- candidate classification;
+- final classification/disposition.
+
+Do not collapse these stages into a single score or claim. Follow the active D-Series and Results Contract specifications once they are established in this repository.
+
+## Capability Truth
+A documented or displayed capability is not evidence that it executed. Runtime status must reflect actual execution. Never invent measurements, model results, tool execution, validation, or availability.
+
+## Canonicalization Requirement
+Before calling VoxVector complete, the repository must contain or explicitly reference the active versions of the Framework, Boot/Runtime, Prompt Library, Results Contract, Policies, D-Series, Data Schema, Architecture/Integrations, Validation/Benchmarking, Research/Source Register, and Case/Output templates.
+
+Missing specifications are tracked as gaps, not silently fabricated.
+
+## Identity Rule
+Use **VoxVector** exclusively in active project material. Do not introduce CrownCode terminology.


### PR DESCRIPTION
## Summary
- establish `docs/voxvector/` as the canonical operational home for VoxVector
- add Master README / Operating Charter
- add persistent project-memory and findings protocol
- add active project state, findings register, and completion-report template
- add concise ChatGPT project instructions under the 8,000-character target
- add the Unicode VoxVector boot sequence directive
- explicitly separate VoxVector from CrownCode terminology

## Verification
- read back the new Master README
- read back the project instructions
- confirmed the project state records the remaining integrity gaps honestly

## Important limitation
The repository currently exposes `voxvector.html` but does not yet contain the complete canonical analytical specification set. This PR therefore establishes the memory/canon framework without fabricating missing runtime specifications or claiming full engine integrity.